### PR TITLE
Improve support of nullable types

### DIFF
--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -258,9 +258,9 @@ namespace DynamicExpresso.UnitTest
 			result = lambda.Invoke(new Scope { ValueInt = 5 });
 			Assert.AreEqual(5, result);
 
-			interpreter.SetVariable("scope", new Scope { ValueInt = 5 });
-			var resultNullableBool = interpreter.Eval<bool>("scope?.ValueInt?.HasValue");
-			Assert.IsTrue(resultNullableBool);
+			var scope = new Scope { Value = 5 };
+			interpreter.SetVariable("scope", scope);
+			Assert.AreEqual(scope?.Value.HasValue, interpreter.Eval<bool>("scope?.Value.HasValue"));
 
 			// must throw, because scope.ValueInt is not a nullable type
 			Assert.Throws<ParseException>(() => interpreter.Eval<bool>("scope.ValueInt.HasValue"));
@@ -396,6 +396,24 @@ namespace DynamicExpresso.UnitTest
 
 			var result = interpreter.Eval<object>("Utils.Select(Utils.Array(\"a\", \"b\"), \"x+x\")");
 			Assert.IsNotNull(result);
+		}
+
+		[Test]
+		public void GitHub_Issue_205_Property_on_nullable()
+		{
+			var interpreter = new Interpreter();
+
+			DateTime? date = DateTime.UtcNow;
+			interpreter.SetVariable("date", date);
+
+			Assert.AreEqual(date?.Day, interpreter.Eval("date?.Day"));
+			Assert.AreEqual(date?.IsDaylightSavingTime(), interpreter.Eval("date?.IsDaylightSavingTime()"));
+
+			date = null;
+			interpreter.SetVariable("date", date);
+
+			Assert.AreEqual(date?.Day, interpreter.Eval("date?.Day"));
+			Assert.AreEqual(date?.IsDaylightSavingTime(), interpreter.Eval("date?.IsDaylightSavingTime()"));
 		}
 
 		public class Utils

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -416,6 +416,24 @@ namespace DynamicExpresso.UnitTest
 			Assert.AreEqual(date?.IsDaylightSavingTime(), interpreter.Eval("date?.IsDaylightSavingTime()"));
 		}
 
+		[Test]
+		public void GitHub_Issue_205()
+		{
+			var interpreter = new Interpreter();
+
+			var date1 = DateTimeOffset.UtcNow;
+			DateTimeOffset? date2 = null;
+
+			interpreter.SetVariable("date1", date1);
+			interpreter.SetVariable("date2", date2);
+
+			Assert.IsNull(interpreter.Eval("(date1 - date2)?.Days"));
+
+			date2 = date1.AddDays(1);
+			interpreter.SetVariable("date2", date2);
+			Assert.AreEqual(-1, interpreter.Eval("(date1 - date2)?.Days"));
+		}
+
 		public class Utils
 		{
 			public static List<T> Array<T>(IEnumerable<T> collection) => new List<T>(collection);

--- a/test/DynamicExpresso.UnitTest/NullableTest.cs
+++ b/test/DynamicExpresso.UnitTest/NullableTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NUnit.Framework;
 // ReSharper disable ConvertNullableToShortForm
 // ReSharper disable PossibleNullReferenceException
@@ -237,7 +237,7 @@ namespace DynamicExpresso.UnitTest
 
 			var interpreter = new Interpreter();
 			interpreter.SetVariable("a", a, typeof(DateTimeOffset));
-			interpreter.SetVariable("b", b, typeof(Nullable<DateTimeOffset>));
+			interpreter.SetVariable("b", b, typeof(DateTimeOffset?));
 			interpreter.SetVariable("c", c, typeof(DateTimeOffset));
 			var expectedReturnType = typeof(bool);
 
@@ -270,6 +270,16 @@ namespace DynamicExpresso.UnitTest
 			lambda = interpreter.Parse("b != c");
 			Assert.AreEqual(expected, lambda.Invoke());
 			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+
+			lambda = interpreter.Parse("a - b");
+			Assert.AreEqual(a - b, lambda.Invoke());
+			Assert.AreEqual(typeof(TimeSpan?), lambda.ReturnType);
+
+			b = null;
+			interpreter.SetVariable("b", b, typeof(DateTimeOffset?));
+			lambda = interpreter.Parse("a - b");
+			Assert.AreEqual(a - b, lambda.Invoke());
+			Assert.AreEqual(typeof(TimeSpan?), lambda.ReturnType);
 		}
 	}
 }


### PR DESCRIPTION
Promote all operands of binary operators.
When applying the ?. operator to nullable types, emit the member access on the underlying type.
Fix #205