### PR TITLE
Fix Issue #305

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -2711,7 +2711,10 @@ namespace DynamicExpresso.Parsing
 			if (better)
 				return true;
 
-			if (!method.MethodBase.IsGenericMethod && otherMethod.MethodBase.IsGenericMethod)
+			if (method.MethodBase != null &&
+				otherMethod.MethodBase != null &&
+				!method.MethodBase.IsGenericMethod &&
+				otherMethod.MethodBase.IsGenericMethod)
 				return true;
 
 			if (!method.HasParamsArray && otherMethod.HasParamsArray)
@@ -2720,6 +2723,19 @@ namespace DynamicExpresso.Parsing
 			// if a method has a params parameter, it can have less parameters than the number of arguments
 			if (method.HasParamsArray && otherMethod.HasParamsArray && method.Parameters.Length > otherMethod.Parameters.Length)
 				return true;
+
+			if (method is IndexerData indexer && otherMethod is IndexerData otherIndexer)
+			{
+				var declaringType = indexer.Indexer.DeclaringType;
+				var otherDeclaringType = otherIndexer.Indexer.DeclaringType;
+
+				var isOtherIndexerIsInParentType = otherDeclaringType.IsAssignableFrom(declaringType);
+				if (isOtherIndexerIsInParentType)
+				{
+					var isIndexerIsInDescendantType = !declaringType.IsAssignableFrom(otherDeclaringType);
+					return isIndexerIsInDescendantType;
+				}
+			}
 
 			return better;
 		}

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -793,6 +793,32 @@ namespace DynamicExpresso.UnitTest
 			var doesntWork = (string) evaluator.Eval("StringConcat(GlobalSettings.MyTestPath,\"test.txt\")");
 			Assert.That(doesntWork, Is.EqualTo("C:\\delme\\test.txt"));
 		}
+
+		#region GitHub_Issue_305
+
+		public class _305_A
+		{
+			public string this[int index] => "some string";
+		}
+
+		public class _305_B : _305_A
+		{
+			public new int this[int index] => 25;
+		}
+
+		[Test]
+		public void GitHub_Issue_305()
+		{
+			var b = new _305_B();
+
+			var interpreter = new Interpreter();
+			var lambda = interpreter.Parse("this[0]", new Parameter("this", b));
+			var res = lambda.Invoke(b);
+
+			Assert.AreEqual(25, res);
+		}
+
+		#endregion
 	}
 
 	internal static class GithubIssuesTestExtensionsMethods


### PR DESCRIPTION
As described in #305 , the bug is related to overridden indexer in inherited class. So, to fix it, I added an additional comparison to select indexer with higher priority - indexer that is declared in the descendant class.

Fix #305 