### PR TITLE
Fix issue when parsing hexadecimal and binary literals

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -893,6 +893,9 @@ namespace DynamicExpresso.Parsing
 				else if (text.StartsWith("0b") || text.StartsWith("0B"))
 				{
 					var binary = text.Substring(2);
+					if (string.IsNullOrEmpty(binary))
+						throw CreateParseException(_token.pos, ErrorMessages.InvalidIntegerLiteral, text);
+
 					try
 					{
 						value = Convert.ToUInt64(binary, 2);
@@ -3073,6 +3076,8 @@ namespace DynamicExpresso.Parsing
 								{
 									NextChar();
 								} while (char.IsDigit(_parseChar) || (_parseChar >= 'a' && _parseChar <= 'f') || (_parseChar >= 'A' && _parseChar <= 'F'));
+
+								PreviousChar();
 							}
 							else if (_parseChar == 'b' || _parseChar == 'B')
 							{
@@ -3081,6 +3086,8 @@ namespace DynamicExpresso.Parsing
 								{
 									NextChar();
 								} while (_parseChar == '0' || _parseChar == '1');
+
+								PreviousChar();
 							}
 							else
 							{

--- a/test/DynamicExpresso.UnitTest/LiteralsTest.cs
+++ b/test/DynamicExpresso.UnitTest/LiteralsTest.cs
@@ -360,8 +360,9 @@ namespace DynamicExpresso.UnitTest
 
 			Assert.AreEqual(0b101ul, target.Eval("0b101ul"));
 			Assert.AreEqual(0B1111L, target.Eval("0B1111l"));
-			Assert.AreEqual(6, target.Eval("4 + 0b10"));
+			Assert.AreEqual(8, target.Eval("4+0b10+2"));
 
+			Assert.Throws<ParseException>(() => target.Eval("0b"));
 			Assert.Throws<ParseException>(() => target.Eval("0b12"));
 			Assert.Throws<ParseException>(() => target.Eval("0b10.10"));
 			Assert.Throws<ParseException>(() => target.Eval("0b10d"));
@@ -375,8 +376,10 @@ namespace DynamicExpresso.UnitTest
 
 			Assert.AreEqual(0x012EFul, target.Eval("0x012EFul"));
 			Assert.AreEqual(0XAAe2L, target.Eval("0XAAe2l"));
-			Assert.AreEqual(165, target.Eval("4 + 0xA1"));
+			Assert.AreEqual(170, target.Eval("4+0xA1+5"));
+			Assert.AreEqual(170, target.Eval("4+(0xA1)+5"));
 
+			Assert.Throws<ParseException>(() => target.Eval("0x"));
 			Assert.Throws<ParseException>(() => target.Eval("0x1Gl"));
 			Assert.Throws<ParseException>(() => target.Eval("0x12.12"));
 		}


### PR DESCRIPTION
The lexer took one more character than needed when parsing an hexadecimal or a binary literal:

```c#
4+0x124+5
```` 

Instead of `0x124`, the lexer considered `0x124+` to be the literal. Now, we backtrack one character to avoid this issue.

Fix #241