### PR TITLE
Improve bitwise operations support

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/ParseSignatures.cs
+++ b/src/DynamicExpresso.Core/Parsing/ParseSignatures.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace DynamicExpresso.Parsing
 {
@@ -77,6 +77,31 @@ namespace DynamicExpresso.Parsing
 		{
 			void F(bool x);
 			void F(bool? x);
+		}
+
+		public interface IBitwiseComplementSignatures
+		{
+			void F(int x, int count);
+			void F(uint x, int count);
+			void F(long x, int count);
+			void F(ulong x, int count);
+			void F(int? x, int? count);
+			void F(uint? x, int? count);
+			void F(long? x, int? count);
+			void F(ulong? x, int? count);
+		}
+
+		// the signatures are the same for the left and right shifts
+		public interface IShiftSignatures
+		{
+			void F(int x);
+			void F(uint x);
+			void F(long x);
+			void F(ulong x);
+			void F(int? x);
+			void F(uint? x);
+			void F(long? x);
+			void F(ulong? x);
 		}
 
 		//interface IEnumerableSignatures

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -513,6 +513,11 @@ namespace DynamicExpresso.Parsing
 			return left;
 		}
 
+		/// <summary>
+		/// Returns true if and only if the current token is in fact a shift operator.
+		/// In that case <paramref name="shiftType"/> is set to the proper expression type.
+		/// If the function returns false, <paramref name="shiftType"/> shouldn't be used.
+		/// </summary>
 		public bool IsShiftOperator(out ExpressionType shiftType)
 		{
 			// >> is not a token, because it conflicts with generics such as List<List<int>>
@@ -530,7 +535,8 @@ namespace DynamicExpresso.Parsing
 				return true;
 			}
 
-			shiftType = ExpressionType.DebugInfo; // dummy expression type
+			// dummy expression type that shouldn't be used
+			shiftType = ExpressionType.DebugInfo;
 			return false;
 		}
 

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -503,7 +503,7 @@ namespace DynamicExpresso.Parsing
 		private Expression ParseShift()
 		{
 			var left = ParseAdditive();
-			while (IsShift(out var shiftType))
+			while (IsShiftOperator(out var shiftType))
 			{
 				NextToken();
 				var right = ParseAdditive();
@@ -513,14 +513,16 @@ namespace DynamicExpresso.Parsing
 			return left;
 		}
 
-		public bool IsShift(out ExpressionType shiftType)
+		public bool IsShiftOperator(out ExpressionType shiftType)
 		{
+			// >> is not a token, because it conflicts with generics such as List<List<int>>
 			if (_token.id == TokenId.GreaterThan && _parseChar == '>')
 			{
 				NextToken(); // consume next >
 				shiftType = ExpressionType.RightShift;
 				return true;
 			}
+			// << could be a token, but is not for symmetry
 			else if (_token.id == TokenId.LessThan && _parseChar == '<')
 			{
 				NextToken(); // consume next < 

--- a/src/DynamicExpresso.Core/Parsing/TokenId.cs
+++ b/src/DynamicExpresso.Core/Parsing/TokenId.cs
@@ -17,6 +17,7 @@ namespace DynamicExpresso.Parsing
 		Plus,
 		Comma,
 		Minus,
+		Tilde,
 		Dot,
 		QuestionQuestion,
 		Slash,
@@ -38,7 +39,7 @@ namespace DynamicExpresso.Parsing
 		Caret,
 		OpenCurlyBracket,
 		CloseCurlyBracket,
-		LambdaArrow
+		LambdaArrow,
 	}
 
 }

--- a/test/DynamicExpresso.UnitTest/OperatorsTest.cs
+++ b/test/DynamicExpresso.UnitTest/OperatorsTest.cs
@@ -38,6 +38,88 @@ namespace DynamicExpresso.UnitTest
 			Assert.AreEqual(-45, target.Eval("-45"));
 			Assert.AreEqual(5, target.Eval("+5"));
 			Assert.AreEqual(false, target.Eval("!true"));
+
+			Assert.AreEqual(~2, target.Eval("~2"));
+			Assert.AreEqual(~2ul, target.Eval("~2ul"));
+		}
+
+		[Test]
+		public void Shift_Operators()
+		{
+			var target = new Interpreter();
+			var x = 0b_1100_1001_0000_0000_0000_0000_0001_0001;
+			target.SetVariable("x", x);
+
+			Assert.AreEqual(x >> 4, target.Eval("x >> 4"));
+			Assert.AreEqual(x << 4, target.Eval("x << 4"));
+
+			// ensure they can be chained
+			Assert.AreEqual(x >> 1 >> 1 >> 1, target.Eval("x >> 1 >> 1 >> 1"));
+			Assert.AreEqual(x << 1 << 1 << 1, target.Eval("x << 1 << 1 << 1"));
+
+			// ensure priority
+			Assert.IsFalse(target.Eval<bool>("1 << 4 < 16"));
+			Assert.IsTrue(target.Eval<bool>("1 << 4 < 17"));
+		}
+
+		[Test]
+		public void Numeric_Logical_And()
+		{
+			var target = new Interpreter();
+			target.Reference(typeof(Convert));
+
+			var a = 0b_1111_1000;
+			var b = 0b_0001_1100;
+			target.SetVariable("a", a);
+			target.SetVariable("b", b);
+
+			Assert.AreEqual(a & b, target.Eval("a & b"));
+		}
+
+		[Test]
+		public void Numeric_Logical_Or()
+		{
+			var target = new Interpreter();
+			target.Reference(typeof(Convert));
+
+			var a = 0b_1111_1000;
+			var b = 0b_0001_1100;
+			target.SetVariable("a", a);
+			target.SetVariable("b", b);
+
+			Assert.AreEqual(a | b, target.Eval("a | b"));
+		}
+
+		[Test]
+		public void Numeric_Logical_Xor()
+		{
+			var target = new Interpreter();
+			target.Reference(typeof(Convert));
+
+			var a = 0b_1111_1000;
+			var b = 0b_0001_1100;
+			target.SetVariable("a", a);
+			target.SetVariable("b", b);
+
+			Assert.AreEqual(a ^ b, target.Eval("a ^ b"));
+		}
+
+		[Test, Ignore("Current operator resolution doesn't lift int to uint")]
+		public void Bitwise_operations_uint_int()
+		{
+			var target = new Interpreter();
+
+			// ensure we can resolve operators between uint and int
+			var x = 0b_1111_1000u;
+			target.SetVariable("x", x);
+
+			Assert.AreEqual(~x, target.Eval<uint>("~x"));
+			Assert.AreEqual(x >> 4, target.Eval<uint>("x >> 4"));
+			Assert.AreEqual(x << 4, target.Eval<uint>("x << 4"));
+
+			Assert.AreEqual(x & 4, target.Eval<uint>("x & 4"));
+			Assert.AreEqual(x | 4, target.Eval<uint>("x | 4"));
+			Assert.AreEqual(x ^ 4, target.Eval<uint>("x ^ 4"));
 		}
 
 		[Test]


### PR DESCRIPTION
Add support of the unary bitwise complement operator (~)
Add support of the shift operators (>> and <<)
Fix #206

```c#
var target = new Interpreter();
var x = 0b_1100_1001_0000_0000_0000_0000_0001_0001;
target.SetVariable("x", x);

Assert.Equal(~x, target.Eval<uint>("~x"));
Assert.Equal(x >> 4, target.Eval<uint>("x >> 4"));
Assert.Equal(x << 4, target.Eval<uint>("x << 4"));
```