### PR TITLE
.NET 7 build updates #270

### DIFF
--- a/test/DynamicExpresso.UnitTest/EnumerableTest.cs
+++ b/test/DynamicExpresso.UnitTest/EnumerableTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using NUnit.Framework;
 using System.Collections.Generic;
 
@@ -18,6 +18,7 @@ namespace DynamicExpresso.UnitTest
 
 			Assert.AreEqual(x.Count(), target.Eval("x.Count()"));
 			Assert.AreEqual(x.Average(), target.Eval("x.Average()"));
+			Assert.AreEqual(x.Sum(), target.Eval("x.Sum()"));
 			Assert.AreEqual(x.First(), target.Eval("x.First()"));
 			Assert.AreEqual(x.Last(), target.Eval("x.Last()"));
 			Assert.AreEqual(x.Max(), target.Eval("x.Max()"));


### PR DESCRIPTION
Sum and Average have new type parameter options that cause issues at runtime. Simple bypass operation that should only affect .NET 7 compilation. Affects #270 