### PR TITLE
Improve MethodHasPriority algorithm

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -2296,30 +2296,23 @@ namespace DynamicExpresso.Parsing
 			// check conversion from argument list to parameter list
 			for (int i = 0, m = 0, o = 0; i < args.Length; i++)
 			{
+				var arg = args[i];
 				var methodParam = method.Parameters[m];
 				var otherMethodParam = otherMethod.Parameters[o];
 				var methodParamType = GetParameterType(methodParam);
 				var otherMethodParamType = GetParameterType(otherMethodParam);
 
-				var promoteMethodParam = methodParamType.IsGenericType && methodParamType.ContainsGenericParameters;
-				var promoteOtherMethodParam = otherMethodParamType.IsGenericType && otherMethodParamType.ContainsGenericParameters;
-
-				if (promoteMethodParam)
+				if (arg is InterpreterExpression)
+				{
 					methodParamType = method.PromotedParameters[i].Type;
-				if (promoteOtherMethodParam)
 					otherMethodParamType = otherMethod.PromotedParameters[i].Type;
+				}
 
-				var c = CompareConversions(args[i].Type, methodParamType, otherMethodParamType);
+				var c = CompareConversions(arg.Type, methodParamType, otherMethodParamType);
 				if (c < 0)
 					return false;
 				if (c > 0)
 					better = true;
-
-				// no conversion to param types is better: favor the one without promotion
-				if (!promoteMethodParam && promoteOtherMethodParam)
-					better = true;
-				if (promoteMethodParam && !promoteOtherMethodParam)
-					return false;
 
 				if (!HasParamsArrayType(methodParam)) m++;
 				if (!HasParamsArrayType(otherMethodParam)) o++;

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1881,7 +1881,7 @@ namespace DynamicExpresso.Parsing
 
 		private static bool CheckIfMethodIsApplicableAndPrepareIt(MethodData method, Expression[] args)
 		{
-			if (method.Parameters.Count(y => !y.HasDefaultValue) > args.Length)
+			if (method.Parameters.Count(y => !y.HasDefaultValue && !HasParamsArrayType(y)) > args.Length)
 				return false;
 
 			var promotedArgs = new List<Expression>();
@@ -1965,7 +1965,14 @@ namespace DynamicExpresso.Parsing
 			}
 
 			// Add default params, if needed.
-			promotedArgs.AddRange(method.Parameters.Skip(promotedArgs.Count).Select(x => Expression.Constant(x.DefaultValue, x.ParameterType)));
+			promotedArgs.AddRange(method.Parameters.Skip(promotedArgs.Count).Select<ParameterInfo, Expression>(x =>
+			{
+				if (x.HasDefaultValue)
+					return Expression.Constant(x.DefaultValue, x.ParameterType);
+				if (HasParamsArrayType(x))
+					return Expression.NewArrayInit(x.ParameterType.GetElementType());
+				throw new Exception("No default value found!");
+			}));
 
 			method.PromotedParameters = promotedArgs.ToArray();
 
@@ -2284,32 +2291,24 @@ namespace DynamicExpresso.Parsing
 
 		private static bool MethodHasPriority(Expression[] args, MethodData method, MethodData otherMethod)
 		{
-			if (method.HasParamsArray == false && otherMethod.HasParamsArray)
-				return true;
-			if (method.HasParamsArray && otherMethod.HasParamsArray == false)
-				return false;
-
-			//if (m1.Parameters.Length > m2.Parameters.Length)
-			//	return true;
-			//else if (m1.Parameters.Length < m2.Parameters.Length)
-			//	return false;
-
 			var better = false;
-			for (var i = 0; i < args.Length; i++)
+
+			// check conversion from argument list to parameter list
+			for (int i = 0, m = 0, o = 0; i < args.Length; i++)
 			{
-				var methodParam = method.Parameters[i];
-				var otherMethodParam = otherMethod.Parameters[i];
+				var methodParam = method.Parameters[m];
+				var otherMethodParam = otherMethod.Parameters[o];
 				var methodParamType = GetParameterType(methodParam);
 				var otherMethodParamType = GetParameterType(otherMethodParam);
 
 				var promoteMethodParam = methodParamType.IsGenericType && methodParamType.ContainsGenericParameters;
 				var promoteOtherMethodParam = otherMethodParamType.IsGenericType && otherMethodParamType.ContainsGenericParameters;
 
-				if (promoteMethodParam) 
+				if (promoteMethodParam)
 					methodParamType = method.PromotedParameters[i].Type;
 				if (promoteOtherMethodParam)
 					otherMethodParamType = otherMethod.PromotedParameters[i].Type;
-				
+
 				var c = CompareConversions(args[i].Type, methodParamType, otherMethodParamType);
 				if (c < 0)
 					return false;
@@ -2322,9 +2321,23 @@ namespace DynamicExpresso.Parsing
 				if (promoteMethodParam && !promoteOtherMethodParam)
 					return false;
 
-				if (HasParamsArrayType(methodParam) || HasParamsArrayType(otherMethodParam))
-					break;
+				if (!HasParamsArrayType(methodParam)) m++;
+				if (!HasParamsArrayType(otherMethodParam)) o++;
 			}
+
+			if (better)
+				return true;
+
+			if (!method.MethodBase.IsGenericMethod && otherMethod.MethodBase.IsGenericMethod)
+				return true;
+
+			if (!method.HasParamsArray && otherMethod.HasParamsArray)
+				return true;
+
+			// if a method has a params parameter, it can have less parameters than the number of arguments
+			if (method.Parameters.Length > otherMethod.Parameters.Length)
+				return true;
+
 			return better;
 		}
 
@@ -3021,6 +3034,11 @@ namespace DynamicExpresso.Parsing
 					MethodBase = method,
 					Parameters = method.GetParameters()
 				};
+			}
+
+			public override string ToString()
+			{
+				return MethodBase.ToString();
 			}
 		}
 

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -1,6 +1,8 @@
 using DynamicExpresso.Exceptions;
 using NUnit.Framework;
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
@@ -344,5 +346,24 @@ namespace DynamicExpresso.UnitTest
 			result = interpreter.Eval<string>("x?.ToString()");
 			Assert.AreEqual("56", result);
 		}
+
+		[Test]
+		public void GitHub_Issue_191()
+		{
+			var interpreter = new Interpreter();
+			interpreter.Reference(typeof(Utils));
+
+			var result = interpreter.Eval<object>("Utils.Select(Utils.Array(\"a\", \"b\"), \"x+x\")");
+			Assert.IsNotNull(result);
+		}
+
+		public class Utils
+		{
+			public static List<T> Array<T>(IEnumerable<T> collection) => new List<T>(collection);
+			public static List<dynamic> Array(params dynamic[] array) => Array((IEnumerable<dynamic>)array);
+			public static IEnumerable<dynamic> Select<TSource>(IEnumerable<TSource> collection, string expression) =>  new List<dynamic>();
+			public static IEnumerable<dynamic> Select(IEnumerable collection, string expression) => new List<dynamic>();
+		}
+
 	}
 }

--- a/test/DynamicExpresso.UnitTest/MemberInvocationTest.cs
+++ b/test/DynamicExpresso.UnitTest/MemberInvocationTest.cs
@@ -446,6 +446,11 @@ namespace DynamicExpresso.UnitTest
 			public static int WithParamsArray(params int[] i) => 3;
 			public static int WithParamsArray(int i, params int[] j) => 4;
 			public static int WithParamsArray(int i, int j) => 5;
+
+			public static List<T> Array<T>(params T[] array)
+			{
+				return new List<T>(array);
+			}
 		}
 
 		[Test]
@@ -605,14 +610,6 @@ namespace DynamicExpresso.UnitTest
 			public string AMethod()
 			{
 				return "Ciao mondo";
-			}
-		}
-
-		private static class Utils
-		{
-			public static List<T> Array<T>(params T[] array)
-			{
-				return new List<T>(array);
 			}
 		}
 	}

--- a/test/DynamicExpresso.UnitTest/MemberInvocationTest.cs
+++ b/test/DynamicExpresso.UnitTest/MemberInvocationTest.cs
@@ -423,6 +423,43 @@ namespace DynamicExpresso.UnitTest
 			Assert.AreEqual(x.HelloWorld().ToUpper(), target.Eval("x.HelloWorld().ToUpper()"));
 		}
 
+		internal static class Utils
+		{
+			public static int GenericVsNonGeneric(int i) => 1;
+			public static int GenericVsNonGeneric<T>(T i) => 2;
+
+			public static int WithParamsArray(params int[] i) => 3;
+			public static int WithParamsArray(int i, params int[] j) => 4;
+			public static int WithParamsArray(int i, int j) => 5;
+		}
+
+		[Test]
+		public void Method_overload_generic_vs_non_generic()
+		{
+			var target = new Interpreter();
+			target.Reference(typeof(Utils));
+
+			Assert.AreEqual(1, target.Eval("Utils.GenericVsNonGeneric(12345)"));
+			Assert.AreEqual(2, target.Eval("Utils.GenericVsNonGeneric('a')"));
+		}
+
+		[Test]
+		public void Method_overload_params_array()
+		{
+			var target = new Interpreter();
+			target.Reference(typeof(Utils));
+
+			var arr = new int[] { 2 };
+			target.SetVariable("arr", arr);
+
+			Assert.AreEqual(3, target.Eval("Utils.WithParamsArray(arr)"));
+			Assert.AreEqual(4, target.Eval("Utils.WithParamsArray(1)"));
+			Assert.AreEqual(4, target.Eval("Utils.WithParamsArray(1, arr)"));
+			Assert.AreEqual(5, target.Eval("Utils.WithParamsArray(1, 2)"));
+			Assert.AreEqual(4, target.Eval("Utils.WithParamsArray(1, 2, 3)"));
+			Assert.AreEqual(4, target.Eval("Utils.WithParamsArray(1, 2, 3, 4)"));
+		}
+
 		private interface MyTestInterface
 		{
 		}


### PR DESCRIPTION
This is mainly a fix for #191, but I also took the opportunity to improve the support of params arrays, to more closely match the C# specification.

For example, the following method calls are now properly resolved:

```c#
public static class Utils
{
  public static int WithParamsArray(params int[] i) => 3;
  public static int WithParamsArray(int i, params int[] j) => 4;
  public static int WithParamsArray(int i, int j) => 5;
}

var target = new Interpreter();
target.Reference(typeof(Utils));

var arr = new int[] { 2 };
target.SetVariable("arr", arr);

Assert.AreEqual(3, target.Eval("Utils.WithParamsArray(arr)"));
Assert.AreEqual(4, target.Eval("Utils.WithParamsArray(1)")); // improper call to int WithParamsArray(params int[] i)
Assert.AreEqual(4, target.Eval("Utils.WithParamsArray(1, arr)"));
Assert.AreEqual(5, target.Eval("Utils.WithParamsArray(1, 2)"));
Assert.AreEqual(4, target.Eval("Utils.WithParamsArray(1, 2, 3)")); // resolution failure 
Assert.AreEqual(4, target.Eval("Utils.WithParamsArray(1, 2, 3, 4)")); // resolution failure 
```

 