### PR TITLE
Remove unneeded NETSTANDARD1_6 compiler directives and unneeded usings

### DIFF
--- a/src/DynamicExpresso.Core/DefaultNumberType.cs
+++ b/src/DynamicExpresso.Core/DefaultNumberType.cs
@@ -1,19 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace DynamicExpresso
 {
-    /// <summary>
-    /// Setting the default number types when no suffix is specified
-    /// </summary>
-    public enum DefaultNumberType
-    {
-        Default = 0, //(Int by default or Double if real number)
-        Int = 1,
-        Long = 2,
-        Single = 3,
-        Double = 4,
-        Decimal = 5
-    }
+	/// <summary>
+	/// Setting the default number types when no suffix is specified
+	/// </summary>
+	public enum DefaultNumberType
+	{
+		Default = 0, //(Int by default or Double if real number)
+		Int = 1,
+		Long = 2,
+		Single = 3,
+		Double = 4,
+		Decimal = 5
+	}
 }

--- a/src/DynamicExpresso.Core/Exceptions/AssignmentOperatorDisabledException.cs
+++ b/src/DynamicExpresso.Core/Exceptions/AssignmentOperatorDisabledException.cs
@@ -1,40 +1,33 @@
-﻿#if !NETSTANDARD1_6
 using System;
 using System.Runtime.Serialization;
 using System.Security.Permissions;
-#endif
 
 namespace DynamicExpresso.Exceptions
 {
-	#if !NETSTANDARD1_6
 	[Serializable]
-	#endif
 	public class AssignmentOperatorDisabledException : ParseException
 	{
 		public AssignmentOperatorDisabledException(string operatorString, int position)
-			: base(string.Format("Assignment operator '{0}' not allowed", operatorString), position) 
+			: base(string.Format("Assignment operator '{0}' not allowed", operatorString), position)
 		{
 			OperatorString = operatorString;
 		}
 
 		public string OperatorString { get; private set; }
 
-		#if !NETSTANDARD1_6
 		protected AssignmentOperatorDisabledException(
 			SerializationInfo info,
 			StreamingContext context)
-			: base(info, context) 
+			: base(info, context)
 		{
 			OperatorString = info.GetString("OperatorString");
 		}
 
-		[SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("OperatorString", OperatorString);
 
 			base.GetObjectData(info, context);
 		}
-		#endif
 	}
 }

--- a/src/DynamicExpresso.Core/Exceptions/AssignmentOperatorDisabledException.cs
+++ b/src/DynamicExpresso.Core/Exceptions/AssignmentOperatorDisabledException.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.Serialization;
-using System.Security.Permissions;
 
 namespace DynamicExpresso.Exceptions
 {

--- a/src/DynamicExpresso.Core/Exceptions/DuplicateParameterException.cs
+++ b/src/DynamicExpresso.Core/Exceptions/DuplicateParameterException.cs
@@ -1,39 +1,32 @@
-﻿#if !NETSTANDARD1_6
 using System;
 using System.Runtime.Serialization;
 using System.Security.Permissions;
-#endif
 
 namespace DynamicExpresso.Exceptions
 {
-#if !NETSTANDARD1_6
 	[Serializable]
-#endif
 	public class DuplicateParameterException : DynamicExpressoException
 	{
 		public DuplicateParameterException(string identifier)
-			: base(string.Format("The parameter '{0}' was defined more than once", identifier)) 
+			: base(string.Format("The parameter '{0}' was defined more than once", identifier))
 		{
 			Identifier = identifier;
 		}
 		public string Identifier { get; private set; }
 
-#if !NETSTANDARD1_6
 		protected DuplicateParameterException(
 			SerializationInfo info,
 			StreamingContext context)
-			: base(info, context) 
+			: base(info, context)
 		{
 			Identifier = info.GetString("Identifier");
 		}
 
-		[SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("Identifier", Identifier);
 
 			base.GetObjectData(info, context);
 		}
-#endif
 	}
 }

--- a/src/DynamicExpresso.Core/Exceptions/DuplicateParameterException.cs
+++ b/src/DynamicExpresso.Core/Exceptions/DuplicateParameterException.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.Serialization;
-using System.Security.Permissions;
 
 namespace DynamicExpresso.Exceptions
 {

--- a/src/DynamicExpresso.Core/Exceptions/DynamicExpressoException.cs
+++ b/src/DynamicExpresso.Core/Exceptions/DynamicExpressoException.cs
@@ -1,21 +1,17 @@
-﻿using System;
+using System;
 
 namespace DynamicExpresso.Exceptions
 {
-#if !NETSTANDARD1_6
 	[Serializable]
-#endif
 	public class DynamicExpressoException : Exception
 	{
 		public DynamicExpressoException() { }
 		public DynamicExpressoException(string message) : base(message) { }
 		public DynamicExpressoException(string message, Exception inner) : base(message, inner) { }
 
-#if !NETSTANDARD1_6
 		protected DynamicExpressoException(
 		System.Runtime.Serialization.SerializationInfo info,
 		System.Runtime.Serialization.StreamingContext context)
 			: base(info, context) { }
-#endif
 	}
 }

--- a/src/DynamicExpresso.Core/Exceptions/NoApplicableMethodException.cs
+++ b/src/DynamicExpresso.Core/Exceptions/NoApplicableMethodException.cs
@@ -1,18 +1,14 @@
-﻿#if !NETSTANDARD1_6
 using System;
 using System.Runtime.Serialization;
 using System.Security.Permissions;
-#endif
 
 namespace DynamicExpresso.Exceptions
 {
-#if !NETSTANDARD1_6
 	[Serializable]
-#endif
 	public class NoApplicableMethodException : ParseException
 	{
 		public NoApplicableMethodException(string methodName, string methodTypeName, int position)
-			: base(string.Format("No applicable method '{0}' exists in type '{1}'", methodName, methodTypeName), position) 
+			: base(string.Format("No applicable method '{0}' exists in type '{1}'", methodName, methodTypeName), position)
 		{
 			MethodTypeName = methodTypeName;
 			MethodName = methodName;
@@ -21,17 +17,15 @@ namespace DynamicExpresso.Exceptions
 		public string MethodTypeName { get; private set; }
 		public string MethodName { get; private set; }
 
-#if !NETSTANDARD1_6
 		protected NoApplicableMethodException(
 			SerializationInfo info,
 			StreamingContext context)
-			: base(info, context) 
+			: base(info, context)
 		{
 			MethodTypeName = info.GetString("MethodTypeName");
 			MethodName = info.GetString("MethodName");
 		}
 
-		[SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("MethodName", MethodName);
@@ -39,6 +33,5 @@ namespace DynamicExpresso.Exceptions
 
 			base.GetObjectData(info, context);
 		}
-#endif
 	}
 }

--- a/src/DynamicExpresso.Core/Exceptions/NoApplicableMethodException.cs
+++ b/src/DynamicExpresso.Core/Exceptions/NoApplicableMethodException.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.Serialization;
-using System.Security.Permissions;
 
 namespace DynamicExpresso.Exceptions
 {

--- a/src/DynamicExpresso.Core/Exceptions/ParseException.cs
+++ b/src/DynamicExpresso.Core/Exceptions/ParseException.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.Serialization;
-using System.Security.Permissions;
 using DynamicExpresso.Resources;
 
 namespace DynamicExpresso.Exceptions

--- a/src/DynamicExpresso.Core/Exceptions/ParseException.cs
+++ b/src/DynamicExpresso.Core/Exceptions/ParseException.cs
@@ -1,19 +1,15 @@
-﻿#if !NETSTANDARD1_6
 using System;
 using System.Runtime.Serialization;
 using System.Security.Permissions;
-#endif
 using DynamicExpresso.Resources;
 
 namespace DynamicExpresso.Exceptions
 {
-	#if !NETSTANDARD1_6
 	[Serializable]
-	#endif
 	public class ParseException : DynamicExpressoException
 	{
 		public ParseException(string message, int position)
-			: base(string.Format(ErrorMessages.Format, message, position)) 
+			: base(string.Format(ErrorMessages.Format, message, position))
 		{
 			Position = position;
 		}
@@ -26,22 +22,19 @@ namespace DynamicExpresso.Exceptions
 
 		public int Position { get; private set; }
 
-		#if !NETSTANDARD1_6
 		protected ParseException(
 			SerializationInfo info,
 			StreamingContext context)
-			: base(info, context) 
+			: base(info, context)
 		{
 			Position = info.GetInt32("Position");
 		}
 
-		[SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("Position", Position);
 
 			base.GetObjectData(info, context);
 		}
-		#endif
 	}
 }

--- a/src/DynamicExpresso.Core/Exceptions/ReflectionNotAllowedException.cs
+++ b/src/DynamicExpresso.Core/Exceptions/ReflectionNotAllowedException.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Security.Permissions;
 using System.Runtime.Serialization;
 
 namespace DynamicExpresso.Exceptions

--- a/src/DynamicExpresso.Core/Exceptions/ReflectionNotAllowedException.cs
+++ b/src/DynamicExpresso.Core/Exceptions/ReflectionNotAllowedException.cs
@@ -1,34 +1,27 @@
-﻿#if !NETSTANDARD1_6
 using System;
 using System.Security.Permissions;
 using System.Runtime.Serialization;
-#endif
 
 namespace DynamicExpresso.Exceptions
 {
-#if !NETSTANDARD1_6
 	[Serializable]
-#endif
 	public class ReflectionNotAllowedException : ParseException
 	{
 		public ReflectionNotAllowedException()
-			: base("Reflection expression not allowed. To enable reflection use Interpreter.EnableReflection().", 0) 
+			: base("Reflection expression not allowed. To enable reflection use Interpreter.EnableReflection().", 0)
 		{
 		}
 
-		#if !NETSTANDARD1_6
 		protected ReflectionNotAllowedException(
 			SerializationInfo info,
 			StreamingContext context)
-			: base(info, context) 
+			: base(info, context)
 		{
 		}
 
-		[SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);
 		}
-		#endif
 	}
 }

--- a/src/DynamicExpresso.Core/Exceptions/UnknownIdentifierException.cs
+++ b/src/DynamicExpresso.Core/Exceptions/UnknownIdentifierException.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.Serialization;
-using System.Security.Permissions;
 
 namespace DynamicExpresso.Exceptions
 {

--- a/src/DynamicExpresso.Core/Exceptions/UnknownIdentifierException.cs
+++ b/src/DynamicExpresso.Core/Exceptions/UnknownIdentifierException.cs
@@ -1,40 +1,33 @@
-﻿#if !NETSTANDARD1_6
 using System;
 using System.Runtime.Serialization;
 using System.Security.Permissions;
-#endif
 
 namespace DynamicExpresso.Exceptions
 {
-#if !NETSTANDARD1_6
 	[Serializable]
-#endif
 	public class UnknownIdentifierException : ParseException
 	{
 		public UnknownIdentifierException(string identifier, int position)
-			: base(string.Format("Unknown identifier '{0}'", identifier), position) 
+			: base(string.Format("Unknown identifier '{0}'", identifier), position)
 		{
 			Identifier = identifier;
 		}
 
 		public string Identifier { get; private set; }
 
-#if !NETSTANDARD1_6
 		protected UnknownIdentifierException(
 			SerializationInfo info,
 			StreamingContext context)
-			: base(info, context) 
+			: base(info, context)
 		{
 			Identifier = info.GetString("Identifier");
 		}
 
-		[SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			info.AddValue("Identifier", Identifier);
 
 			base.GetObjectData(info, context);
 		}
-#endif
 	}
 }

--- a/src/DynamicExpresso.Core/Interpreter.cs
+++ b/src/DynamicExpresso.Core/Interpreter.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using DynamicExpresso.Exceptions;
-using System.Dynamic;
 
 namespace DynamicExpresso
 {

--- a/test/DynamicExpresso.UnitTest/LambdaExpressionTest.cs
+++ b/test/DynamicExpresso.UnitTest/LambdaExpressionTest.cs
@@ -3,7 +3,6 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 
 namespace DynamicExpresso.UnitTest
 {


### PR DESCRIPTION
Since we only compile for netstandard2.0, the compiler directive is no longer needed.