### PR TITLE
Added support of collection initializer syntax.

### DIFF
--- a/src/DynamicExpresso.Core/Lambda.cs
+++ b/src/DynamicExpresso.Core/Lambda.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1268,13 +1268,9 @@ namespace DynamicExpresso.Parsing
 				}
 				else if (_token.id != TokenId.Equal || _arguments.TryGetIdentifier(propertyOrFieldName, out _) || _arguments.TryGetParameters(propertyOrFieldName, out _))
 				{
-					SetTextPos(pos);
-					NextToken();
 					ParseCollectionInitalizer(newType, pos, bindingList, actions, instance, allowCollectionInit);
 					return;
 				}
-				SetTextPos(pos);
-				NextToken();
 			}
 			if (member == null)
 			{

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1268,9 +1268,13 @@ namespace DynamicExpresso.Parsing
 				}
 				else if (_token.id != TokenId.Equal || _arguments.TryGetIdentifier(propertyOrFieldName, out _) || _arguments.TryGetParameters(propertyOrFieldName, out _))
 				{
+					SetTextPos(pos);
+					NextToken();
 					ParseCollectionInitalizer(newType, pos, bindingList, actions, instance, allowCollectionInit);
 					return;
 				}
+				SetTextPos(pos);
+				NextToken();
 			}
 			if (member == null)
 			{

--- a/src/DynamicExpresso.Core/Resources/ErrorMessages.Designer.cs
+++ b/src/DynamicExpresso.Core/Resources/ErrorMessages.Designer.cs
@@ -31,11 +31,11 @@ namespace DynamicExpresso.Resources {
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal ErrorMessages() {
         }
-        
-        /// <summary>
-        ///   Returns the cached ResourceManager instance used by this class.
-        /// </summary>
-        [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
+
+		/// <summary>
+		///   Returns the cached ResourceManager instance used by this class.
+		/// </summary>
+		[global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
@@ -531,5 +531,33 @@ namespace DynamicExpresso.Resources {
 				return ResourceManager.GetString("UnsupportedMultidimensionalArrays", resourceCulture);
 			}
 		}
+
+		/// <summary>
+		///   Looks up a localized string similar to Invalid initializer member declarator.
+		/// </summary>
+		internal static string InvalidInitializerMemberDeclarator {
+			get {
+				return ResourceManager.GetString("InvalidInitializerMemberDeclarator", resourceCulture);
+			}
+		}
+
+		/// <summary>
+		///   Looks up a localized string similar to Cannot initialize type '{0}' with a collection initializer because it does not implement '{1}'.
+		/// </summary>
+		internal static string CollectionInitializationNotSupported {
+			get {
+				return ResourceManager.GetString("CollectionInitializationNotSupported", resourceCulture);
+			}
+		}
+
+		/// <summary>
+		///   Looks up a localized string similar to The best overloaded Add method '{0}.Add' for the collection initializer has some invalid arguments.
+		/// </summary>
+		internal static string UnableToFindAppropriateAddMethod { 
+			get {
+				return ResourceManager.GetString("UnableToFindAppropriateAddMethod", resourceCulture);
+			}
+		}
+
 	}
 }

--- a/src/DynamicExpresso.Core/Resources/ErrorMessages.resx
+++ b/src/DynamicExpresso.Core/Resources/ErrorMessages.resx
@@ -267,4 +267,13 @@
   <data name="UnsupportedMultidimensionalArrays" xml:space="preserve">
     <value>Multidimensional arrays are not supported</value>
   </data>
+  <data name="InvalidInitializerMemberDeclarator" xml:space="preserve">
+    <value>Invalid initializer member declarator</value>
+  </data>
+  <data name="CollectionInitializationNotSupported" xml:space="preserve">
+    <value>Cannot initialize type '{0}' with a collection initializer because it does not implement '{1}'</value>
+  </data>
+  <data name="UnableToFindAppropriateAddMethod" xml:space="preserve">
+    <value>The best overloaded Add method '{0}.Add' for the collection initializer has some invalid arguments</value>
+  </data>
 </root>

--- a/test/DynamicExpresso.UnitTest/ConstructorTest.cs
+++ b/test/DynamicExpresso.UnitTest/ConstructorTest.cs
@@ -209,16 +209,23 @@ namespace DynamicExpresso.UnitTest
 			target.Reference(typeof(MyClassAdder));
 			target.Reference(typeof(MyClass));
 			var strProp = new Parameter("StrProp", typeof(string).MakeByRefType(), "0");
+			var intProp = new Parameter("IntField", typeof(int).MakeByRefType(), int.MaxValue);
 			var args = new object[]
 			{
-				strProp.Value
+				strProp.Value,
+				intProp.Value
 			};
 			Assert.AreEqual(
 				new MyClassAdder() { { 1, 2, 3, 4, 5 }, "6", 7 },
-				target.Parse("new MyClassAdder(){{ 1, 2, 3, 4, 5},{StrProp = \"6\" },7}", strProp).Invoke(args));
+				target.Parse("new MyClassAdder(){{ 1, 2, 3, 4, 5},{StrProp = \"6\" },7}", strProp, intProp).Invoke(args));
 			Assert.AreEqual(
 				new MyClassAdder() { { 1, 2, 3, 4, 5 }, string.Empty, 7 },
 				target.Eval<MyClassAdder>("new MyClassAdder(){{ 1, 2, 3, 4, 5},string.Empty, 7}"));
+
+			var IntField = int.MaxValue;
+			Assert.AreEqual(
+				new MyClassAdder() { { IntField = 5 }, { 1, 2, 3, 4, IntField }, "6" },
+				target.Parse("new MyClassAdder(){ { IntField = 5 }, { 1, 2, 3, 4, 5},{StrProp = \"6\" }, IntField}", strProp, intProp).Invoke(args));
 		}
 
 		[Test]

--- a/test/DynamicExpresso.UnitTest/ConstructorTest.cs
+++ b/test/DynamicExpresso.UnitTest/ConstructorTest.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections;
 using DynamicExpresso.Exceptions;
 using NUnit.Framework;
+using System.Linq;
 
 namespace DynamicExpresso.UnitTest
 {
@@ -121,7 +123,6 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 			target.Reference(typeof(MyClass));
-
 			Assert.Throws<ParseException>(() => target.Parse("new MyClass() { StrProp }"));
 			Assert.Throws<ParseException>(() => target.Parse("new MyClass() { StrProp = }"));
 			Assert.Throws<ArgumentException>(() => target.Parse("new MyClass() { StrProp = 5 }")); // type mismatch
@@ -130,7 +131,7 @@ namespace DynamicExpresso.UnitTest
 			Assert.Throws<ParseException>(() => target.Parse("new MyClass() { StrProp ")); // no close bracket
 			Assert.Throws<ParseException>(() => target.Parse("new MyClass() StrProp }")); // no open bracket
 			Assert.Throws<ParseException>(() => target.Parse("new MyClass() {{IntField = 5}}")); // multiple bracket
-			Assert.Throws<ParseException>(() => target.Parse("new MyClass() {5}")); // no field name
+			Assert.Throws<ParseException>(() => target.Parse("new MyClass() {5}")); // collection initializer not supported
 		}
 
 		[Test]
@@ -179,6 +180,121 @@ namespace DynamicExpresso.UnitTest
 			Assert.Throws<ParseException>(() => target.Parse("new int[,] { { 1 }, { 2 } }"));
 		}
 
+		[Test]
+		public void Ctor_NewDictionaryWithItems()
+		{
+			var target = new Interpreter();
+			target.Reference(typeof(System.Collections.Generic.Dictionary<,>));
+			var l = target.Eval<System.Collections.Generic.Dictionary<int, string>>("new Dictionary<int, string>(){{1, \"1\"}, {2, \"2\"}, {3, \"3\"}, {4, \"4\"}, {5, \"5\"}}");
+			Assert.AreEqual(5, l.Count);
+			for (int i = 0; i < l.Count; ++i)
+			{
+				Assert.AreEqual(i + 1 + "", l[i + 1]);
+			}
+		}
+
+		[Test]
+		public void Ctor_NewMyClassWithItems()
+		{
+			var target = new Interpreter();
+			target.Reference(typeof(MyClassAdder));
+			var l = target.Eval<MyClassAdder>("new MyClassAdder(){{ 1, 2, 3, 4, 5},{\"6\" },7	}.Add(true)");
+			Assert.AreEqual(5, l.MyArr.Length);
+			for (int i = 0; i < l.MyArr.Length; ++i)
+			{
+				Assert.AreEqual(i + 1, l.MyArr[i]);
+			}
+			Assert.AreEqual("6", l.StrProp);
+			Assert.AreEqual(7, l.IntField);
+		}
+
+
+		[Test]
+		public void Ctor_NewMyClassWithCross()
+		{
+			var StrProp = string.Empty;
+
+			new MyClassAdder() { StrProp = StrProp = "6" };
+
+			var target = new Interpreter();
+			target.Reference(typeof(MyClassAdder));
+			target.Reference(typeof(MyClass));
+			var strProp = new Parameter("StrProp", typeof(string).MakeByRefType(), "0");
+			var args = new object[]
+			{
+				strProp.Value
+			};
+			Assert.AreEqual(new MyClassAdder() { { 1, 2, 3, 4, 5 }, "6", 7 }, target.Parse("new MyClassAdder(){{ 1, 2, 3, 4, 5},{StrProp = \"6\" },7}", strProp).Invoke(args));
+			Assert.AreEqual(new MyClassAdder() { { 1, 2, 3, 4, 5 }, string.Empty, 7 }, target.Eval<MyClassAdder>("new MyClassAdder(){{ 1, 2, 3, 4, 5},string.Empty, 7}"));
+			Assert.AreEqual(new MyClassAdder() {StrProp = string.Empty, MyArr = new[] { 1, 2, 3, 4, 5 }, IntField = int.MinValue }, target.Eval<MyClassAdder>("new MyClassAdder() {StrProp = string.Empty, MyArr = new int[] {1, 2, 3, 4, 5}, IntField = int.MinValue }"));
+			Assert.Throws<ParseException>(() => target.Eval<MyClassAdder>("new MyClassAdder(){{ 1, 2, 3, 4, 5},{StrProp = \"6\" },7	}"));
+			Assert.Throws<ParseException>(() => target.Eval<MyClassAdder>("new MyClassAdder(){{ 1, 2, 3, 4, 5},StrProp = \"6\" ,7	}"));
+			Assert.Throws<ParseException>(() => target.Eval<MyClassAdder>("new MyClassAdder(){StrProp = \"6\" ,{ 1, 2, 3, 4, 5},7	}"));
+			Assert.Throws<ParseException>(() => target.Eval<MyClass>("new MyClass(){ 1, 2, 3, 4, 5}"));
+		}
+		[Test]
+		public void Ctor_NewListWithItems()
+		{
+			Ctor_NewListGeneric<string, string>("\"1\"", "\"2\"", "\"3\"", "{string.Empty}", "string.Empty", "int.MaxValue.ToString()", "{int.MinValue.ToString()}");
+			Ctor_NewListGeneric<int, int>("1", "2", "3", "int.MinValue", "int.MaxValue", "{int.MinValue}", "{int.MaxValue}");
+			Ctor_NewListGeneric<object, object>("string.Empty", "int.MinValue");
+		}
+
+		[Test]
+		public void Ctor_NewListCantFindAddMethod()
+		{
+			var target = new Interpreter();
+			target.Reference(typeof(System.Collections.Generic.List<>));
+			Assert.Throws<ParseException>(() => target.Eval<System.Collections.Generic.List<int>>("string.Empty"));
+			Assert.Throws<ParseException>(() => target.Eval<System.Collections.Generic.List<string>>("int.MaxValue"));
+		}
+
+		public void Ctor_NewListGeneric<TList, TObject>(params string[] items)
+		{
+			var target = new Interpreter();
+			target.Reference(typeof(System.Collections.Generic.List<>));
+			target.Reference(typeof(TList));
+			target.Reference(typeof(TObject));
+			//Create a random list of values to test.
+			var actual = new System.Collections.Generic.List<TObject>();
+			foreach (var v in items)
+			{
+				actual.Add(target.Eval<TObject>(v.Trim('}', '{')));
+			}
+			for (var min = 0; min < actual.Count; ++min)
+			{
+				for (var count = Math.Min(min, 1); count <= actual.Count - min; ++count)
+				{
+					var evalText = $"new List<{typeof(TList).Name}>(){{{string.Join(",", items.Skip(min).Take(count))}}}";
+					System.Collections.Generic.List<TList> eval = null;
+					Assert.DoesNotThrow(() => eval = target.Eval<System.Collections.Generic.List<TList>>(evalText), evalText);
+					Assert.AreEqual(count, eval.Count);
+					for (var i = 0; i < count; ++i)
+					{
+						Assert.AreEqual(actual[i + min], eval[i]);
+					}
+				}
+			}
+		}
+
+		[Test]
+		public void Ctor_NewListWithString()
+		{
+			var target = new Interpreter();
+			target.Reference(typeof(System.Collections.Generic.List<>));
+			var list = target.Eval<System.Collections.Generic.List<string>>("new List<string>(){string.Empty}");
+			Assert.AreEqual(1, list.Count);
+			for (int i = 0; i < list.Count; ++i)
+			{
+				Assert.AreSame(string.Empty, list[i]);
+			}
+			list = target.Eval<System.Collections.Generic.List<string>>("new List<string>(){StrProp = string.Empty}", new Parameter("StrProp", "0"));
+			Assert.AreSame(string.Empty, list[0]);
+			list = target.Eval<System.Collections.Generic.List<string>>("new List<string>(){StrValue()}", new Parameter("StrValue", new Func<string>(() => "Func")));
+			Assert.AreEqual("Func", list[0]);
+		}
+
+
 		private class MyClass
 		{
 			public int IntField;
@@ -217,6 +333,43 @@ namespace DynamicExpresso.UnitTest
 			{
 				return 0;
 			}
+		}
+
+		private class MyClassAdder : MyClass, System.Collections.IEnumerable
+		{
+
+			public MyClassAdder Add(string s)
+			{
+				StrProp = s;
+				return this;
+			}
+
+			public MyClassAdder Add(int intValue)
+			{
+				IntField = intValue;
+				return this;
+			}
+
+			public MyClassAdder Add(params int[] intValues)
+			{
+				MyArr = intValues;
+				return this;
+			}
+
+			public MyClassAdder Add(bool returnMe)
+			{
+				if (returnMe)
+				{
+					return this;
+				}
+				return null;
+			}
+
+			IEnumerator IEnumerable.GetEnumerator()
+			{
+				yield break;
+			}
+
 		}
 	}
 }

--- a/test/DynamicExpresso.UnitTest/ParametersTest.cs
+++ b/test/DynamicExpresso.UnitTest/ParametersTest.cs
@@ -332,7 +332,6 @@ namespace DynamicExpresso.UnitTest
 			Assert.AreEqual(4, lambda.Invoke(1, 5));
 		}
 
-
 		[Test]
 		public void When_lambda_is_invoked_I_can_omit_parameters_not_used()
 		{

--- a/test/DynamicExpresso.UnitTest/ParametersTest.cs
+++ b/test/DynamicExpresso.UnitTest/ParametersTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NUnit.Framework;
 using System.Globalization;
 using System.Reflection;
@@ -331,6 +331,7 @@ namespace DynamicExpresso.UnitTest
 
 			Assert.AreEqual(4, lambda.Invoke(1, 5));
 		}
+
 
 		[Test]
 		public void When_lambda_is_invoked_I_can_omit_parameters_not_used()


### PR DESCRIPTION
Implementation of collection initializer syntax support for constructor #194   Managed to somehow close the original PR on accident during rebase operation [pull 246](https://github.com/dynamicexpresso/DynamicExpresso/pull/246), but all comments have now been resolved.

You can now write

```
var target = new Interpreter();
target.Reference(typeof(System.Collections.Generic.List<>));
var intList = target.Eval<System.Collections.Generic.List<int>>("new List<int>(){1, 2, 3, 4, 5}");
Assert.AreEqual(5, intList.Count);
for (int i = 0; i < intList.Count; ++i)
{
    Assert.AreEqual(i + 1, intList[i]);
}
or 
 target.Eval<System.Collections.Generic.List<string>>("new List<string>(){string.Empty}");
```

as well as implementations supporting multiple parameters in the Add method such as 

`new MyClassAdder(){{ 1, 2, 3, 4, 5},{\"6\" },7	}`
and
`new Dictionary<int, string>(){{1, \"1\"}, {2, \"2\"}, {3, \"3\"}, {4, \"4\"}, {5, \"5\"}}`

Reference to method parameters is also supported like below

`target.Eval<System.Collections.Generic.List<string>>("new List<string>(){StrProp = string.Empty}", new Parameter("StrProp", "0"))
target.Eval<System.Collections.Generic.List<string>>("new List<string>(){StrValue()}", new Parameter("StrValue", new Func<string>(() => "Func")))`