### PR TITLE
Add support of Single-Dimensional Arrays initialization

### DIFF
--- a/src/DynamicExpresso.Core/Resources/ErrorMessages.Designer.cs
+++ b/src/DynamicExpresso.Core/Resources/ErrorMessages.Designer.cs
@@ -520,5 +520,16 @@ namespace DynamicExpresso.Resources {
                 return ResourceManager.GetString("InvalidOperation", resourceCulture);
             }
         }
-    }
+
+		/// <summary>
+		///   Looks up a localized string similar to Multidimensional arrays are not supported.
+		/// </summary>
+		internal static string UnsupportedMultidimensionalArrays
+		{
+			get
+			{
+				return ResourceManager.GetString("UnsupportedMultidimensionalArrays", resourceCulture);
+			}
+		}
+	}
 }

--- a/src/DynamicExpresso.Core/Resources/ErrorMessages.resx
+++ b/src/DynamicExpresso.Core/Resources/ErrorMessages.resx
@@ -264,4 +264,7 @@
   <data name="AmbiguousConstructorInvocation" xml:space="preserve">
     <value>Ambiguous invocation of constructor in type '{0}'</value>
   </data>
+  <data name="UnsupportedMultidimensionalArrays" xml:space="preserve">
+    <value>Multidimensional arrays are not supported</value>
+  </data>
 </root>

--- a/test/DynamicExpresso.UnitTest/ConstructorTest.cs
+++ b/test/DynamicExpresso.UnitTest/ConstructorTest.cs
@@ -141,6 +141,44 @@ namespace DynamicExpresso.UnitTest
 			Assert.AreEqual(new MyClass(6, 5, 4, 3).MyArr, target.Eval("new MyClass(6, 5, 4, 3).MyArr"));
 		}
 
+		[Test]
+		public void Array_constructor()
+		{
+			var target = new Interpreter();
+			var arr = target.Eval<int[]>("new int[] { 1, 2 }");
+			Assert.AreEqual(2, arr.Length);
+			Assert.AreEqual(1, arr[0]);
+			Assert.AreEqual(2, arr[1]);
+		}
+
+		[Test]
+		public void Array_constructor_type_mismatch()
+		{
+			// Exception: an expression of type 'System.Char' cannot be used to initialize an array of type 'System.Int32'
+			var target = new Interpreter();
+			Assert.Throws<ParseException>(() => target.Eval<int[]>("new int[] { 1, 'a' }"));
+		}
+
+		[Test]
+		public void Jagged_array_constructor()
+		{
+			var target = new Interpreter();
+			var arr = target.Eval<int[][]>("new int[][] { new int[] { 1, 2, }, new int[] { 3, 4, }, }");
+			Assert.AreEqual(2, arr.Length);
+			Assert.AreEqual(1, arr[0][0]);
+			Assert.AreEqual(2, arr[0][1]);
+			Assert.AreEqual(3, arr[1][0]);
+			Assert.AreEqual(4, arr[1][1]);
+		}
+
+		[Test]
+		public void Array_multi_dimension_constructor()
+		{
+			// creating a multidimensional array is not supported
+			var target = new Interpreter();
+			Assert.Throws<ParseException>(() => target.Parse("new int[,] { { 1 }, { 2 } }"));
+		}
+
 		private class MyClass
 		{
 			public int IntField;


### PR DESCRIPTION
First step towards fixing #194 : single-dimension array initialization.

You can now write:

```c#
var target = new Interpreter();
var arr = target.Eval<int[]>("new int[] { 1, 2 }");
Assert.AreEqual(2, arr.Length);
Assert.AreEqual(1, arr[0]);
Assert.AreEqual(2, arr[1]);
```

Jagged arrays are also supported:

```c#
var target = new Interpreter();
var arr = target.Eval<int[][]>("new int[][] { new int[] { 1, 2, }, new int[] { 3, 4, }, }");
```

Multidimensional arrays are not supported, because I couldn't find the Linq expression needed to create them: `NewArrayInit` can initialize a single dimension array with values, while `NewArrayBounds` can initialize a multidimension array, but without values. Considering how rare multidimensional arrays are, I think the limitation is not really an issue.