### PR TITLE
Added support of collection initializer syntax.

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1203,16 +1203,17 @@ namespace DynamicExpresso.Parsing
 
 		private Expression ParseMemberAndInitializerList(NewExpression newExpr, Type newType)
 		{
-			int originalPos = _token.pos;
+			var originalPos = _token.pos;
 			var bindingList = new List<MemberBinding>();
-			List<Expression> actions = new List<Expression>();
+			var actions = new List<Expression>();
 			ParameterExpression instance = null;
+			var allowCollectionInit = typeof(IEnumerable).IsAssignableFrom(newType);
 			while (true)
 			{
 				if (_token.id == TokenId.CloseCurlyBracket) break;
 				if (_token.id != TokenId.Identifier)
 				{
-					if (!typeof(IEnumerable).IsAssignableFrom(newType))
+					if (!allowCollectionInit)
 					{
 						throw CreateParseException(_token.pos, ErrorMessages.CollectionInitializationNotSupported, newType, typeof(IEnumerable));
 					}
@@ -1259,7 +1260,7 @@ namespace DynamicExpresso.Parsing
 				if (_token.id != TokenId.Comma) break;
 				NextToken();
 			}
-			if(instance != null)
+			if (instance != null)
 			{
 				actions.Add(instance);
 				return Expression.Block(new ParameterExpression[] { instance }, actions);

--- a/src/DynamicExpresso.Core/Resources/ErrorMessages.Designer.cs
+++ b/src/DynamicExpresso.Core/Resources/ErrorMessages.Designer.cs
@@ -519,6 +519,24 @@ namespace DynamicExpresso.Resources {
             get {
                 return ResourceManager.GetString("InvalidOperation", resourceCulture);
             }
-        }
-    }
+		}
+
+		/// <summary>
+		///   Looks up a localized string similar to Invalid initializer member declarator.
+		/// </summary>
+		internal static string InvalidInitializerMemberDeclarator {
+			get {
+				return ResourceManager.GetString("InvalidInitializerMemberDeclarator", resourceCulture);
+			}
+		}
+
+		/// <summary>
+		///   Looks up a localized string similar to Cannot initialize type '{0}' with a collection initializer because it does not implement '{1}'.
+		/// </summary>
+		internal static string CollectionInitializationNotSupported {
+			get {
+				return ResourceManager.GetString("CollectionInitializationNotSupported", resourceCulture);
+			}
+		}
+	}
 }

--- a/src/DynamicExpresso.Core/Resources/ErrorMessages.resx
+++ b/src/DynamicExpresso.Core/Resources/ErrorMessages.resx
@@ -264,4 +264,10 @@
   <data name="AmbiguousConstructorInvocation" xml:space="preserve">
     <value>Ambiguous invocation of constructor in type '{0}'</value>
   </data>
+  <data name="InvalidInitializerMemberDeclarator" xml:space="preserve">
+    <value>Invalid initializer member declarator</value>
+  </data>
+  <data name="CollectionInitializationNotSupported" xml:space="preserve">
+    <value>Cannot initialize type '{0}' with a collection initializer because it does not implement '{1}'</value>
+  </data>
 </root>

--- a/test/DynamicExpresso.UnitTest/ConstructorTest.cs
+++ b/test/DynamicExpresso.UnitTest/ConstructorTest.cs
@@ -186,6 +186,7 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter();
 			target.Reference(typeof(MyClassAdder));
 			Assert.DoesNotThrow(() => target.Eval<MyClassAdder>("new MyClassAdder(){{ 1, 2, 3, 4, 5},{StrProp = \"6\" },7}", new Parameter("StrProp", "0")));
+			Assert.DoesNotThrow(() => target.Eval<MyClassAdder>("new MyClassAdder(){{ 1, 2, 3, 4, 5},StrProp = \"6\",7}", new Parameter("StrProp", "0")));
 			Assert.DoesNotThrow(() => target.Eval<MyClassAdder>("new MyClassAdder(){{ 1, 2, 3, 4, 5},string.Empty, 7}"));
 			Assert.Throws<ParseException>(() => target.Eval<MyClassAdder>("new MyClassAdder(){{ 1, 2, 3, 4, 5},{StrProp = \"6\" },7	}"));
 		}
@@ -201,6 +202,22 @@ namespace DynamicExpresso.UnitTest
 				Assert.AreEqual(i + 1, intList[i]);
 			}
 		}
+
+		[Test]
+		public void Ctor_NewListWithString()
+		{
+			var target = new Interpreter();
+			target.Reference(typeof(System.Collections.Generic.List<>));
+			var list = target.Eval<System.Collections.Generic.List<string>>("new List<string>(){string.Empty}");
+			Assert.AreEqual(1, list.Count);
+			for (int i = 0; i < list.Count; ++i)
+			{
+				Assert.AreSame(string.Empty, list[i]);
+			}
+			Assert.DoesNotThrow(() => target.Eval<System.Collections.Generic.List<string>>("new List<string>(){StrProp = string.Empty}", new Parameter("StrProp", "0")));
+			Assert.DoesNotThrow(() => target.Eval<System.Collections.Generic.List<string>>("new List<string>(){StrValue()}", new Parameter("StrValue", new Func<string>(() => "Func"))));
+		}
+
 
 		private class MyClass
 		{

--- a/test/DynamicExpresso.UnitTest/ConstructorTest.cs
+++ b/test/DynamicExpresso.UnitTest/ConstructorTest.cs
@@ -169,6 +169,26 @@ namespace DynamicExpresso.UnitTest
 			Assert.AreEqual(7, l.IntField);
 		}
 
+
+		[Test]
+		public void Ctor_NewMyClassWithCross()
+		{
+			string StrProp = "";
+			var mc = new MyClassAdder()
+			{
+				{1,2,3 },
+				{StrProp = "6" }
+			};
+			if (StrProp == "6")
+			{
+
+			}
+			var target = new Interpreter();
+			target.Reference(typeof(MyClassAdder));
+			Assert.DoesNotThrow(() => target.Eval<MyClassAdder>("new MyClassAdder(){{ 1, 2, 3, 4, 5},{StrProp = \"6\" },7}", new Parameter("StrProp", "0")));
+			Assert.DoesNotThrow(() => target.Eval<MyClassAdder>("new MyClassAdder(){{ 1, 2, 3, 4, 5},string.Empty, 7}"));
+			Assert.Throws<ParseException>(() => target.Eval<MyClassAdder>("new MyClassAdder(){{ 1, 2, 3, 4, 5},{StrProp = \"6\" },7	}"));
+		}
 		[Test]
 		public void Ctor_NewListWithItems()
 		{


### PR DESCRIPTION
Implementation of collection initializer syntax support for constructor #194   Copied a little bit of conflicting code from [pull 245](https://github.com/dynamicexpresso/DynamicExpresso/pull/245).

You can now write

```
var target = new Interpreter();
target.Reference(typeof(System.Collections.Generic.List<>));
var intList = target.Eval<System.Collections.Generic.List<int>>("new List<int>(){1, 2, 3, 4, 5}");
Assert.AreEqual(5, intList.Count);
for (int i = 0; i < intList.Count; ++i)
{
    Assert.AreEqual(i + 1, intList[i]);
}
```

as well as implementations supporting multiple parameters in the Add method such as 

`new MyClassAdder(){{ 1, 2, 3, 4, 5},{\"6\" },7	}`
and
`new Dictionary<int, string>(){{1, \"1\"}, {2, \"2\"}, {3, \"3\"}, {4, \"4\"}, {5, \"5\"}}`