### PR TITLE
Issues 212, 256: Adding support for internal lambdas to reference parameters from the parent lambda

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Dynamic;
 using System.Globalization;
 using System.Linq;
@@ -138,7 +139,7 @@ namespace DynamicExpresso.Parsing
 		{
 			// in case the expression is not a lambda, we have to restart parsing
 			var originalPos = _token.pos;
-
+			var isLambda = false;
 			try
 			{
 				var parameters = ParseLambdaParameterList();
@@ -168,10 +169,15 @@ namespace DynamicExpresso.Parsing
 				}
 
 				var lambdaBodyExp = _expressionText.Substring(startExpr, _token.pos - startExpr);
+				isLambda = true;
 				return new InterpreterExpression(_arguments, lambdaBodyExp, parameters);
 			}
 			catch (ParseException)
 			{
+				if (isLambda)
+				{
+					throw;
+				}
 				// not a lambda, return to the saved position
 				SetTextPos(originalPos);
 				NextToken();
@@ -180,13 +186,24 @@ namespace DynamicExpresso.Parsing
 			}
 		}
 
-		private Parameter[] ParseLambdaParameterList()
+		private class ParameterWithPosition : Parameter
+		{
+			public ParameterWithPosition(int pos, string name, Type type)
+				: base(name, type)
+			{
+				Position = pos;
+			}
+
+			public int Position { get; }
+		}
+
+		private ParameterWithPosition[] ParseLambdaParameterList()
 		{
 			var hasOpenParen = _token.id == TokenId.OpenParen;
 			if (hasOpenParen)
 				NextToken();
 
-			var parameters = _token.id != TokenId.CloseParen ? ParseLambdaParameters() : new Parameter[0];
+			var parameters = _token.id != TokenId.CloseParen ? ParseLambdaParameters() : new ParameterWithPosition[0];
 			if (hasOpenParen)
 			{
 				ValidateToken(TokenId.CloseParen, ErrorMessages.CloseParenOrCommaExpected);
@@ -196,9 +213,9 @@ namespace DynamicExpresso.Parsing
 			return parameters;
 		}
 
-		private Parameter[] ParseLambdaParameters()
+		private ParameterWithPosition[] ParseLambdaParameters()
 		{
-			var argList = new List<Parameter>();
+			var argList = new List<ParameterWithPosition>();
 			while (true)
 			{
 				argList.Add(ParseLambdaParameter());
@@ -208,11 +225,12 @@ namespace DynamicExpresso.Parsing
 			return argList.ToArray();
 		}
 
-		private Parameter ParseLambdaParameter()
+		private ParameterWithPosition ParseLambdaParameter()
 		{
 			ValidateToken(TokenId.Identifier);
 			var name = _token.text;
 
+			var pos = _token.pos;
 			if (TryParseKnownType(name, out var type))
 			{
 				ValidateToken(TokenId.Identifier);
@@ -224,7 +242,7 @@ namespace DynamicExpresso.Parsing
 			}
 
 			NextToken();
-			return new Parameter(name, type);
+			return new ParameterWithPosition(pos, name, type);
 		}
 
 		// = operator
@@ -1229,7 +1247,6 @@ namespace DynamicExpresso.Parsing
 				var member = FindPropertyOrField(newType, propertyOrFieldName, false);
 				if (member == null)
 					throw CreateParseException(_token.pos, ErrorMessages.UnknownPropertyOrField, propertyOrFieldName, GetTypeName(newType));
-
 				NextToken();
 
 				ValidateToken(TokenId.Equal, ErrorMessages.EqualExpected);
@@ -3249,9 +3266,10 @@ namespace DynamicExpresso.Parsing
 			private readonly IList<Parameter> _parameters;
 			private Type _type;
 
-			public InterpreterExpression(ParserArguments parserArguments, string expressionText, params Parameter[] parameters)
+			public InterpreterExpression(ParserArguments parserArguments, string expressionText, params ParameterWithPosition[] parameters)
 			{
-				_interpreter = new Interpreter(parserArguments.Settings.Clone());
+				var settings = parserArguments.Settings.Clone();
+				_interpreter = new Interpreter(settings);
 				_expressionText = expressionText;
 				_parameters = parameters;
 
@@ -3263,6 +3281,14 @@ namespace DynamicExpresso.Parsing
 					// Have to mark the parameter as "Used" otherwise we can get a compilation error.
 					parserArguments.TryGetParameters(dp.Name, out var pe);
 					_interpreter.SetIdentifier(new Identifier(dp.Name, pe));
+				}
+
+				foreach (var myParameter in parameters)
+				{
+					if (settings.Identifiers.ContainsKey(myParameter.Name))
+					{
+						throw new ParseException($"A local or parameter named '{myParameter.Name}' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter", myParameter.Position);
+					}
 				}
 
 				// prior to evaluation, we don't know the generic arguments types

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -3255,11 +3255,14 @@ namespace DynamicExpresso.Parsing
 				_expressionText = expressionText;
 				_parameters = parameters;
 
-				// convert the parent's parameters to variables
+				// Take the parent expression's parameters and set them as an identifier that
+				// can be accessed by any lower call
 				// note: this doesn't impact the initial settings, because they're cloned
-				foreach (var pe in parserArguments.DeclaredParameters)
+				foreach (var dp in parserArguments.DeclaredParameters)
 				{
-					_interpreter.SetVariable(pe.Name, pe.Value, pe.Type);
+					// Have to mark the parameter as "Used" otherwise we can get a compilation error.
+					parserArguments.TryGetParameters(dp.Name, out var pe);
+					_interpreter.SetIdentifier(new Identifier(dp.Name, pe));
 				}
 
 				// prior to evaluation, we don't know the generic arguments types

--- a/test/DynamicExpresso.UnitTest/LambdaExpressionTest.cs
+++ b/test/DynamicExpresso.UnitTest/LambdaExpressionTest.cs
@@ -178,7 +178,7 @@ namespace DynamicExpresso.UnitTest
 			result = target.Eval<char>("str.WithSeveralParams((c, i) => c == 'd')");
 			Assert.AreEqual('d', result);
 
-			result = target.Eval<char>("str.WithSeveralParams((c, i, str) => c == 'd')");
+			result = target.Eval<char>("str.WithSeveralParams((c, i, str2) => c == 'd')");
 			Assert.AreEqual('d', result);
 		}
 

--- a/test/DynamicExpresso.UnitTest/LambdaExpressionTest.cs
+++ b/test/DynamicExpresso.UnitTest/LambdaExpressionTest.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 
 namespace DynamicExpresso.UnitTest
 {
@@ -283,6 +284,24 @@ namespace DynamicExpresso.UnitTest
 		}
 
 		[Test]
+		public void Lambda_with_parameter_AsCompiledLambda()
+		{
+			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
+			var parm = new Parameter("x", 1);
+			var list = new Parameter("list", new[] { 1, 2, 3 });
+			var listLamba = target.Parse("list.Where(n => n > x)", list, parm).Compile<Func<int[], int, IEnumerable<int>>>();
+			var result = listLamba(list.Value as int[], 2);
+			Assert.AreEqual(new[] { 3 }, result);
+
+			var listInt = listLamba(list.Value as int[], 1);
+			Assert.AreEqual(new[] { 2, 3 }, listInt);
+
+			// ensure the parameters can be reused with different values
+			listInt = target.Eval<IEnumerable<int>>("list.Where(n => n > x)", new Parameter("list", new[] { 2, 4, 5 }), new Parameter("x", 2));
+			Assert.AreEqual(new[] { 4, 5 }, listInt);
+		}
+
+		[Test]
 		public void Lambda_with_parameter_2()
 		{
 			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
@@ -299,6 +318,230 @@ namespace DynamicExpresso.UnitTest
 
 			var listInt = target.Eval<IEnumerable<int>>("list.Where(n => n > x)");
 			Assert.AreEqual(new[] { 2, 3 }, listInt);
+		}
+
+		public class NestedLambdaTestClass
+		{
+			public NestedLambdaTestClass()
+			{
+			}
+
+			public List<NestedLambdaTestClass> Children
+			{
+				get; set;
+			}
+
+			public string Name
+			{
+				get; set;
+			}
+
+			// TODO
+			// Add support for non generics with our lambda evaluation
+			// The below fails to compile
+			// public string GetChildrenIdentifiers<T>(Func<NestedLambdaTestClass, T> f)
+			public string GetChildrenIdentifiers<T>(Func<NestedLambdaTestClass, T> f)
+			{
+				if (Children == null)
+				{
+					return string.Empty;
+				}
+				return string.Join(",", Children.Select(f));
+			}
+		}
+
+		[Test]
+		public void Lambda_WithMultipleNestedExpressions()
+		{
+			NestedLambdaTestClass root = new NestedLambdaTestClass()
+			{
+				Name = "Root",
+				Children = new List<NestedLambdaTestClass>()
+				{
+					new NestedLambdaTestClass()
+					{
+						Name = "A",
+						Children = new List<NestedLambdaTestClass>()
+						{
+							new NestedLambdaTestClass()
+							{
+								Name = "B",
+								Children = new List<NestedLambdaTestClass>()
+								{
+									new NestedLambdaTestClass()
+									{
+										Name = "C",
+								Children = new List<NestedLambdaTestClass>()
+								{
+									new NestedLambdaTestClass()
+									{
+										Name = "C"
+									},
+									new NestedLambdaTestClass()
+									{
+										Name = "F"
+									}
+								}
+									},
+									new NestedLambdaTestClass()
+									{
+										Name = "F",
+								Children = new List<NestedLambdaTestClass>()
+								{
+									new NestedLambdaTestClass()
+									{
+										Name = "C"
+									},
+									new NestedLambdaTestClass()
+									{
+										Name = "F"
+									}
+								}
+									}
+								}
+							},
+							new NestedLambdaTestClass()
+							{
+								Name = "D",
+								Children = new List<NestedLambdaTestClass>()
+								{
+									new NestedLambdaTestClass()
+									{
+										Name = "E",
+								Children = new List<NestedLambdaTestClass>()
+								{
+									new NestedLambdaTestClass()
+									{
+										Name = "C"
+									},
+									new NestedLambdaTestClass()
+									{
+										Name = "F"
+									}
+								}
+									},
+									new NestedLambdaTestClass()
+									{
+										Name = "G",
+								Children = new List<NestedLambdaTestClass>()
+								{
+									new NestedLambdaTestClass()
+									{
+										Name = "C"
+									},
+									new NestedLambdaTestClass()
+									{
+										Name = "F"
+									}
+								}
+									}
+								}
+							}
+						}
+					},
+					new NestedLambdaTestClass()
+					{
+						Name = "B",
+						Children = new List<NestedLambdaTestClass>()
+						{
+							new NestedLambdaTestClass()
+							{
+								Name = "B",
+								Children = new List<NestedLambdaTestClass>()
+								{
+									new NestedLambdaTestClass()
+									{
+										Name = "C",
+								Children = new List<NestedLambdaTestClass>()
+								{
+									new NestedLambdaTestClass()
+									{
+										Name = "C"
+									},
+									new NestedLambdaTestClass()
+									{
+										Name = "F"
+									}
+								}
+									},
+									new NestedLambdaTestClass()
+									{
+										Name = "F",
+								Children = new List<NestedLambdaTestClass>()
+								{
+									new NestedLambdaTestClass()
+									{
+										Name = "C"
+									},
+									new NestedLambdaTestClass()
+									{
+										Name = "F"
+									}
+								}
+									}
+								}
+							},
+							new NestedLambdaTestClass()
+							{
+								Name = "D",
+								Children = new List<NestedLambdaTestClass>()
+								{
+									new NestedLambdaTestClass()
+									{
+										Name = "E",
+								Children = new List<NestedLambdaTestClass>()
+								{
+									new NestedLambdaTestClass()
+									{
+										Name = "C"
+									},
+									new NestedLambdaTestClass()
+									{
+										Name = "F",
+								Children = new List<NestedLambdaTestClass>()
+								{
+									new NestedLambdaTestClass()
+									{
+										Name = "C"
+									},
+									new NestedLambdaTestClass()
+									{
+										Name = "F"
+									}
+								}
+									}
+								}
+									},
+									new NestedLambdaTestClass()
+									{
+										Name = "G"
+									}
+								}
+							}
+						}
+					}
+				}
+			};
+			var expectedResult = root.GetChildrenIdentifiers(
+				// root
+				l1 => l1.Name + l1.GetChildrenIdentifiers(
+					// level 2, references my parameter, plus original lamda
+					l2 => l2.Name + l1.Name + l2.GetChildrenIdentifiers(
+						// level 3, references my parameter, plus parameter from l1 lamda
+						l3 => l3.Name + l2.Name + l3.GetChildrenIdentifiers(
+							// level 4, references my parameter, plus all parameters that have been used 
+							l4 => l4.Name + l2.Name + l3.Name + l1.Name + root.Name)
+							)));
+
+			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
+
+			var evalResult = target.Eval<string>(@"root.GetChildrenIdentifiers(
+				l1 => l1.Name + l1.GetChildrenIdentifiers(
+					l2 => l2.Name + l1.Name + l2.GetChildrenIdentifiers(
+						l3 => l3.Name + l2.Name + l3.GetChildrenIdentifiers(
+							l4 => l4.Name + l2.Name + l3.Name + l1.Name + root.Name)
+							)))", new Parameter(nameof(root), root));
+			Assert.AreEqual(expectedResult, evalResult);
 		}
 	}
 


### PR DESCRIPTION
Issue #212 was really the issue here.  

When replicating the code given in Issue #256 the last "x.Grade" was being immediately resolved as the value from the parameter was being inserted directly.  In the previous implementation of "InterpreterExpression", it was creating it as a new ParameterExpression.  
This code update captures the "parent" ParameterExpressions as identifiers.

This is essentially what happens with compiled code, so instead of us having to create a class, Expression actually allows us to reference the existing Expression as an Identifier.

Fix #212, #200, #256