### PR TITLE
Allow a lambda expression to access the initial expression's parameters

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -167,7 +167,7 @@ namespace DynamicExpresso.Parsing
 				}
 
 				var lambdaBodyExp = _expressionText.Substring(startExpr, _token.pos - startExpr);
-				return new InterpreterExpression(_arguments.Settings, lambdaBodyExp, parameters);
+				return new InterpreterExpression(_arguments, lambdaBodyExp, parameters);
 			}
 			catch (ParseException)
 			{
@@ -3012,11 +3012,18 @@ namespace DynamicExpresso.Parsing
 			private readonly IList<Parameter> _parameters;
 			private Type _type;
 
-			public InterpreterExpression(ParserSettings parentSettings, string expressionText, params Parameter[] parameters)
+			public InterpreterExpression(ParserArguments parserArguments, string expressionText, params Parameter[] parameters)
 			{
-				_interpreter = new Interpreter(parentSettings);
+				_interpreter = new Interpreter(parserArguments.Settings.Clone());
 				_expressionText = expressionText;
 				_parameters = parameters;
+
+				// convert the parent's parameters to variables
+				// note: this doesn't impact the initial settings, because they're cloned
+				foreach (var pe in parserArguments.DeclaredParameters)
+				{
+					_interpreter.SetVariable(pe.Name, pe.Value, pe.Type);
+				}
 
 				// prior to evaluation, we don't know the generic arguments types
 				_type = typeof(Func<>).Assembly.GetType($"System.Func`{parameters.Length + 1}");

--- a/src/DynamicExpresso.Core/Parsing/ParserSettings.cs
+++ b/src/DynamicExpresso.Core/Parsing/ParserSettings.cs
@@ -6,11 +6,11 @@ namespace DynamicExpresso.Parsing
 {
 	internal class ParserSettings
 	{
-		private Dictionary<string, Identifier> _identifiers;
-		private Dictionary<string, ReferenceType> _knownTypes;
-		private HashSet<MethodInfo> _extensionMethods;
+		private readonly Dictionary<string, Identifier> _identifiers;
+		private readonly Dictionary<string, ReferenceType> _knownTypes;
+		private readonly HashSet<MethodInfo> _extensionMethods;
 
-		public ParserSettings(bool caseInsensitive,bool lateBindObject)
+		public ParserSettings(bool caseInsensitive, bool lateBindObject)
 		{
 			CaseInsensitive = caseInsensitive;
 
@@ -27,23 +27,30 @@ namespace DynamicExpresso.Parsing
 			_extensionMethods = new HashSet<MethodInfo>();
 
 			AssignmentOperators = AssignmentOperators.All;
-      
+
 			DefaultNumberType = DefaultNumberType.Default;
-      
+
 			LambdaExpressions = false;
+		}
+
+		private ParserSettings(ParserSettings other) : this(other.CaseInsensitive, other.LateBindObject)
+		{
+			_knownTypes = new Dictionary<string, ReferenceType>(other._knownTypes);
+			_identifiers = new Dictionary<string, Identifier>(other._identifiers);
+			_extensionMethods = new HashSet<MethodInfo>(other._extensionMethods);
+
+			AssignmentOperators = other.AssignmentOperators;
+			DefaultNumberType = other.DefaultNumberType;
+			LambdaExpressions = other.LambdaExpressions;
 		}
 
 		/// <summary>
 		/// Creates a deep copy of the current settings, so that the identifiers/types/methods can be changed
 		/// without impacting the existing settings.
 		/// </summary>
-		internal ParserSettings Clone()
+		public ParserSettings Clone()
 		{
-			var clone = (ParserSettings)MemberwiseClone();
-			clone._identifiers = new Dictionary<string, Identifier>(_identifiers);
-			clone._knownTypes = new Dictionary<string, ReferenceType>(_knownTypes);
-			clone._extensionMethods = new HashSet<MethodInfo>(_extensionMethods);
-			return clone;
+			return new ParserSettings(this);
 		}
 
 		public IDictionary<string, ReferenceType> KnownTypes
@@ -64,31 +71,27 @@ namespace DynamicExpresso.Parsing
 		public bool CaseInsensitive
 		{
 			get;
-			private set;
 		}
 
 		public bool LateBindObject
 		{
 			get;
-			private set;
+		}
+
+		public StringComparison KeyComparison
+		{
+			get;
+		}
+
+		public IEqualityComparer<string> KeyComparer
+		{
+			get;
 		}
 
 		public DefaultNumberType DefaultNumberType
 		{
 			get;
 			set;
-		}
-
-		public StringComparison KeyComparison
-		{
-			get;
-			private set;
-		}
-
-		public IEqualityComparer<string> KeyComparer
-		{
-			get;
-			private set;
 		}
 
 		public AssignmentOperators AssignmentOperators

--- a/src/DynamicExpresso.Core/Parsing/ParserSettings.cs
+++ b/src/DynamicExpresso.Core/Parsing/ParserSettings.cs
@@ -6,10 +6,10 @@ namespace DynamicExpresso.Parsing
 {
 	internal class ParserSettings
 	{
-		private readonly Dictionary<string, Identifier> _identifiers;
-		private readonly Dictionary<string, ReferenceType> _knownTypes;
-		private readonly HashSet<MethodInfo> _extensionMethods;
-		
+		private Dictionary<string, Identifier> _identifiers;
+		private Dictionary<string, ReferenceType> _knownTypes;
+		private HashSet<MethodInfo> _extensionMethods;
+
 		public ParserSettings(bool caseInsensitive,bool lateBindObject)
 		{
 			CaseInsensitive = caseInsensitive;
@@ -31,6 +31,19 @@ namespace DynamicExpresso.Parsing
 			DefaultNumberType = DefaultNumberType.Default;
       
 			LambdaExpressions = false;
+		}
+
+		/// <summary>
+		/// Creates a deep copy of the current settings, so that the identifiers/types/methods can be changed
+		/// without impacting the existing settings.
+		/// </summary>
+		internal ParserSettings Clone()
+		{
+			var clone = (ParserSettings)MemberwiseClone();
+			clone._identifiers = new Dictionary<string, Identifier>(_identifiers);
+			clone._knownTypes = new Dictionary<string, ReferenceType>(_knownTypes);
+			clone._extensionMethods = new HashSet<MethodInfo>(_extensionMethods);
+			return clone;
 		}
 
 		public IDictionary<string, ReferenceType> KnownTypes

--- a/test/DynamicExpresso.UnitTest/LambdaExpressionTest.cs
+++ b/test/DynamicExpresso.UnitTest/LambdaExpressionTest.cs
@@ -269,6 +269,37 @@ namespace DynamicExpresso.UnitTest
 			Assert.AreEqual(3, results.Count());
 			Assert.AreEqual(strList.Zip(intList, (str, i) => str + i), results);
 		}
+
+		[Test]
+		public void Lambda_with_parameter()
+		{
+			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
+			var listInt = target.Eval<IEnumerable<int>>("list.Where(n => n > x)", new Parameter("list", new[] { 1, 2, 3 }), new Parameter("x", 1));
+			Assert.AreEqual(new[] { 2, 3 }, listInt);
+
+			// ensure the parameters can be reused with different values
+			listInt = target.Eval<IEnumerable<int>>("list.Where(n => n > x)", new Parameter("list", new[] { 2, 4, 5 }), new Parameter("x", 2));
+			Assert.AreEqual(new[] { 4, 5 }, listInt);
+		}
+
+		[Test]
+		public void Lambda_with_parameter_2()
+		{
+			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
+			var listInt = target.Eval<IEnumerable<int>>("list.Select(n => n - 1).Where(n => n > x).Select(n => n + x)", new Parameter("list", new[] { 1, 2, 3 }), new Parameter("x", 1));
+			Assert.AreEqual(new[] { 3 }, listInt);
+		}
+
+		[Test]
+		public void Lambda_with_variable()
+		{
+			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
+			target.SetVariable("list", new[] { 1, 2, 3 });
+			target.SetVariable("x", 1);
+
+			var listInt = target.Eval<IEnumerable<int>>("list.Where(n => n > x)");
+			Assert.AreEqual(new[] { 2, 3 }, listInt);
+		}
 	}
 
 	/// <summary>


### PR DESCRIPTION
Fix #200

It works by making all the initial expression parameters as variables of the lambda expression interpreter. 