### PR TITLE
feat: .net 8 and github issue 311

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: '0' # all
-    - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '3.1.x'
-    - name: Setup .NET 7.0
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '7.0.x'
     - name: Setup .NET 8.0
       uses: actions/setup-dotnet@v4
       with:
@@ -36,10 +28,6 @@ jobs:
       run: dotnet restore DynamicExpresso.sln
     - name: Build
       run: dotnet build DynamicExpresso.sln --no-restore -c Release /p:Version=${{steps.calc_version.outputs.PROJECT_VERSION}}
-    - name: Test .net core 3.1
-      run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release --verbosity normal -f netcoreapp3.1
-    - name: Test .net core 7.0
-      run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release --verbosity normal -f net7.0
     - name: Test .net core 8.0
       run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release --verbosity normal -f net8.0
   test-win:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,19 +8,23 @@ on:
 
 jobs:
   test-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: '0' # all
     - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '3.1.x'
     - name: Setup .NET 7.0
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '7.0.x'
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
     - name: Setup gitversion
       run: dotnet tool install --global GitVersion.Tool
     - name: Calculate version
@@ -36,14 +40,20 @@ jobs:
       run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release --verbosity normal -f netcoreapp3.1
     - name: Test .net core 7.0
       run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release --verbosity normal -f net7.0
+    - name: Test .net core 8.0
+      run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release --verbosity normal -f net8.0
   test-win:
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET 7.0
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '7.0.x'
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
     - name: Restore packages
       run: dotnet restore DynamicExpresso.sln
     - name: Build
@@ -52,3 +62,5 @@ jobs:
       run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release --verbosity normal -f net461
     - name: Test .net 4.5
       run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release --verbosity normal -f net45
+    - name: Test .net core 8.0
+      run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release --verbosity normal -f net8.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,8 +35,6 @@ jobs:
       run: dotnet restore DynamicExpresso.sln
     - name: Build
       run: dotnet build DynamicExpresso.sln --no-restore -c Release /p:Version=${{steps.calc_version.outputs.PROJECT_VERSION}}
-    - name: Test .net core 3.1
-      run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release /p:Version=${{steps.calc_version.outputs.PROJECT_VERSION}} --verbosity normal -f netcoreapp3.1
     - name: Test .net core 8.0
       run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release /p:Version=${{steps.calc_version.outputs.PROJECT_VERSION}} --verbosity normal -f net8.0
     - name: Setup nuget sources

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,16 +14,16 @@ on:
         default: 'true'
 jobs:
   publish-nuget:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: "${{ github.event.inputs.ref }}"
         fetch-depth: '0' # all
-    - name: Setup .NET Core 7.0
-      uses: actions/setup-dotnet@v3
+    - name: Setup .NET Core 8.0
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '7.0.x'
+        dotnet-version: '8.0.x'
     - name: Setup gitversion
       run: dotnet tool install --global GitVersion.Tool
     - name: Calculate version
@@ -37,8 +37,8 @@ jobs:
       run: dotnet build DynamicExpresso.sln --no-restore -c Release /p:Version=${{steps.calc_version.outputs.PROJECT_VERSION}}
     - name: Test .net core 3.1
       run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release /p:Version=${{steps.calc_version.outputs.PROJECT_VERSION}} --verbosity normal -f netcoreapp3.1
-    - name: Test .net core 7.0
-      run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release /p:Version=${{steps.calc_version.outputs.PROJECT_VERSION}} --verbosity normal -f net7.0
+    - name: Test .net core 8.0
+      run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release /p:Version=${{steps.calc_version.outputs.PROJECT_VERSION}} --verbosity normal -f net8.0
     - name: Setup nuget sources
       run: dotnet nuget add source --name github "https://nuget.pkg.github.com/dynamicexpresso/index.json"
     - name: Pack

--- a/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
+++ b/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
@@ -4,6 +4,8 @@
 		<TargetFrameworks>net8.0;net7.0;net5.0;netcoreapp3.1;net462</TargetFrameworks>
 
 		<IsPackable>false</IsPackable>
+
+    <InvariantGlobalization>true</InvariantGlobalization>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
+++ b/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
@@ -1,11 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net5.0;netcoreapp3.1;net462</TargetFrameworks>
+		<TargetFrameworks>net8.0;net7.0;net5.0;net462</TargetFrameworks>
 
 		<IsPackable>false</IsPackable>
-
-    <InvariantGlobalization>true</InvariantGlobalization>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
+++ b/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0;net5.0;netcoreapp3.1;net462</TargetFrameworks>
+		<TargetFrameworks>net8.0;net7.0;net5.0;netcoreapp3.1;net462</TargetFrameworks>
 
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -254,7 +254,7 @@ namespace DynamicExpresso.UnitTest
 			Assert.Throws<ParseException>(() => interpreter.Eval("GFunction(arg)"));
 
 			// GFunction1 is used
-			// because gFunc1.Method.GetParameters()[0].HasDefaultValue == true 
+			// because gFunc1.Method.GetParameters()[0].HasDefaultValue == true
 			// and     gFunc2.Method.GetParameters()[0].HasDefaultValue == false
 			Assert.False((bool)interpreter.Eval("GFunction()"));
 		}
@@ -819,6 +819,23 @@ namespace DynamicExpresso.UnitTest
 		}
 
 		#endregion
+
+		[Test]
+		public void GitHub_Issue_311()
+		{
+			var a = "AABB";
+
+			var interpreter1 = new Interpreter();
+			interpreter1.SetVariable("a", a);
+			Assert.AreEqual("AA", interpreter1.Eval("a.Substring(0, 2)"));
+
+			var interpreter2 = new Interpreter().SetDefaultNumberType(DefaultNumberType.Decimal);
+			interpreter2.SetVariable("a", a);
+			// expected to throw because Substring is not defined for decimal
+			Assert.Throws<NoApplicableMethodException>(() => interpreter2.Eval("a.Substring(0, 2)"));
+			// It works if we cast to int
+			Assert.AreEqual("AA", interpreter2.Eval("a.Substring((int)0, (int)2)"));
+		}
 	}
 
 	internal static class GithubIssuesTestExtensionsMethods

--- a/test/DynamicExpresso.UnitTest/MemberInvocationTest.cs
+++ b/test/DynamicExpresso.UnitTest/MemberInvocationTest.cs
@@ -108,7 +108,7 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("x", x);
 			var y = new MyTestService();
 			target.SetVariable("y", y);
-			
+
 			Assert.AreEqual(x[1, 2], target.Eval("x[1, 2]"));
 			Assert.AreEqual(y[y.Today, 2], target.Eval("y[y.Today, 2]"));
 			Assert.AreEqual(y[y.Today], target.Eval("y[y.Today]"));


### PR DESCRIPTION
Configured .NET runtime 8.0, removed support for .NET 3.1.

Close #311:  Add a test to demostrate that it is not a bug. `Substring` method in .NET (https://learn.microsoft.com/en-us/dotnet/api/system.string.substring?view=net-8.0#system-string-substring(system-int32-system-int32)) it is not defined for Decimal type, so if we force all types to be decimal it will not work unless you perform a cast to int.

```
var interpreter2 = new Interpreter().SetDefaultNumberType(DefaultNumberType.Decimal);
interpreter2.SetVariable("a", a);
// expected to throw because Substring is not defined for decimal
Assert.Throws<NoApplicableMethodException>(() => interpreter2.Eval("a.Substring(0, 2)"));
// It works if we cast to int
Assert.AreEqual("AA", interpreter2.Eval("a.Substring((int)0, (int)2)"));
```
