### PR TITLE
Prototype to capture variables so that they can be used in an inner lambda

### DIFF
--- a/src/DynamicExpresso.Core/Interpreter.cs
+++ b/src/DynamicExpresso.Core/Interpreter.cs
@@ -403,21 +403,6 @@ namespace DynamicExpresso
 			return lambda.LambdaExpression<TDelegate>();
 		}
 
-		internal LambdaExpression ParseAsExpression(Type delegateType, string expressionText, params string[] parametersNames)
-		{
-			var delegateInfo = ReflectionExtensions.GetDelegateInfo(delegateType, parametersNames);
-
-			// return type is object means that we have no information beforehand
-			// => we force it to typeof(void) so that no conversion expression is emitted by the parser
-			//    and the actual expression type is preserved
-			var returnType = delegateInfo.ReturnType;
-			if (returnType == typeof(object))
-				returnType = typeof(void);
-
-			var lambda = ParseAsLambda(expressionText, returnType, delegateInfo.Parameters);
-			return lambda.LambdaExpression(delegateType);
-		}
-
 		public Lambda ParseAs<TDelegate>(string expressionText, params string[] parametersNames)
 		{
 			return ParseAs(typeof(TDelegate), expressionText, parametersNames); 
@@ -478,7 +463,7 @@ namespace DynamicExpresso
 
 		#region Private methods
 
-		private Lambda ParseAsLambda(string expressionText, Type expressionType, Parameter[] parameters)
+		internal Lambda ParseAsLambda(string expressionText, Type expressionType, Parameter[] parameters)
 		{
 			var arguments = new ParserArguments(
 												expressionText,

--- a/src/DynamicExpresso.Core/Parsing/ParserSettings.cs
+++ b/src/DynamicExpresso.Core/Parsing/ParserSettings.cs
@@ -7,6 +7,7 @@ namespace DynamicExpresso.Parsing
 	internal class ParserSettings
 	{
 		private readonly Dictionary<string, Identifier> _identifiers;
+		public readonly Dictionary<string, object> _capturedVariables;
 		private readonly Dictionary<string, ReferenceType> _knownTypes;
 		private readonly HashSet<MethodInfo> _extensionMethods;
 
@@ -21,6 +22,8 @@ namespace DynamicExpresso.Parsing
 			KeyComparison = CaseInsensitive ? StringComparison.InvariantCultureIgnoreCase : StringComparison.InvariantCulture;
 
 			_identifiers = new Dictionary<string, Identifier>(KeyComparer);
+
+			_capturedVariables = new Dictionary<string, object>(KeyComparer);
 
 			_knownTypes = new Dictionary<string, ReferenceType>(KeyComparer);
 
@@ -37,6 +40,7 @@ namespace DynamicExpresso.Parsing
 		{
 			_knownTypes = new Dictionary<string, ReferenceType>(other._knownTypes);
 			_identifiers = new Dictionary<string, Identifier>(other._identifiers);
+			_capturedVariables = other._capturedVariables;
 			_extensionMethods = new HashSet<MethodInfo>(other._extensionMethods);
 
 			AssignmentOperators = other.AssignmentOperators;

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -446,6 +446,44 @@ namespace DynamicExpresso.UnitTest
 			Assert.AreEqual(-1, interpreter.Eval("(date1 - date2)?.Days"));
 		}
 
+		[Test]
+		public void GitHub_Issue_212()
+		{
+			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
+			var list = new Parameter("list", new[] { 1, 2, 3 });
+			var value1 = new Parameter("value", 1);
+			var value2 = new Parameter("value", 2);
+			var expression = "list.Where(x => x > value)";
+			var lambda = target.Parse(expression, list, value1);
+			var result = lambda.Invoke(list, value2);
+			Assert.AreEqual(new[] { 3 }, result);
+		}
+
+		[Test]
+		public void GitHub_Issue_212_bis()
+		{
+			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
+			var list = new Parameter("list", new[] { 1, 2, 3 });
+			var value1 = new Parameter("value", 1);
+			var value2 = new Parameter("value", 2);
+			var expression = "list.Where(x => x > value)";
+			var lambda = target.Parse(expression, (new[] { list, value1 }).Select(p => new Parameter(p.Name, p.Type)).ToArray());
+			var result = lambda.Invoke(list, value1);
+			Assert.AreEqual(new[] { 2, 3 }, result);
+		}
+
+		[Test]
+		public void GitHub_Issue_200_capture()
+		{
+			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
+			var list = new List<string> { "ab", "cdc" };
+			target.SetVariable("myList", list);
+
+			// the str parameter is captured, and can be used in the nested lambda
+			var results = target.Eval("myList.Select(str => str.Select(c => str.Length))");
+			Assert.AreEqual(new[] { new[] { 2, 2 }, new[] { 3, 3, 3 } }, results);
+		}
+
 		public class Utils
 		{
 			public static List<T> Array<T>(IEnumerable<T> collection) => new List<T>(collection);


### PR DESCRIPTION
The idea is:

- use a dictionary to store captured variables (= parameters from all levels of lambda expressions)
- when parsing an expression, first assign the captured parameter to the dictionary

For example, it we parse `x + 5`, and call `f(2)` we convert it to:


```c#
dict["x"] = 2;
return dict["x"] + 5;
```

Fix #212