### PR TITLE
Adding fuller support for resolving anonymous type data on a dynamic object

### DIFF
--- a/src/DynamicExpresso.Core/Interpreter.cs
+++ b/src/DynamicExpresso.Core/Interpreter.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using DynamicExpresso.Exceptions;
+using System.Dynamic;
 
 namespace DynamicExpresso
 {

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -3342,24 +3342,22 @@ namespace DynamicExpresso.Parsing
 		/// </summary>
 		private class LateGetMemberCallSiteBinder : CallSiteBinder
 		{
-			private readonly string m_propertyOrFieldName;
+			private readonly string _propertyOrFieldName;
 
 			public LateGetMemberCallSiteBinder(string propertyOrFieldName)
 			{
-				m_propertyOrFieldName = propertyOrFieldName;
+				_propertyOrFieldName = propertyOrFieldName;
 			}
 
 			public override Expression Bind(object[] args, ReadOnlyCollection<ParameterExpression> parameters, LabelTarget returnLabel)
 			{
-				var binder =
-					Microsoft.CSharp.RuntimeBinder.Binder.GetMember(
+				var binder = Microsoft.CSharp.RuntimeBinder.Binder.GetMember(
 					Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags.None,
-					m_propertyOrFieldName,
+					_propertyOrFieldName,
 					RemoveArrayType(args[0]?.GetType()),
 					new[] { Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags.None, null) }
 				);
-				var e = binder.Bind(args, parameters, returnLabel);
-				return e;
+				return binder.Bind(args, parameters, returnLabel);
 			}
 		}
 

--- a/test/DynamicExpresso.UnitTest/DynamicTest.cs
+++ b/test/DynamicExpresso.UnitTest/DynamicTest.cs
@@ -20,11 +20,7 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter()
 				.SetVariable("dyn", (object)dyn);
 
-			var l = interpreter.Parse("dyn.Foo");
-			l.Invoke();
-			l.Invoke();
-
-			//Assert.AreEqual(dyn.Foo, interpreter.Eval("dyn.Foo"));
+			Assert.AreEqual(dyn.Foo, interpreter.Eval("dyn.Foo"));
 		}
 
 		[Test]
@@ -161,12 +157,30 @@ namespace DynamicExpresso.UnitTest
 			var anonType2 = new { Foo = "string.Empty" };
 			var nullAnonType = anonType1;
 			nullAnonType = null;
-			dyn.Sub = new { Arg1 = anonType1, Arg2 = anonType2, Arg3 = nullAnonType };
+			dyn.Sub = new
+			{
+				Arg1 = anonType1,
+				Arg2 = anonType2,
+				Arg3 = nullAnonType,
+				Arr = new[] { anonType1, anonType2, nullAnonType },
+				ObjArr = new object[] { "Test", anonType1 }
+			};
 			var interpreter = new Interpreter().SetVariable("dyn", (object)dyn);
 			Assert.AreSame(dyn.Sub.Arg1.Foo, interpreter.Eval("dyn.Sub.Arg1.Foo"));
 			Assert.AreSame(dyn.Sub.Arg2.Foo, interpreter.Eval("dyn.Sub.Arg2.Foo"));
 			Assert.Throws<RuntimeBinderException>(() => Console.WriteLine(dyn.Sub.Arg3.Foo));
 			Assert.Throws<RuntimeBinderException>(() => interpreter.Eval("dyn.Sub.Arg3.Foo"));
+			Assert.AreSame(dyn.Sub.Arr[0].Foo, interpreter.Eval("dyn.Sub.Arr[0].Foo"));
+			Assert.AreSame(dyn.Sub.Arr[1].Foo, interpreter.Eval("dyn.Sub.Arr[1].Foo"));
+
+			Assert.Throws<RuntimeBinderException>(() => Console.WriteLine(dyn.Sub.Arr[2].Foo));
+			Assert.Throws<RuntimeBinderException>(() => interpreter.Eval("dyn.Sub.Arr[2].Foo"));
+
+			Assert.AreSame(dyn.Sub.ObjArr[0], interpreter.Eval("dyn.Sub.ObjArr[0]"));
+			Assert.AreEqual(dyn.Sub.ObjArr[0].Length, interpreter.Eval("dyn.Sub.ObjArr[0].Length"));
+
+			Assert.AreSame(dyn.Sub.ObjArr[1], interpreter.Eval("dyn.Sub.ObjArr[1]"));
+			Assert.AreSame(dyn.Sub.ObjArr[1].Foo, interpreter.Eval("dyn.Sub.ObjArr[1].Foo"));
 		}
 
 		[Test]

--- a/test/DynamicExpresso.UnitTest/DynamicTest.cs
+++ b/test/DynamicExpresso.UnitTest/DynamicTest.cs
@@ -152,6 +152,23 @@ namespace DynamicExpresso.UnitTest
 			Assert.AreEqual(dyn.Sub.Bar.Sub[0], interpreter.Eval("dyn.Sub.Bar.Sub[0]"));
 			Assert.AreEqual(dyn.Sub.Bar.Sub.Length, interpreter.Eval("dyn.Sub.Bar.Sub.Length"));
 		}
+
+		[Test]
+		public void Get_value_of_an_array_of_anonymous_type()
+		{
+			dynamic dyn = new ExpandoObject();
+			var anonType1 = new { Foo = string.Empty };
+			var anonType2 = new { Foo = "string.Empty" };
+			var nullAnonType = anonType1;
+			nullAnonType = null;
+			dyn.Sub = new { Arg1 = anonType1, Arg2 = anonType2, Arg3 = nullAnonType };
+			var interpreter = new Interpreter().SetVariable("dyn", (object)dyn);
+			Assert.AreSame(dyn.Sub.Arg1.Foo, interpreter.Eval("dyn.Sub.Arg1.Foo"));
+			Assert.AreSame(dyn.Sub.Arg2.Foo, interpreter.Eval("dyn.Sub.Arg2.Foo"));
+			Assert.Throws<RuntimeBinderException>(() => Console.WriteLine(dyn.Sub.Arg3.Foo));
+			Assert.Throws<RuntimeBinderException>(() => interpreter.Eval("dyn.Sub.Arg3.Foo"));
+		}
+
 		[Test]
 		public void Get_value_of_a_nested_array_error()
 		{

--- a/test/DynamicExpresso.UnitTest/DynamicTest.cs
+++ b/test/DynamicExpresso.UnitTest/DynamicTest.cs
@@ -20,7 +20,20 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter()
 				.SetVariable("dyn", (object)dyn);
 
-			Assert.AreEqual(dyn.Foo, interpreter.Eval("dyn.Foo"));
+			var l = interpreter.Parse("dyn.Foo");
+			l.Invoke();
+			l.Invoke();
+
+			//Assert.AreEqual(dyn.Foo, interpreter.Eval("dyn.Foo"));
+		}
+
+		[Test]
+		public void Get_Property_of_a_nested_anonymous()
+		{
+			dynamic dyn = new ExpandoObject();
+			dyn.Sub = new { Foo = new { Bar = new { Foo2 = "bar" } } };
+			var interpreter = new Interpreter().SetVariable("dyn", (object)dyn);
+			Assert.AreEqual(dyn.Sub.Foo.Bar.Foo2, interpreter.Eval("dyn.Sub.Foo.Bar.Foo2"));
 		}
 
 		[Test]
@@ -87,6 +100,19 @@ namespace DynamicExpresso.UnitTest
 		}
 
 		[Test]
+		public void Invoke_Method_of_a_nested_ExpandoObject_WithAnonymousType()
+		{
+			dynamic dyn = new ExpandoObject();
+			dyn.Sub = new ExpandoObject();
+			dyn.Sub.Foo = new { Func = new Func<string>(() => "bar") };
+
+			var interpreter = new Interpreter()
+					.SetVariable("dyn", dyn);
+
+			Assert.AreEqual(dyn.Sub.Foo.Func(), interpreter.Eval("dyn.Sub.Foo.Func()"));
+		}
+
+		[Test]
 		public void Standard_methods_have_precedence_over_dynamic_methods()
 		{
 			var dyn = new TestDynamicClass();
@@ -116,6 +142,16 @@ namespace DynamicExpresso.UnitTest
 			Assert.AreEqual(dyn.Sub[0], interpreter.Eval("dyn.Sub[0]"));
 		}
 
+		[Test]
+		public void Get_value_of_a_nested_array_from_anonymous_type()
+		{
+			dynamic dyn = new ExpandoObject();
+			dyn.Sub = new { Foo = new int[] { 42 }, Bar = new { Sub = new int[] { 43 } } };
+			var interpreter = new Interpreter().SetVariable("dyn", (object)dyn);
+			Assert.AreEqual(dyn.Sub.Foo[0], interpreter.Eval("dyn.Sub.Foo[0]"));
+			Assert.AreEqual(dyn.Sub.Bar.Sub[0], interpreter.Eval("dyn.Sub.Bar.Sub[0]"));
+			Assert.AreEqual(dyn.Sub.Bar.Sub.Length, interpreter.Eval("dyn.Sub.Bar.Sub.Length"));
+		}
 		[Test]
 		public void Get_value_of_a_nested_array_error()
 		{


### PR DESCRIPTION
Issue #93 

The major change made with this is that rather than performing the binding, somewhat greedily, on typeof(object), we leverage the actual instance present in the CallSiteBinder args parameter to get the actual type as late as possible.