### PR TITLE
Promotion InterpreterExpressions to lambda expressions

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -214,6 +214,9 @@ namespace DynamicExpresso.Parsing
 				NextToken();
 			}
 
+			if (!hasOpenParen && parameters.Length > 1)
+				throw new ParseException("Multiple lambda parameters detected, but with no surrounding parenthesis", _parsePosition);
+
 			return parameters;
 		}
 
@@ -2309,11 +2312,11 @@ namespace DynamicExpresso.Parsing
 					if (method.PromotedParameters[i] is InterpreterExpression ie)
 					{
 						var actualParamInfo = actualMethodParameters[i];
-						var delegateType = actualParamInfo.ParameterType;
-						if (delegateType.GetGenericArguments().Length != ie.Parameters.Count + 1)
+						var lambdaExpr = GenerateLambdaFromInterpreterExpression(ie, actualParamInfo.ParameterType);
+						if (lambdaExpr == null)
 							return false;
 
-						method.PromotedParameters[i] = ie.EvalAs(delegateType);
+						method.PromotedParameters[i] = lambdaExpr;
 
 						// we have inferred all types, update the method definition
 						genericMethod = MakeGenericMethod(method);
@@ -2324,6 +2327,14 @@ namespace DynamicExpresso.Parsing
 			}
 
 			return true;
+		}
+
+		private static LambdaExpression GenerateLambdaFromInterpreterExpression(InterpreterExpression ie, Type delegateType)
+		{
+			if (delegateType.GetGenericArguments().Length != ie.Parameters.Count + 1)
+				return null;
+
+			return ie.EvalAs(delegateType);
 		}
 
 		private static MethodInfo MakeGenericMethod(MethodData method)
@@ -2404,6 +2415,9 @@ namespace DynamicExpresso.Parsing
 			{
 				if (!ie.IsCompatibleWithDelegate(type))
 					return null;
+
+				if (!type.ContainsGenericParameters)
+					return GenerateLambdaFromInterpreterExpression(ie, type);
 
 				return expr;
 			}

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -662,6 +662,28 @@ namespace DynamicExpresso.UnitTest
 			public string PageName { get; set; }
 			public int VisualCount { get; set; }
 		}
+
+		[Test]
+		public void Lambda_Issue_262()
+		{
+			var list = new List<int> { 10, 30, 4 };
+
+			var options = InterpreterOptions.Default | InterpreterOptions.LambdaExpressions;
+			var interpreter = new Interpreter(options);
+			interpreter.SetVariable("b", new Functions());
+			interpreter.SetVariable("list", list);
+
+			var results = interpreter.Eval<List<int>>(@"b.Add(list, (int t) => t + 10)");
+			Assert.AreEqual(new List<int> { 20, 40, 14 }, results);
+		}
+
+		public class Functions
+		{
+			public List<int> Add(List<int> list, Func<int, int> transform)
+			{
+				return list.Select(i => transform(i)).ToList();
+			}
+		}
 	}
 
 	internal static class GithubIssuesTestExtensionsMethods

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -664,7 +664,7 @@ namespace DynamicExpresso.UnitTest
 		}
 
 		[Test]
-		public void Lambda_Issue_262()
+		public void GitHub_Issue_262()
 		{
 			var list = new List<int> { 10, 30, 4 };
 
@@ -674,6 +674,10 @@ namespace DynamicExpresso.UnitTest
 			interpreter.SetVariable("list", list);
 
 			var results = interpreter.Eval<List<int>>(@"b.Add(list, (int t) => t + 10)");
+			Assert.AreEqual(new List<int> { 20, 40, 14 }, results);
+
+			// ensure that list, t are not parsed as two arguments of a lambda expression
+			results = interpreter.Eval<List<int>>(@"b.Add(list, t => t + 10)");
 			Assert.AreEqual(new List<int> { 20, 40, 14 }, results);
 		}
 


### PR DESCRIPTION
When a method parameter is a fully closed generic type (ie doesn't depend on a method generic's parameters), we never converted the parsed lambda expression to an actual expression. 

Example:

```c#
[Test]
public void Lambda_Issue_262()
{
	var list = new List<int> { 10, 30, 4 };

	var options = InterpreterOptions.Default | InterpreterOptions.LambdaExpressions;
	var interpreter = new Interpreter(options);
	interpreter.SetVariable("b", new Functions());
	interpreter.SetVariable("list", list);

	var results = interpreter.Eval<List<int>>(@"b.Add(list, t => t + 10)");
	Assert.AreEqual(new List<int> { 20, 40, 14 }, results);
}

public class Functions
{
	public List<int> Add(List<int> list, Func<int, int> transform)
	{
		return list.Select(i => transform(i)).ToList();
	}
}
```

In that case, `Func<int, int>` is a fully closed generic type, and thus `t => t + 10` was never converted to the proper Linq expression.

Note: I also fixed a bug where in `b.Add(list, t => t + 10)`, `list, t` was improperly seen as the two arguments to the lambda expression.

Fixes #262