### PR TITLE
Added support of param arrays within constructors

### DIFF
--- a/src/DynamicExpresso.Core/Resources/ErrorMessages.Designer.cs
+++ b/src/DynamicExpresso.Core/Resources/ErrorMessages.Designer.cs
@@ -58,12 +58,12 @@ namespace DynamicExpresso.Resources {
             set {
                 resourceCulture = value;
             }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Ambiguous invocation of indexer in type &apos;{0}&apos;.
-        /// </summary>
-        internal static string AmbiguousIndexerInvocation {
+		}
+
+		/// <summary>
+		///   Looks up a localized string similar to Ambiguous invocation of indexer in type &apos;{0}&apos;.
+		/// </summary>
+		internal static string AmbiguousIndexerInvocation {
             get {
                 return ResourceManager.GetString("AmbiguousIndexerInvocation", resourceCulture);
             }
@@ -385,12 +385,23 @@ namespace DynamicExpresso.Resources {
             get {
                 return ResourceManager.GetString("NoApplicableConstructor", resourceCulture);
             }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to No applicable indexer exists in type &apos;{0}&apos;.
-        /// </summary>
-        internal static string NoApplicableIndexer {
+		}
+
+		/// <summary>
+		///   Looks up a localized string similar to Ambiguous invocation of constructor in type &apos;{0}&apos;.
+		/// </summary>
+		internal static string AmbiguousConstructorInvocation
+		{
+			get
+			{
+				return ResourceManager.GetString("AmbiguousConstructorInvocation", resourceCulture);
+			}
+		}
+
+		/// <summary>
+		///   Looks up a localized string similar to No applicable indexer exists in type &apos;{0}&apos;.
+		/// </summary>
+		internal static string NoApplicableIndexer {
             get {
                 return ResourceManager.GetString("NoApplicableIndexer", resourceCulture);
             }

--- a/src/DynamicExpresso.Core/Resources/ErrorMessages.resx
+++ b/src/DynamicExpresso.Core/Resources/ErrorMessages.resx
@@ -261,4 +261,7 @@
   <data name="ParamsArrayTypeNotAnArray" xml:space="preserve">
     <value>Params array type is not an array, element not found</value>
   </data>
+  <data name="AmbiguousConstructorInvocation" xml:space="preserve">
+    <value>Ambiguous invocation of constructor in type '{0}'</value>
+  </data>
 </root>

--- a/test/DynamicExpresso.UnitTest/ConstructorTest.cs
+++ b/test/DynamicExpresso.UnitTest/ConstructorTest.cs
@@ -133,11 +133,20 @@ namespace DynamicExpresso.UnitTest
 			Assert.Throws<ParseException>(() => target.Parse("new MyClass() {5}")); // no field name
 		}
 
+		[Test]
+		public void Ctor_params_array()
+		{
+			var target = new Interpreter();
+			target.Reference(typeof(MyClass));
+			Assert.AreEqual(new MyClass(6, 5, 4, 3).MyArr, target.Eval("new MyClass(6, 5, 4, 3).MyArr"));
+		}
+
 		private class MyClass
 		{
 			public int IntField;
 			public string StrProp { get; set; }
 			public int ReadOnlyProp { get; }
+			public int[] MyArr { get; set; }
 
 			public MyClass()
 			{
@@ -146,6 +155,11 @@ namespace DynamicExpresso.UnitTest
 			public MyClass(string strValue)
 			{
 				StrProp = strValue;
+			}
+
+			public MyClass(params int[] intValues)
+			{
+				MyArr = intValues;
 			}
 
 			public override bool Equals(object obj)


### PR DESCRIPTION
This simply re-uses the existing method resolution, but for constructors (instead of a special resolution).

Fix #196