### PR TITLE
No longer crash when a lambda parameter argument type can't be parsed

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1230,6 +1230,10 @@ namespace DynamicExpresso.Parsing
 		// we found a known type identifier, check if it has some modifiers
 		private Type ParseTypeModifiers(Type type)
 		{
+			// type modifiers require the base type to be known
+			if (type == null)
+				return null;
+
 			var errorPos = _token.pos;
 			if (_token.id == TokenId.Question)
 			{

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -348,6 +348,26 @@ namespace DynamicExpresso.UnitTest
 		}
 
 		[Test]
+		public void GitHub_Issue_197()
+		{
+			var interpreterWithLambdas = new Interpreter(InterpreterOptions.DefaultCaseInsensitive | InterpreterOptions.LambdaExpressions);
+			var interpreterWithoutLambdas = new Interpreter(InterpreterOptions.DefaultCaseInsensitive);
+
+			var stringExpression = "booleanValue ? someStringValue : \".\"";
+			var parameters = new List<Parameter>
+			{
+				new Parameter($"someStringValue", typeof(string), $"E33"),
+				new Parameter("booleanValue", typeof(bool), true)
+			};
+
+			var expressionWithoutLambdas = interpreterWithoutLambdas.Parse(stringExpression, typeof(void), parameters.ToArray());
+			Assert.AreEqual("E33", expressionWithoutLambdas.Invoke(parameters.ToArray()));
+
+			var expressionWithLambdas = interpreterWithLambdas.Parse(stringExpression, typeof(void), parameters.ToArray());
+			Assert.AreEqual("E33", expressionWithLambdas.Invoke(parameters.ToArray()));
+		}
+
+		[Test]
 		public void GitHub_Issue_185()
 		{
 			var interpreter = new Interpreter().SetVariable("a", 123L);


### PR DESCRIPTION
Fix #197