### PR TITLE
Throw exception when trying to register a closed generic type.

### DIFF
--- a/src/DynamicExpresso.Core/ReferenceType.cs
+++ b/src/DynamicExpresso.Core/ReferenceType.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -24,6 +24,14 @@ namespace DynamicExpresso
 
 			if (type == null)
 				throw new ArgumentNullException(nameof(type));
+
+			if (type.IsGenericType && !type.IsGenericTypeDefinition)
+			{
+				var genericType = type.GetGenericTypeDefinition();
+				var genericTypeName = genericType.Name.Substring(0, genericType.Name.IndexOf('`'));
+				genericTypeName += $"<{new string(',', genericType.GetGenericArguments().Length - 1)}>";
+				throw new ArgumentException($"Generic type must be referenced via its generic definition: {genericTypeName}");
+			}
 
 			Type = type;
 			Name = name;

--- a/test/DynamicExpresso.UnitTest/ReferencedTypesPropertyTest.cs
+++ b/test/DynamicExpresso.UnitTest/ReferencedTypesPropertyTest.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 
 namespace DynamicExpresso.UnitTest
@@ -36,6 +38,21 @@ namespace DynamicExpresso.UnitTest
 
 		public class FakeClass
 		{
+		}
+
+		[Test]
+		public void Registering_generic_types()
+		{
+			var target = new Interpreter(InterpreterOptions.None);
+
+			var exception = Assert.Throws<ArgumentException>(() => target.Reference(typeof(List<string>)));
+			Assert.That(exception.Message, Contains.Substring("List<>"));
+
+			exception = Assert.Throws<ArgumentException>(() => target.Reference(typeof(Tuple<string, string, int>)));
+			Assert.That(exception.Message, Contains.Substring("Tuple<,,>"));
+
+			Assert.DoesNotThrow(() => target.Reference(typeof(List<>)));
+			Assert.DoesNotThrow(() => target.Reference(typeof(Tuple<,,>)));
 		}
 	}
 }


### PR DESCRIPTION
This new exception will prevent users from trying to reference a closed generic type, and provide the proper type to register.

```C#
target.Reference(typeof(List<string>)); // throws 
target.Reference(typeof(List<>)); // doesn't throw
```

Fixes #264