### PR TITLE
Case insensitivity option is now properly used inside lambda expressions

### DIFF
--- a/src/DynamicExpresso.Core/ParserArguments.cs
+++ b/src/DynamicExpresso.Core/ParserArguments.cs
@@ -1,4 +1,4 @@
-﻿using DynamicExpresso.Parsing;
+using DynamicExpresso.Parsing;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -108,7 +108,8 @@ namespace DynamicExpresso
 
 		public IEnumerable<MethodInfo> GetExtensionMethods(string methodName)
 		{
-			return Settings.ExtensionMethods.Where(p => p.Name == methodName);
+			var comparer = Settings.KeyComparer;
+			return Settings.ExtensionMethods.Where(p => comparer.Equals(p.Name, methodName));
 		}
 	}
 }

--- a/src/DynamicExpresso.Core/Parsing/ParserSettings.cs
+++ b/src/DynamicExpresso.Core/Parsing/ParserSettings.cs
@@ -35,8 +35,8 @@ namespace DynamicExpresso.Parsing
 
 		private ParserSettings(ParserSettings other) : this(other.CaseInsensitive, other.LateBindObject)
 		{
-			_knownTypes = new Dictionary<string, ReferenceType>(other._knownTypes);
-			_identifiers = new Dictionary<string, Identifier>(other._identifiers);
+			_knownTypes = new Dictionary<string, ReferenceType>(other._knownTypes, other._knownTypes.Comparer);
+			_identifiers = new Dictionary<string, Identifier>(other._identifiers, other._identifiers.Comparer);
 			_extensionMethods = new HashSet<MethodInfo>(other._extensionMethods);
 
 			AssignmentOperators = other.AssignmentOperators;


### PR DESCRIPTION
The comparers for the known types and identifiers were lost when cloning the parser settings.

I also took the opportunity to address the fact that case insensitivity wasn't used when resolving extension methods, which wasn't consistent. Now, extension methods are resolved with the proper case comparison.

Fixes #221