### PR TITLE
Params array: only promote first argument if it can be an array

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -2212,7 +2212,7 @@ namespace DynamicExpresso.Parsing
 					declaredWorkingParameters++;
 				}
 
-				if (paramsArrayPromotedArgument == null)
+				if (paramsArrayPromotedArgument == null && (paramsArrayTypeFound == null || args.Length == method.Parameters.Length))
 				{
 					if (parameterType.IsGenericParameter)
 					{

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -533,6 +533,7 @@ namespace DynamicExpresso.UnitTest
 		{
 			public static List<T> Array<T>(IEnumerable<T> collection) => new List<T>(collection);
 			public static List<dynamic> Array(params dynamic[] array) => Array((IEnumerable<dynamic>)array);
+			public static int ParamArrayObjects(params object[] values) => values.Length;
 			public static IEnumerable<dynamic> Select<TSource>(IEnumerable<TSource> collection, string expression) => new List<dynamic>();
 			public static IEnumerable<dynamic> Select(IEnumerable collection, string expression) => new List<dynamic>();
 			public static int Any<T>(IEnumerable<T> collection) => 1;
@@ -661,6 +662,21 @@ namespace DynamicExpresso.UnitTest
 		{
 			public string PageName { get; set; }
 			public int VisualCount { get; set; }
+		}
+
+		[Test]
+		[TestCase("0, null, 0, 0")]
+		[TestCase("null, null, 0, 0")]
+		[TestCase("new object[] { null, null, null, null }")]
+		public void GitHub_Issue_263(string paramsArguments)
+		{
+			var interpreter = new Interpreter();
+			interpreter.Reference(typeof(Utils));
+
+			Assert.Throws<NullReferenceException>(() => interpreter.Eval<int>("Utils.ParamArrayObjects(null)"));
+
+			var result = interpreter.Eval<int>($"Utils.ParamArrayObjects({paramsArguments})");
+			Assert.AreEqual(4, result);
 		}
 	}
 


### PR DESCRIPTION
When trying to parse a params array, promoting the first argument only makes sense if it might be the full array.

Fixes #263