### PR TITLE
MethodHasPriority: improve resolution

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -2340,11 +2340,11 @@ namespace DynamicExpresso.Parsing
 				var methodParamType = GetParameterType(methodParam);
 				var otherMethodParamType = GetParameterType(otherMethodParam);
 
-				if (arg is InterpreterExpression)
-				{
+				if (methodParamType.ContainsGenericParameters)
 					methodParamType = method.PromotedParameters[i].Type;
+
+				if (otherMethodParamType.ContainsGenericParameters)
 					otherMethodParamType = otherMethod.PromotedParameters[i].Type;
-				}
 
 				var c = CompareConversions(arg.Type, methodParamType, otherMethodParamType);
 				if (c < 0)

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -398,6 +398,19 @@ namespace DynamicExpresso.UnitTest
 			Assert.IsNotNull(result);
 		}
 
+		[Test]
+		public void GitHub_Issue_203()
+		{
+			var target = new Interpreter();
+			target.Reference(typeof(Utils));
+
+			var list = new[] { 1, 2, 3 };
+
+			var listInt = target.Eval<List<int>>("Utils.Array(list)", new Parameter("list", list));
+			Assert.AreEqual(Utils.Array(list), listInt);
+		}
+
+
 		public class Utils
 		{
 			public static List<T> Array<T>(IEnumerable<T> collection) => new List<T>(collection);


### PR DESCRIPTION
MethodHasPriority: use promoted parameters when the method's argument type is an inferred generic type.
Fixes #203