### PR TITLE
No longer try to parse a generic type if there's no possible candidates

### DIFF
--- a/src/DynamicExpresso.Core/ParserArguments.cs
+++ b/src/DynamicExpresso.Core/ParserArguments.cs
@@ -77,7 +77,7 @@ namespace DynamicExpresso
 		}
 
 		/// <summary>
-		/// Returns true if the known types contain a generic definition type with the given name + any arity (e.g. name`1).
+		/// Returns true if the known types contain a generic type definition with the given name + any arity (e.g. name`1).
 		/// </summary>
 		internal bool HasKnownGenericTypeDefinition(string name)
 		{

--- a/src/DynamicExpresso.Core/ParserArguments.cs
+++ b/src/DynamicExpresso.Core/ParserArguments.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using DynamicExpresso.Exceptions;
+using System.Text.RegularExpressions;
 
 namespace DynamicExpresso
 {
@@ -73,6 +74,15 @@ namespace DynamicExpresso
 
 			type = null;
 			return false;
+		}
+
+		/// <summary>
+		/// Returns true if the known types contain a generic definition type with the given name + any arity (e.g. name`1).
+		/// </summary>
+		internal bool HasKnownGenericTypeDefinition(string name)
+		{
+			var regex = new Regex("^" + name + "`\\d+$");
+			return Settings.KnownTypes.Values.Any(refType => regex.IsMatch(refType.Name) && refType.Type.IsGenericTypeDefinition);
 		}
 
 		public bool TryGetIdentifier(string name, out Expression expression)

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1440,9 +1440,14 @@ namespace DynamicExpresso.Parsing
 		{
 			// if the type is unknown, we need to restart parsing 
 			var originalPos = _token.pos;
-			_arguments.TryGetKnownType(name, out type);
 
-			type = ParseKnownGenericType(name, type);
+			// the name might reference a generic type, with an aliased name (e.g. List<T> = MyList instead of List`1)
+			// it can also reference a generic type for which we don't know the arity yet (and therefore the name doesn't contain the `n suffix)
+			if (_arguments.TryGetKnownType(name, out type) || _arguments.HasKnownGenericTypeDefinition(name))
+			{
+				type = ParseKnownGenericType(name, type);
+			}
+
 			type = ParseTypeModifiers(type);
 
 			if (type == null)

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -819,6 +819,19 @@ namespace DynamicExpresso.UnitTest
 		}
 
 		#endregion
+
+		[Test]
+		public void GitHub_Issue_314()
+		{
+			var interpreter = new Interpreter();
+			var parameters = new[] { new Parameter("a", 1) };
+
+			var exception1 = Assert.Throws<UnknownIdentifierException>(() => interpreter.Eval("a < 1 || b < 1 ", parameters));
+			Assert.AreEqual("b", exception1.Identifier);
+
+			var exception2 = Assert.Throws<UnknownIdentifierException>(() =>  interpreter.Eval("a < 1 || b > 1 ", parameters));
+			Assert.AreEqual("b", exception2.Identifier);
+		}
 	}
 
 	internal static class GithubIssuesTestExtensionsMethods

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -824,12 +824,11 @@ namespace DynamicExpresso.UnitTest
 		public void GitHub_Issue_314()
 		{
 			var interpreter = new Interpreter();
-			var parameters = new[] { new Parameter("a", 1) };
 
-			var exception1 = Assert.Throws<UnknownIdentifierException>(() => interpreter.Eval("a < 1 || b < 1 ", parameters));
+			var exception1 = Assert.Throws<UnknownIdentifierException>(() => interpreter.Eval("b < 1"));
 			Assert.AreEqual("b", exception1.Identifier);
 
-			var exception2 = Assert.Throws<UnknownIdentifierException>(() =>  interpreter.Eval("a < 1 || b > 1 ", parameters));
+			var exception2 = Assert.Throws<UnknownIdentifierException>(() => interpreter.Eval("b > 1"));
 			Assert.AreEqual("b", exception2.Identifier);
 		}
 	}


### PR DESCRIPTION
With the current algorithm that parses known types, we first try to parse the type argument list before checking if there's a matching generic type definition in the known types. This leads to an improper error message when trying to perform a less than comparison on a unknown identifier, because we try to parse the comparison as the type argument list 😅 

```c#
var i = new Interpreter();
var x= i.Eval("b < 1"); // ParseException: '>' expected (at index 4). [misleading]
```

Fix #314