### PR TITLE
Allow a params parameter to have a generic type

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1943,7 +1943,15 @@ namespace DynamicExpresso.Parsing
 
 				if (paramsArrayTypeFound != null)
 				{
-					var promoted = PromoteExpression(currentArgument, paramsArrayTypeFound.GetElementType(), true);
+					var paramsArrayElementType = paramsArrayTypeFound.GetElementType();
+					if (paramsArrayElementType.IsGenericParameter)
+					{
+						paramsArrayPromotedArgument = paramsArrayPromotedArgument ?? new List<Expression>();
+						paramsArrayPromotedArgument.Add(currentArgument);
+						continue;
+					}
+
+					var promoted = PromoteExpression(currentArgument, paramsArrayElementType, true);
 					if (promoted != null)
 					{
 						paramsArrayPromotedArgument = paramsArrayPromotedArgument ?? new List<Expression>();
@@ -1961,6 +1969,16 @@ namespace DynamicExpresso.Parsing
 				var paramsArrayElementType = paramsArrayTypeFound.GetElementType();
 				if (paramsArrayElementType == null)
 					throw new Exception("Type is not an array, element not found");
+
+				if (paramsArrayElementType.IsGenericParameter)
+				{
+					var actualTypes = paramsArrayPromotedArgument.Select(_ => _.Type).Distinct().ToArray();
+					if (actualTypes.Length != 1)
+						throw new Exception($"The type arguments for method '{method.MethodBase}' cannot be inferred from the usage.");
+
+					paramsArrayElementType = actualTypes[0];
+				}
+
 				promotedArgs.Add(Expression.NewArrayInit(paramsArrayElementType, paramsArrayPromotedArgument));
 			}
 
@@ -2029,6 +2047,16 @@ namespace DynamicExpresso.Parsing
 				{
 					if (!actualType.IsGenericParameter)
 						extractedGenericTypes[requestedType.Name] = actualType;
+				}
+				else if (requestedType.IsArray && actualType.IsArray)
+				{
+					var innerGenericTypes = ExtractActualGenericArguments(
+						new[] { requestedType.GetElementType() },
+						new[] { actualType.GetElementType()
+					});
+
+					foreach (var innerGenericType in innerGenericTypes)
+						extractedGenericTypes[innerGenericType.Key] = innerGenericType.Value;
 				}
 				else if (requestedType.ContainsGenericParameters)
 				{

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1968,13 +1968,13 @@ namespace DynamicExpresso.Parsing
 				method.HasParamsArray = true;
 				var paramsArrayElementType = paramsArrayTypeFound.GetElementType();
 				if (paramsArrayElementType == null)
-					throw new Exception("Type is not an array, element not found");
+					throw CreateParseException(-1, ErrorMessages.ParamsArrayTypeNotAnArray);
 
 				if (paramsArrayElementType.IsGenericParameter)
 				{
 					var actualTypes = paramsArrayPromotedArgument.Select(_ => _.Type).Distinct().ToArray();
 					if (actualTypes.Length != 1)
-						throw new Exception($"The type arguments for method '{method.MethodBase}' cannot be inferred from the usage.");
+						throw CreateParseException(-1, ErrorMessages.MethodTypeParametersCantBeInferred, method.MethodBase);
 
 					paramsArrayElementType = actualTypes[0];
 				}

--- a/src/DynamicExpresso.Core/Resources/ErrorMessages.Designer.cs
+++ b/src/DynamicExpresso.Core/Resources/ErrorMessages.Designer.cs
@@ -337,11 +337,33 @@ namespace DynamicExpresso.Resources {
                 return ResourceManager.GetString("InvalidMethodCall", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Invalid real literal &apos;{0}&apos;.
-        /// </summary>
-        internal static string InvalidRealLiteral {
+
+		/// <summary>
+		/// Looks up a localized string similar to Params array type is not an array, element not found
+		/// </summary>
+		internal static string ParamsArrayTypeNotAnArray
+		{
+			get
+			{
+				return ResourceManager.GetString("ParamsArrayTypeNotAnArray", resourceCulture);
+			}
+		}
+
+		/// <summary>
+		/// Looks up a localized string similar to The type arguments for method '{0}' cannot be inferred from the usage.
+		/// </summary>
+		internal static string MethodTypeParametersCantBeInferred
+		{
+			get
+			{
+				return ResourceManager.GetString("MethodTypeParametersCantBeInferred", resourceCulture);
+			}
+		}
+
+		/// <summary>
+		///   Looks up a localized string similar to Invalid real literal &apos;{0}&apos;.
+		/// </summary>
+		internal static string InvalidRealLiteral {
             get {
                 return ResourceManager.GetString("InvalidRealLiteral", resourceCulture);
             }

--- a/src/DynamicExpresso.Core/Resources/ErrorMessages.resx
+++ b/src/DynamicExpresso.Core/Resources/ErrorMessages.resx
@@ -255,4 +255,10 @@
   <data name="CloseTypeArgumentListExpected" xml:space="preserve">
     <value>'&gt;' expected</value>
   </data>
+  <data name="MethodTypeParametersCantBeInferred" xml:space="preserve">
+    <value>The type arguments for method '{0}' cannot be inferred from the usage.</value>
+  </data>
+  <data name="ParamsArrayTypeNotAnArray" xml:space="preserve">
+    <value>Params array type is not an array, element not found</value>
+  </data>
 </root>

--- a/test/DynamicExpresso.UnitTest/MemberInvocationTest.cs
+++ b/test/DynamicExpresso.UnitTest/MemberInvocationTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -370,7 +370,21 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("x", x);
 			Assert.AreEqual(3, target.Eval("x.OverloadMethodWithParamsArray(2, 3, 1)"));
 		}
-		
+
+
+		[Test]
+		public void Generic_method_with_params()
+		{
+			var target = new Interpreter();
+			target.Reference(typeof(Utils));
+
+			var listInt = target.Eval<List<int>>("Utils.Array(1, 2, 3)");
+			Assert.AreEqual(new[] { 1, 2, 3 }, listInt);
+
+			// type parameter can't be inferred from usage
+			Assert.Throws<Exception>(() => target.Eval<List<int>>("Utils.Array(1,\"str\", 3)"));
+		}
+
 		[Test]
 		public void Method_with_optional_param()
 		{
@@ -553,6 +567,14 @@ namespace DynamicExpresso.UnitTest
 			public string AMethod()
 			{
 				return "Ciao mondo";
+			}
+		}
+
+		private static class Utils
+		{
+			public static List<T> Array<T>(params T[] array)
+			{
+				return new List<T>(array);
 			}
 		}
 	}

--- a/test/DynamicExpresso.UnitTest/MemberInvocationTest.cs
+++ b/test/DynamicExpresso.UnitTest/MemberInvocationTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using DynamicExpresso.Exceptions;
 using NUnit.Framework;
 
 namespace DynamicExpresso.UnitTest
@@ -382,7 +383,7 @@ namespace DynamicExpresso.UnitTest
 			Assert.AreEqual(new[] { 1, 2, 3 }, listInt);
 
 			// type parameter can't be inferred from usage
-			Assert.Throws<Exception>(() => target.Eval<List<int>>("Utils.Array(1,\"str\", 3)"));
+			Assert.Throws<ParseException>(() => target.Eval<List<int>>("Utils.Array(1,\"str\", 3)"));
 		}
 
 		[Test]


### PR DESCRIPTION
This is a fix for part of #191. The goal is to allow a `params` method parameter to be a generic. 
Use case:

```c#
private static class Utils
{
  public static List<T> Array<T>(params T[] array)
  {
    return new List<T>(array);
  }
}

var target = new Interpreter();
target.Reference(typeof(Utils));

var listInt = target.Eval<List<int>>("Utils.Array(1, 2, 3)");
Assert.AreEqual(new[] { 1, 2, 3 }, listInt);
```

Previously, the generic type was not promoted from the actual array type.