### PR TITLE
implicit `this` reference #232.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,25 @@ Assert.AreEqual(30, myFunc.Invoke(23, 7));
 Assert.AreEqual(30, myFunc.Invoke(32, -2));
 ```
 
+### Special identifiers
+
+Either a variable or a parameter with name `this` can be referenced implicitly.
+
+```csharp
+class Customer { public string Name { get; set; } }
+
+var target = new Interpreter();
+
+// 'this' is treated as a special identifier and could by accessed implicitly 
+target.SetVariable("this", new Customer { Name = "John" });
+
+// explicit context reference via 'this' variable
+Assert.AreEqual("John", target.Eval("this.Name"));
+
+// 'this' variable is referenced implicitly
+Assert.AreEqual("John", target.Eval("Name"));
+```
+
 ### Built-in types and custom types
 Currently predefined types available are:
 
@@ -305,12 +324,21 @@ The following character escape sequences are supported inside string or char lit
 ### Type's members invocation
 Any standard .NET method, field, property or constructor can be invoked.
 ```csharp
-var x = new MyTestService();
-var target = new Interpreter().SetVariable("x", x);
+var service = new MyTestService();
+var context = new MyTestContext();
+
+var target = new Interpreter()
+  .SetVariable("x", service)
+  .SetVariable("this", context);
 
 Assert.AreEqual(x.HelloWorld(), target.Eval("x.HelloWorld()"));
 Assert.AreEqual(x.AProperty, target.Eval("x.AProperty"));
 Assert.AreEqual(x.AField, target.Eval("x.AField"));
+
+// implicit context reference
+Assert.AreEqual(x.HelloWorld(), target.Eval("GetContextId()"));
+Assert.AreEqual(x.AProperty, target.Eval("ContextName"));
+Assert.AreEqual(x.AField, target.Eval("ContextField"));
 ```
 ```csharp
 var target = new Interpreter();

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ class Customer { public string Name { get; set; } }
 
 var target = new Interpreter();
 
-// 'this' is treated as a special identifier and could by accessed implicitly 
+// 'this' is treated as a special identifier and can be accessed implicitly 
 target.SetVariable("this", new Customer { Name = "John" });
 
 // explicit context reference via 'this' variable
@@ -322,6 +322,7 @@ The following character escape sequences are supported inside string or char lit
 - `\v` - Vertical quote (character 11)
 
 ### Type's members invocation
+
 Any standard .NET method, field, property or constructor can be invoked.
 ```csharp
 var service = new MyTestService();
@@ -331,14 +332,14 @@ var target = new Interpreter()
   .SetVariable("x", service)
   .SetVariable("this", context);
 
-Assert.AreEqual(x.HelloWorld(), target.Eval("x.HelloWorld()"));
-Assert.AreEqual(x.AProperty, target.Eval("x.AProperty"));
-Assert.AreEqual(x.AField, target.Eval("x.AField"));
+Assert.AreEqual(service.HelloWorld(), target.Eval("x.HelloWorld()"));
+Assert.AreEqual(service.AProperty, target.Eval("x.AProperty"));
+Assert.AreEqual(service.AField, target.Eval("x.AField"));
 
 // implicit context reference
-Assert.AreEqual(x.HelloWorld(), target.Eval("GetContextId()"));
-Assert.AreEqual(x.AProperty, target.Eval("ContextName"));
-Assert.AreEqual(x.AField, target.Eval("ContextField"));
+Assert.AreEqual(context.GetContextId(), target.Eval("GetContextId()"));
+Assert.AreEqual(context.ContextName, target.Eval("ContextName"));
+Assert.AreEqual(context.ContextField, target.Eval("ContextField"));
 ```
 ```csharp
 var target = new Interpreter();

--- a/src/DynamicExpresso.Core/LanguageConstants.cs
+++ b/src/DynamicExpresso.Core/LanguageConstants.cs
@@ -6,6 +6,8 @@ namespace DynamicExpresso
 {
 	public static class LanguageConstants
 	{
+		public const string This = "this";
+
 		public static readonly ReferenceType[] PrimitiveTypes = {
             new ReferenceType(typeof(object)),
             new ReferenceType(typeof(bool)),

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1019,12 +1019,31 @@ namespace DynamicExpresso.Parsing
 			{
 				return ParseTypeKeyword(knownType);
 			}
-			
+
+			var token = _token;
+
+			try
+			{
+				if (_arguments.TryGetIdentifier("this", out var thisKeywordExpression))
+				{
+					return ParseMemberAccess(thisKeywordExpression);
+				}
+
+				if (_arguments.TryGetParameters("this", out var thisParameterExpression))
+				{
+					return ParseMemberAccess(thisParameterExpression);
+				}
+			}
+			catch
+			{
+				// ignore
+			}
+
 			// Working context implementation
 			//if (it != null)
 			//    return ParseMemberAccess(null, it);
 
-			throw new UnknownIdentifierException(_token.text, _token.pos);
+			throw new UnknownIdentifierException(token.text, token.pos);
 		}
 
 		// Working context implementation

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1034,7 +1034,7 @@ namespace DynamicExpresso.Parsing
 					return ParseMemberAccess(thisParameterExpression);
 				}
 			}
-			catch
+			catch(ParseException)
 			{
 				// ignore
 			}

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1024,12 +1024,12 @@ namespace DynamicExpresso.Parsing
 
 			try
 			{
-				if (_arguments.TryGetIdentifier("this", out var thisKeywordExpression))
+				if (_arguments.TryGetIdentifier(LanguageConstants.This, out var thisKeywordExpression))
 				{
 					return ParseMemberAccess(thisKeywordExpression);
 				}
 
-				if (_arguments.TryGetParameters("this", out var thisParameterExpression))
+				if (_arguments.TryGetParameters(LanguageConstants.This, out var thisParameterExpression))
 				{
 					return ParseMemberAccess(thisParameterExpression);
 				}

--- a/test/DynamicExpresso.UnitTest/IdentifiersTest.cs
+++ b/test/DynamicExpresso.UnitTest/IdentifiersTest.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using NUnit.Framework;
 
 namespace DynamicExpresso.UnitTest
@@ -7,6 +6,16 @@ namespace DynamicExpresso.UnitTest
 	[TestFixture]
 	public class IdentifiersTest
 	{
+		class Customer
+		{
+			public string Name { get; set; }
+
+			public string GetName()
+			{
+				return Name;
+			}
+		}
+
 		[Test]
 		public void Default_identifiers_are_saved_inside_the_interpreter()
 		{
@@ -44,33 +53,32 @@ namespace DynamicExpresso.UnitTest
 		public void This_identifier_variable()
 		{
 			const string Name = "John";
-			var context = new KeyValuePair<string, string>(nameof(Name), Name);
 
 			var interpreter = new Interpreter();
 
-			interpreter.SetVariable("this", context);
+			interpreter.SetVariable("this", new Customer {Name = Name});
 
-			Assert.AreEqual(Name, interpreter.Eval("this.Value"));
-			Assert.AreEqual(nameof(Name), interpreter.Eval("this.Key"));
+			Assert.AreEqual(Name, interpreter.Eval("this.Name"));
+			Assert.AreEqual(Name, interpreter.Eval("this.GetName()"));
 
-			Assert.AreEqual(Name, interpreter.Eval("Value"));
-			Assert.AreEqual(nameof(Name), interpreter.Eval("Key"));
+			Assert.AreEqual(Name, interpreter.Eval("Name"));
+			Assert.AreEqual(Name, interpreter.Eval("GetName()"));
 		}
 
 		[Test]
 		public void This_identifier_parameter()
 		{
 			const string Name = "John";
-			var context = new KeyValuePair<string, string>(nameof(Name), Name);
-			var parameter = new Parameter("this", context.GetType());
 
+			var context = new Customer {Name = Name};
+			var parameter = new Parameter("this", context.GetType());
 			var interpreter = new Interpreter();
 
-			Assert.AreEqual(Name, interpreter.Parse("this.Value", parameter).Invoke(context));
-			Assert.AreEqual(nameof(Name), interpreter.Parse("this.Key", parameter).Invoke(context));
+			Assert.AreEqual(Name, interpreter.Parse("this.Name", parameter).Invoke(context));
+			Assert.AreEqual(Name, interpreter.Parse("this.GetName()", parameter).Invoke(context));
 
-			Assert.AreEqual(Name, interpreter.Parse("Value", parameter).Invoke(context));
-			Assert.AreEqual(nameof(Name), interpreter.Parse("Key", parameter).Invoke(context));
+			Assert.AreEqual(Name, interpreter.Parse("Name", parameter).Invoke(context));
+			Assert.AreEqual(Name, interpreter.Parse("GetName()", parameter).Invoke(context));
 		}
 	}
 }

--- a/test/DynamicExpresso.UnitTest/IdentifiersTest.cs
+++ b/test/DynamicExpresso.UnitTest/IdentifiersTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 
 namespace DynamicExpresso.UnitTest
@@ -37,6 +38,39 @@ namespace DynamicExpresso.UnitTest
 			Assert.AreEqual(2, lambda.Identifiers.Count());
 			Assert.AreEqual("x", lambda.Identifiers.ElementAt(0).Name);
 			Assert.AreEqual("true", lambda.Identifiers.ElementAt(1).Name);
+		}
+
+		[Test]
+		public void This_identifier_variable()
+		{
+			const string Name = "John";
+			var context = new KeyValuePair<string, string>(nameof(Name), Name);
+
+			var interpreter = new Interpreter();
+
+			interpreter.SetVariable("this", context);
+
+			Assert.AreEqual(Name, interpreter.Eval("this.Value"));
+			Assert.AreEqual(nameof(Name), interpreter.Eval("this.Key"));
+
+			Assert.AreEqual(Name, interpreter.Eval("Value"));
+			Assert.AreEqual(nameof(Name), interpreter.Eval("Key"));
+		}
+
+		[Test]
+		public void This_identifier_parameter()
+		{
+			const string Name = "John";
+			var context = new KeyValuePair<string, string>(nameof(Name), Name);
+			var parameter = new Parameter("this", context.GetType());
+
+			var interpreter = new Interpreter();
+
+			Assert.AreEqual(Name, interpreter.Parse("this.Value", parameter).Invoke(context));
+			Assert.AreEqual(nameof(Name), interpreter.Parse("this.Key", parameter).Invoke(context));
+
+			Assert.AreEqual(Name, interpreter.Parse("Value", parameter).Invoke(context));
+			Assert.AreEqual(nameof(Name), interpreter.Parse("Key", parameter).Invoke(context));
 		}
 	}
 }


### PR DESCRIPTION
Allows to implicitly access `this` identifier set either as a Variable or passed as a Parameter to have more concise expression.

In other word an emulation of `this` implicit argument passed to a method call.

```c#
const string Name = "John";
var context = new KeyValuePair<string, string>(nameof(Name), Name);
var interpreter = new Interpreter().SetVariable("this", context);

Assert.AreEqual(Name, interpreter.Eval("this.Value"));
Assert.AreEqual(Name, interpreter.Eval("Value"));
```

or

```c#
const string Name = "John";
var context = new KeyValuePair<string, string>(nameof(Name), Name);
var parameter = new Parameter("this", context.GetType());
var interpreter = new Interpreter();

Assert.AreEqual(Name, interpreter.Parse("this.Value", parameter).Invoke(context));
Assert.AreEqual(Name, interpreter.Parse("Value", parameter).Invoke(context));
```

https://github.com/dynamicexpresso/DynamicExpresso/issues/232