### PR TITLE
The identifier detection now supports lambda parameters

### DIFF
--- a/test/DynamicExpresso.UnitTest/DetectIdentifiersTest.cs
+++ b/test/DynamicExpresso.UnitTest/DetectIdentifiersTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 
 namespace DynamicExpresso.UnitTest
@@ -190,6 +191,113 @@ namespace DynamicExpresso.UnitTest
 				Assert.AreEqual("y", detectedIdentifiers.UnknownIdentifiers.ElementAt(1));
 				Assert.AreEqual(2, detectedIdentifiers.UnknownIdentifiers.Count());
 			}
+		}
+
+		[Test]
+		public void Detect_identifiers_inside_lambda_expression_GitHub_Issue_226()
+		{
+			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
+			target.SetVariable("list", new List<string>());
+
+			var detectedIdentifiers = target.DetectIdentifiers("list.Any(x => x == null)");
+			Assert.IsEmpty(detectedIdentifiers.UnknownIdentifiers);
+
+			Assert.AreEqual(3, detectedIdentifiers.Identifiers.Count());
+
+			Assert.AreEqual("list", detectedIdentifiers.Identifiers.ElementAt(0).Name);
+			Assert.AreEqual(typeof(List<string>), detectedIdentifiers.Identifiers.ElementAt(0).Expression.Type);
+
+			Assert.AreEqual("x", detectedIdentifiers.Identifiers.ElementAt(1).Name);
+			Assert.AreEqual(typeof(object), detectedIdentifiers.Identifiers.ElementAt(1).Expression.Type);
+
+			Assert.AreEqual("null", detectedIdentifiers.Identifiers.ElementAt(2).Name);
+			Assert.AreEqual(typeof(object), detectedIdentifiers.Identifiers.ElementAt(2).Expression.Type);
+		}
+
+		[Test]
+		public void Detect_identifiers_inside_lambda_expression_2()
+		{
+			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
+
+			var detectedIdentifiers = target.DetectIdentifiers("x => x + 5");
+			Assert.IsEmpty(detectedIdentifiers.UnknownIdentifiers);
+
+			Assert.AreEqual(1, detectedIdentifiers.Identifiers.Count());
+
+			Assert.AreEqual("x", detectedIdentifiers.Identifiers.ElementAt(0).Name);
+			Assert.AreEqual(typeof(object), detectedIdentifiers.Identifiers.ElementAt(0).Expression.Type);
+		}
+
+		[Test]
+		public void Detect_identifiers_inside_lambda_expression_multiple_params()
+		{
+			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
+
+			var detectedIdentifiers = target.DetectIdentifiers("(x, y) => x + y");
+			Assert.IsEmpty(detectedIdentifiers.UnknownIdentifiers);
+
+			Assert.AreEqual(2, detectedIdentifiers.Identifiers.Count());
+
+			Assert.AreEqual("x", detectedIdentifiers.Identifiers.ElementAt(0).Name);
+			Assert.AreEqual(typeof(object), detectedIdentifiers.Identifiers.ElementAt(0).Expression.Type);
+
+			Assert.AreEqual("y", detectedIdentifiers.Identifiers.ElementAt(1).Name);
+			Assert.AreEqual(typeof(object), detectedIdentifiers.Identifiers.ElementAt(1).Expression.Type);
+		}
+
+		[Test]
+		public void Detect_identifiers_inside_lambda_expression_multiple_params_with_type()
+		{
+			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
+
+			var detectedIdentifiers = target.DetectIdentifiers("(int x, string y) => x + y");
+			Assert.IsEmpty(detectedIdentifiers.UnknownIdentifiers);
+
+			Assert.AreEqual(2, detectedIdentifiers.Types.Count());
+			Assert.AreEqual("int", detectedIdentifiers.Types.ElementAt(0).Name);
+			Assert.AreEqual(typeof(int), detectedIdentifiers.Types.ElementAt(0).Type);
+			Assert.AreEqual("string", detectedIdentifiers.Types.ElementAt(1).Name);
+			Assert.AreEqual(typeof(string), detectedIdentifiers.Types.ElementAt(1).Type);
+
+			Assert.AreEqual(2, detectedIdentifiers.Identifiers.Count());
+
+			Assert.AreEqual("x", detectedIdentifiers.Identifiers.ElementAt(0).Name);
+			Assert.AreEqual(typeof(int), detectedIdentifiers.Identifiers.ElementAt(0).Expression.Type);
+
+			Assert.AreEqual("y", detectedIdentifiers.Identifiers.ElementAt(1).Name);
+			Assert.AreEqual(typeof(string), detectedIdentifiers.Identifiers.ElementAt(1).Expression.Type);
+		}
+
+		[Test]
+		public void Detect_identifiers_inside_lambda_expression_duplicate_param_name()
+		{
+			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
+
+			var detectedIdentifiers = target.DetectIdentifiers("(x, int y, z, int a) => x.Select(z => z + y).Select((string a, string b) => b)");
+			Assert.IsEmpty(detectedIdentifiers.UnknownIdentifiers);
+
+			Assert.AreEqual(2, detectedIdentifiers.Types.Count());
+			Assert.AreEqual("int", detectedIdentifiers.Types.ElementAt(0).Name);
+			Assert.AreEqual(typeof(int), detectedIdentifiers.Types.ElementAt(0).Type);
+			Assert.AreEqual("string", detectedIdentifiers.Types.ElementAt(1).Name);
+			Assert.AreEqual(typeof(string), detectedIdentifiers.Types.ElementAt(1).Type);
+
+			Assert.AreEqual(5, detectedIdentifiers.Identifiers.Count());
+
+			Assert.AreEqual("x", detectedIdentifiers.Identifiers.ElementAt(0).Name);
+			Assert.AreEqual(typeof(object), detectedIdentifiers.Identifiers.ElementAt(0).Expression.Type);
+
+			Assert.AreEqual("y", detectedIdentifiers.Identifiers.ElementAt(1).Name);
+			Assert.AreEqual(typeof(int), detectedIdentifiers.Identifiers.ElementAt(1).Expression.Type);
+
+			Assert.AreEqual("z", detectedIdentifiers.Identifiers.ElementAt(2).Name);
+			Assert.AreEqual(typeof(object), detectedIdentifiers.Identifiers.ElementAt(2).Expression.Type);
+
+			Assert.AreEqual("a", detectedIdentifiers.Identifiers.ElementAt(3).Name);
+			Assert.AreEqual(typeof(object), detectedIdentifiers.Identifiers.ElementAt(3).Expression.Type);
+
+			Assert.AreEqual("b", detectedIdentifiers.Identifiers.ElementAt(4).Name);
+			Assert.AreEqual(typeof(string), detectedIdentifiers.Identifiers.ElementAt(4).Expression.Type);
 		}
 	}
 }


### PR DESCRIPTION
I've added a regex to detect lambda parameters.

Fixes #226