### PR TITLE
🚚 Split Parser.cs

### DIFF
--- a/src/DynamicExpresso.Core/Exceptions/ParseException.cs
+++ b/src/DynamicExpresso.Core/Exceptions/ParseException.cs
@@ -26,7 +26,12 @@ namespace DynamicExpresso.Exceptions
 
 		public int Position { get; private set; }
 
-		#if !NETSTANDARD1_6
+		public static ParseException Create(int pos, string format, params object[] args)
+		{
+			return new ParseException(string.Format(format, args), pos);
+		}
+
+#if !NETSTANDARD1_6
 		protected ParseException(
 			SerializationInfo info,
 			StreamingContext context)

--- a/src/DynamicExpresso.Core/Parameter.cs
+++ b/src/DynamicExpresso.Core/Parameter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq.Expressions;
 
 namespace DynamicExpresso
@@ -48,5 +48,19 @@ namespace DynamicExpresso
 		public object Value { get; private set; }
 
 		public ParameterExpression Expression { get; private set; }
+	}
+
+	/// <summary>
+	/// Parameter with its position in the expression.
+	/// </summary>
+	internal class ParameterWithPosition : Parameter
+	{
+		public ParameterWithPosition(int pos, string name, Type type)
+			: base(name, type)
+		{
+			Position = pos;
+		}
+
+		public int Position { get; }
 	}
 }

--- a/src/DynamicExpresso.Core/Parsing/InterpreterExpression.cs
+++ b/src/DynamicExpresso.Core/Parsing/InterpreterExpression.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using DynamicExpresso.Exceptions;
+using DynamicExpresso.Reflection;
+
+namespace DynamicExpresso.Parsing
+{
+	internal class InterpreterExpression : Expression
+	{
+		private readonly Interpreter _interpreter;
+		private readonly string _expressionText;
+		private readonly IList<Parameter> _parameters;
+		private Type _type;
+
+		public InterpreterExpression(ParserArguments parserArguments, string expressionText, params ParameterWithPosition[] parameters)
+		{
+			var settings = parserArguments.Settings.Clone();
+			_interpreter = new Interpreter(settings);
+			_expressionText = expressionText;
+			_parameters = parameters;
+
+			// Take the parent expression's parameters and set them as an identifier that
+			// can be accessed by any lower call
+			// note: this doesn't impact the initial settings, because they're cloned
+			foreach (var dp in parserArguments.DeclaredParameters)
+			{
+				// Have to mark the parameter as "Used" otherwise we can get a compilation error.
+				parserArguments.TryGetParameters(dp.Name, out var pe);
+				_interpreter.SetIdentifier(new Identifier(dp.Name, pe));
+			}
+
+			foreach (var myParameter in parameters)
+			{
+				if (settings.Identifiers.ContainsKey(myParameter.Name))
+				{
+					throw new ParseException($"A local or parameter named '{myParameter.Name}' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter", myParameter.Position);
+				}
+			}
+
+			// prior to evaluation, we don't know the generic arguments types
+			_type = ReflectionExtensions.GetFuncType(parameters.Length);
+		}
+
+		public IList<Parameter> Parameters
+		{
+			get { return _parameters; }
+		}
+
+		public override Type Type
+		{
+			get { return _type; }
+		}
+
+		internal LambdaExpression EvalAs(Type delegateType)
+		{
+			if (!IsCompatibleWithDelegate(delegateType))
+				return null;
+
+			var lambdaExpr = _interpreter.ParseAsExpression(delegateType, _expressionText, _parameters.Select(p => p.Name).ToArray());
+			_type = lambdaExpr.Type;
+			return lambdaExpr;
+		}
+
+		internal bool IsCompatibleWithDelegate(Type target)
+		{
+			if (!target.IsGenericType || target.BaseType != typeof(MulticastDelegate))
+				return false;
+
+			var genericTypeDefinition = target.GetGenericTypeDefinition();
+			return genericTypeDefinition == ReflectionExtensions.GetFuncType(_parameters.Count)
+				|| genericTypeDefinition == ReflectionExtensions.GetActionType(_parameters.Count);
+		}
+	}
+}

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -272,7 +272,7 @@ namespace DynamicExpresso.Parsing
 				var promoted = PromoteExpression(right, left.Type, true);
 				if (promoted == null)
 					throw ParseException.Create(_token.pos, ErrorMessages.CannotConvertValue,
-						GetTypeName(right.Type), GetTypeName(left.Type));
+						TypeUtils.GetTypeName(right.Type), TypeUtils.GetTypeName(left.Type));
 
 				left = Expression.Assign(left, promoted);
 			}
@@ -400,7 +400,7 @@ namespace DynamicExpresso.Parsing
 				//		else
 				//		{
 				//			throw ParseException.Create(op.pos, ErrorMessages.IncompatibleOperands,
-				//				op.text, GetTypeName(left.Type), GetTypeName(right.Type));
+				//				op.text, TypeUtils.GetTypeName(left.Type), TypeUtils.GetTypeName(right.Type));
 				//		}
 				//	}
 				//}
@@ -420,7 +420,7 @@ namespace DynamicExpresso.Parsing
 				//		else
 				//		{
 				//			throw ParseException.Create(op.pos, ErrorMessages.IncompatibleOperands,
-				//				op.text, GetTypeName(left.Type), GetTypeName(right.Type));
+				//				op.text, TypeUtils.GetTypeName(left.Type), TypeUtils.GetTypeName(right.Type));
 				//		}
 				//	}
 				//}
@@ -704,7 +704,7 @@ namespace DynamicExpresso.Parsing
 			// try to find the user defined operator on both operands
 			var applicableMethods = FindMethods(type, operatorName, true, args);
 			if (applicableMethods.Length > 1)
-				throw ParseException.Create(errorPos, ErrorMessages.AmbiguousUnaryOperatorInvocation, operatorName, GetTypeName(type));
+				throw ParseException.Create(errorPos, ErrorMessages.AmbiguousUnaryOperatorInvocation, operatorName, TypeUtils.GetTypeName(type));
 
 			MethodData userDefinedOperator = null;
 			if (applicableMethods.Length == 1)
@@ -764,7 +764,7 @@ namespace DynamicExpresso.Parsing
 					else if (typeof(Delegate).IsAssignableFrom(expr.Type))
 						expr = ParseDelegateInvocation(expr, tokenPos);
 					else
-						throw ParseException.Create(tokenPos, ErrorMessages.InvalidMethodCall, GetTypeName(expr.Type));
+						throw ParseException.Create(tokenPos, ErrorMessages.InvalidMethodCall, TypeUtils.GetTypeName(expr.Type));
 				}
 				else
 				{
@@ -779,7 +779,7 @@ namespace DynamicExpresso.Parsing
 		/// </summary>
 		private Expression GenerateGetNullableValue(Expression expr)
 		{
-			if (!IsNullableType(expr.Type))
+			if (!TypeUtils.IsNullableType(expr.Type))
 				return expr;
 			return GeneratePropertyOrFieldExpression(expr.Type, expr, _token.pos, "Value");
 		}
@@ -1314,7 +1314,7 @@ namespace DynamicExpresso.Parsing
 			}
 			if (member == null)
 			{
-				throw ParseException.Create(pos, ErrorMessages.UnknownPropertyOrField, propertyOrFieldName, GetTypeName(newType));
+				throw ParseException.Create(pos, ErrorMessages.UnknownPropertyOrField, propertyOrFieldName, TypeUtils.GetTypeName(newType));
 			}
 			NextToken();
 
@@ -1367,7 +1367,7 @@ namespace DynamicExpresso.Parsing
 				var addMethod = ParseNormalMethodInvocation(newType, instance, _token.pos, "Add", args);
 				if (addMethod == null)
 				{
-					throw ParseException.Create(_token.pos, ErrorMessages.UnableToFindAppropriateAddMethod, GetTypeName(newType));
+					throw ParseException.Create(_token.pos, ErrorMessages.UnableToFindAppropriateAddMethod, TypeUtils.GetTypeName(newType));
 				}
 				actions.Add(addMethod);
 			}
@@ -1491,8 +1491,8 @@ namespace DynamicExpresso.Parsing
 			var errorPos = _token.pos;
 			if (_token.id == TokenId.Question)
 			{
-				if (!type.IsValueType || IsNullableType(type))
-					throw ParseException.Create(errorPos, ErrorMessages.TypeHasNoNullableForm, GetTypeName(type));
+				if (!type.IsValueType || TypeUtils.IsNullableType(type))
+					throw ParseException.Create(errorPos, ErrorMessages.TypeHasNoNullableForm, TypeUtils.GetTypeName(type));
 				type = typeof(Nullable<>).MakeGenericType(type);
 
 				NextToken();
@@ -1607,11 +1607,11 @@ namespace DynamicExpresso.Parsing
 		//        case 0:
 		//            if (args.Length == 1)
 		//                return GenerateConversion(args[0], type, errorPos);
-		//            throw ParseError(errorPos, ErrorMessages.NoMatchingConstructor, GetTypeName(type));
+		//            throw ParseError(errorPos, ErrorMessages.NoMatchingConstructor, TypeUtils.GetTypeName(type));
 		//        case 1:
 		//            return Expression.New((ConstructorInfo)method, args);
 		//        default:
-		//            throw ParseError(errorPos, ErrorMessages.AmbiguousConstructorInvocation, GetTypeName(type));
+		//            throw ParseError(errorPos, ErrorMessages.AmbiguousConstructorInvocation, TypeUtils.GetTypeName(type));
 		//    }
 		//}
 
@@ -1669,7 +1669,7 @@ namespace DynamicExpresso.Parsing
 			catch (InvalidOperationException)
 			{
 				throw ParseException.Create(errorPos, ErrorMessages.CannotConvertValue,
-					GetTypeName(exprType), GetTypeName(type));
+					TypeUtils.GetTypeName(exprType), TypeUtils.GetTypeName(type));
 			}
 		}
 
@@ -1700,10 +1700,10 @@ namespace DynamicExpresso.Parsing
 					Expression.Field(instance, (FieldInfo)member);
 			}
 
-			if (IsDynamicType(type) || IsDynamicExpression(instance))
+			if (TypeUtils.IsDynamicType(type) || IsDynamicExpression(instance))
 				return ParseDynamicProperty(type, instance, propertyOrFieldName);
 
-			throw ParseException.Create(errorPos, ErrorMessages.UnknownPropertyOrField, propertyOrFieldName, GetTypeName(type));
+			throw ParseException.Create(errorPos, ErrorMessages.UnknownPropertyOrField, propertyOrFieldName, TypeUtils.GetTypeName(type));
 		}
 
 		private Expression ParseMethodInvocation(Type type, Expression instance, int errorPos, string methodName)
@@ -1724,10 +1724,10 @@ namespace DynamicExpresso.Parsing
 			if (methodInvocationExpression != null)
 				return methodInvocationExpression;
 
-			if (IsDynamicType(type) || IsDynamicExpression(instance))
+			if (TypeUtils.IsDynamicType(type) || IsDynamicExpression(instance))
 				return ParseDynamicMethodInvocation(type, instance, methodName, args);
 
-			throw new NoApplicableMethodException(methodName, GetTypeName(type), errorPos);
+			throw new NoApplicableMethodException(methodName, TypeUtils.GetTypeName(type), errorPos);
 		}
 
 		private Expression ParseExtensionMethodInvocation(Type type, Expression instance, int errorPos, string id, Expression[] args)
@@ -1738,7 +1738,7 @@ namespace DynamicExpresso.Parsing
 
 			var extensionMethods = FindExtensionMethods(id, extensionMethodsArguments);
 			if (extensionMethods.Length > 1)
-				throw ParseException.Create(errorPos, ErrorMessages.AmbiguousMethodInvocation, id, GetTypeName(type));
+				throw ParseException.Create(errorPos, ErrorMessages.AmbiguousMethodInvocation, id, TypeUtils.GetTypeName(type));
 
 			if (extensionMethods.Length == 1)
 			{
@@ -1756,7 +1756,7 @@ namespace DynamicExpresso.Parsing
 		{
 			var applicableMethods = FindMethods(type, id, instance == null, args);
 			if (applicableMethods.Length > 1)
-				throw ParseException.Create(errorPos, ErrorMessages.AmbiguousMethodInvocation, id, GetTypeName(type));
+				throw ParseException.Create(errorPos, ErrorMessages.AmbiguousMethodInvocation, id, TypeUtils.GetTypeName(type));
 
 			if (applicableMethods.Length == 1)
 			{
@@ -1815,21 +1815,6 @@ namespace DynamicExpresso.Parsing
 		//    }
 		//    return Expression.Call(typeof(Enumerable), signature.Name, typeArgs, args);
 		//}
-
-		/// <summary>
-		/// Returns null if <paramref name="t"/> is an Array type.  Needed because the <seealso cref="Microsoft.CSharp.RuntimeBinder.Binder"/> lookup methods fail with a <seealso cref="InvalidCastException"/> if the array type is used.
-		/// Everything still miraculously works on the array if null is given for the type.
-		/// </summary>
-		/// <param name="t"></param>
-		/// <returns></returns>
-		private static Type RemoveArrayType(Type t)
-		{
-			if (t == null || t.IsArray)
-			{
-				return null;
-			}
-			return t;
-		}
 
 		private static Expression ParseDynamicProperty(Type type, Expression instance, string propertyOrFieldName)
 		{
@@ -1896,34 +1881,24 @@ namespace DynamicExpresso.Parsing
 				return Expression.ArrayAccess(expr, args);
 			}
 
-			if (IsDynamicType(expr.Type) || IsDynamicExpression(expr))
+			if (TypeUtils.IsDynamicType(expr.Type) || IsDynamicExpression(expr))
 				return ParseDynamicIndex(expr.Type, expr, args);
 
 			var applicableMethods = FindIndexer(expr.Type, args);
 			if (applicableMethods.Length == 0)
 			{
 				throw ParseException.Create(errorPos, ErrorMessages.NoApplicableIndexer,
-					GetTypeName(expr.Type));
+					TypeUtils.GetTypeName(expr.Type));
 			}
 
 			if (applicableMethods.Length > 1)
 			{
 				throw ParseException.Create(errorPos, ErrorMessages.AmbiguousIndexerInvocation,
-					GetTypeName(expr.Type));
+					TypeUtils.GetTypeName(expr.Type));
 			}
 
 			var indexer = (IndexerData)applicableMethods[0];
 			return Expression.Property(expr, indexer.Indexer, indexer.PromotedParameters);
-		}
-
-		private static bool IsNullableType(Type type)
-		{
-			return Nullable.GetUnderlyingType(type) != null;
-		}
-
-		private static bool IsDynamicType(Type type)
-		{
-			return typeof(IDynamicMetaObjectProvider).IsAssignableFrom(type);
 		}
 
 		private bool IsDynamicExpression(Expression instance)
@@ -1931,60 +1906,6 @@ namespace DynamicExpresso.Parsing
 			return instance != null &&
 				(instance.NodeType == ExpressionType.Dynamic ||
 				(_arguments.Settings.LateBindObject && instance.Type == typeof(object)));
-		}
-
-		private static Type GetNonNullableType(Type type)
-		{
-			return IsNullableType(type) ? type.GetGenericArguments()[0] : type;
-		}
-
-		private static string GetTypeName(Type type)
-		{
-			var baseType = GetNonNullableType(type);
-			var s = baseType.Name;
-			if (type != baseType) s += '?';
-			return s;
-		}
-
-		static bool IsNumericType(Type type)
-		{
-			return GetNumericTypeKind(type) != 0;
-		}
-
-		private static bool IsSignedIntegralType(Type type)
-		{
-			return GetNumericTypeKind(type) == 2;
-		}
-
-		private static bool IsUnsignedIntegralType(Type type)
-		{
-			return GetNumericTypeKind(type) == 3;
-		}
-
-		private static int GetNumericTypeKind(Type type)
-		{
-			type = GetNonNullableType(type);
-			if (type.IsEnum) return 0;
-			switch (Type.GetTypeCode(type))
-			{
-				case TypeCode.Char:
-				case TypeCode.Single:
-				case TypeCode.Double:
-				case TypeCode.Decimal:
-					return 1;
-				case TypeCode.SByte:
-				case TypeCode.Int16:
-				case TypeCode.Int32:
-				case TypeCode.Int64:
-					return 2;
-				case TypeCode.Byte:
-				case TypeCode.UInt16:
-				case TypeCode.UInt32:
-				case TypeCode.UInt64:
-					return 3;
-				default:
-					return 0;
-			}
 		}
 
 		//static bool IsEnumType(Type type)
@@ -2003,7 +1924,8 @@ namespace DynamicExpresso.Parsing
 
 		private void CheckAndPromoteOperands(Type signatures, ref Expression left, ref Expression right)
 		{
-			if ((IsNullableType(left.Type) || IsNullableType(right.Type)) && (GetNonNullableType(left.Type) == right.Type || GetNonNullableType(right.Type) == left.Type))
+			if ((TypeUtils.IsNullableType(left.Type) || TypeUtils.IsNullableType(right.Type)) &&
+				(TypeUtils.GetNonNullableType(left.Type) == right.Type || TypeUtils.GetNonNullableType(right.Type) == left.Type))
 			{
 				left = GenerateNullableTypeConversion(left);
 				right = GenerateNullableTypeConversion(right);
@@ -2160,40 +2082,9 @@ namespace DynamicExpresso.Parsing
 			return applicable;
 		}
 
-		private static Type GetConcreteTypeForGenericMethod(Type type, List<Expression> promotedArgs, MethodData method)
-		{
-			if (type.IsGenericType)
-			{
-				//Generic<T> type
-				var genericArguments = type.GetGenericArguments();
-				var concreteTypeParameters = new Type[genericArguments.Length];
-
-				for (var i = 0; i < genericArguments.Length; i++)
-				{
-					concreteTypeParameters[i] = GetConcreteTypeForGenericMethod(genericArguments[i], promotedArgs,method);
-				}
-
-				return type.GetGenericTypeDefinition().MakeGenericType(concreteTypeParameters);
-			}
-			else if (type.ContainsGenericParameters)
-			{
-				//T case
-				//try finding an actual parameter for the generic
-				for (var i = 0; i < promotedArgs.Count; i++)
-				{
-					if (method.Parameters[i].ParameterType == type)
-					{						
-						return promotedArgs[i].Type;
-					}
-				}
-			}
-
-			return type;//already a concrete type
-		}
-
 		private static bool CheckIfMethodIsApplicableAndPrepareIt(MethodData method, Expression[] args)
 		{
-			if (method.Parameters.Count(y => !y.HasDefaultValue && !HasParamsArrayType(y)) > args.Length)
+			if (method.Parameters.Count(y => !y.HasDefaultValue && !ReflectionExtensions.HasParamsArrayType(y)) > args.Length)
 				return false;
 
 			var promotedArgs = new List<Expression>();
@@ -2225,7 +2116,7 @@ namespace DynamicExpresso.Parsing
 
 					parameterType = parameterDeclaration.ParameterType;
 
-					if (HasParamsArrayType(parameterDeclaration))
+					if (ReflectionExtensions.HasParamsArrayType(parameterDeclaration))
 					{
 						paramsArrayTypeFound = parameterType;
 					}
@@ -2299,13 +2190,13 @@ namespace DynamicExpresso.Parsing
 			{
 				if (x.HasDefaultValue)
 				{
-					var parameterType = GetConcreteTypeForGenericMethod(x.ParameterType, promotedArgs, method);
+					var parameterType = TypeUtils.GetConcreteTypeForGenericMethod(x.ParameterType, promotedArgs, method);
 
 					return Expression.Constant(x.DefaultValue, parameterType);
 				}
 
 
-				if (HasParamsArrayType(x))
+				if (ReflectionExtensions.HasParamsArrayType(x))
 				{
 					method.HasParamsArray = true;
 					return Expression.NewArrayInit(x.ParameterType.GetElementType());
@@ -2436,7 +2327,7 @@ namespace DynamicExpresso.Parsing
 				{
 					if (type.ContainsGenericParameters)
 						return null;
-					if (!type.IsValueType || IsNullableType(type))
+					if (!type.IsValueType || TypeUtils.IsNullableType(type))
 						return Expression.Constant(null, type);
 				}
 			}
@@ -2452,14 +2343,14 @@ namespace DynamicExpresso.Parsing
 				return expr;
 			}
 
-			if (type.IsGenericType && !IsNumericType(type))
+			if (type.IsGenericType && !TypeUtils.IsNumericType(type))
 			{
-				var genericType = FindAssignableGenericType(expr.Type, type);
+				var genericType = TypeUtils.FindAssignableGenericType(expr.Type, type);
 				if (genericType != null)
 					return Expression.Convert(expr, genericType);
 			}
 
-			if (IsCompatibleWith(expr.Type, type) || expr is DynamicExpression)
+			if (TypeUtils.IsCompatibleWith(expr.Type, type) || expr is DynamicExpression)
 			{
 				if (type.IsValueType || exact)
 				{
@@ -2469,142 +2360,6 @@ namespace DynamicExpresso.Parsing
 			}
 
 			return null;
-		}
-
-		private static bool IsCompatibleWith(Type source, Type target)
-		{
-			if (source == target)
-			{
-				return true;
-			}
-
-			if (target.IsGenericParameter)
-			{
-				return true;
-			}
-
-			if (!target.IsValueType)
-			{
-				return target.IsAssignableFrom(source);
-			}
-			var st = GetNonNullableType(source);
-			var tt = GetNonNullableType(target);
-			if (st != source && tt == target) return false;
-			var sc = st.IsEnum ? TypeCode.Object : Type.GetTypeCode(st);
-			var tc = tt.IsEnum ? TypeCode.Object : Type.GetTypeCode(tt);
-			switch (sc)
-			{
-				case TypeCode.SByte:
-					switch (tc)
-					{
-						case TypeCode.SByte:
-						case TypeCode.Int16:
-						case TypeCode.Int32:
-						case TypeCode.Int64:
-						case TypeCode.Single:
-						case TypeCode.Double:
-						case TypeCode.Decimal:
-							return true;
-					}
-					break;
-				case TypeCode.Byte:
-					switch (tc)
-					{
-						case TypeCode.Byte:
-						case TypeCode.Int16:
-						case TypeCode.UInt16:
-						case TypeCode.Int32:
-						case TypeCode.UInt32:
-						case TypeCode.Int64:
-						case TypeCode.UInt64:
-						case TypeCode.Single:
-						case TypeCode.Double:
-						case TypeCode.Decimal:
-							return true;
-					}
-					break;
-				case TypeCode.Int16:
-					switch (tc)
-					{
-						case TypeCode.Int16:
-						case TypeCode.Int32:
-						case TypeCode.Int64:
-						case TypeCode.Single:
-						case TypeCode.Double:
-						case TypeCode.Decimal:
-							return true;
-					}
-					break;
-				case TypeCode.UInt16:
-					switch (tc)
-					{
-						case TypeCode.UInt16:
-						case TypeCode.Int32:
-						case TypeCode.UInt32:
-						case TypeCode.Int64:
-						case TypeCode.UInt64:
-						case TypeCode.Single:
-						case TypeCode.Double:
-						case TypeCode.Decimal:
-							return true;
-					}
-					break;
-				case TypeCode.Int32:
-					switch (tc)
-					{
-						case TypeCode.Int32:
-						case TypeCode.Int64:
-						case TypeCode.Single:
-						case TypeCode.Double:
-						case TypeCode.Decimal:
-							return true;
-					}
-					break;
-				case TypeCode.UInt32:
-					switch (tc)
-					{
-						case TypeCode.UInt32:
-						case TypeCode.Int64:
-						case TypeCode.UInt64:
-						case TypeCode.Single:
-						case TypeCode.Double:
-						case TypeCode.Decimal:
-							return true;
-					}
-					break;
-				case TypeCode.Int64:
-					switch (tc)
-					{
-						case TypeCode.Int64:
-						case TypeCode.Single:
-						case TypeCode.Double:
-						case TypeCode.Decimal:
-							return true;
-					}
-					break;
-				case TypeCode.UInt64:
-					switch (tc)
-					{
-						case TypeCode.UInt64:
-						case TypeCode.Single:
-						case TypeCode.Double:
-						case TypeCode.Decimal:
-							return true;
-					}
-					break;
-				case TypeCode.Single:
-					switch (tc)
-					{
-						case TypeCode.Single:
-						case TypeCode.Double:
-							return true;
-					}
-					break;
-				default:
-					if (st == tt) return true;
-					break;
-			}
-			return false;
 		}
 
 		private static bool IsWritable(Expression expression)
@@ -2632,53 +2387,6 @@ namespace DynamicExpresso.Parsing
 			return false;
 		}
 
-		// from http://stackoverflow.com/a/1075059/209727
-		private static Type FindAssignableGenericType(Type givenType, Type constructedGenericType)
-		{
-			var genericTypeDefinition = constructedGenericType.GetGenericTypeDefinition();
-			var interfaceTypes = givenType.GetInterfaces();
-
-			foreach (var it in interfaceTypes)
-			{
-				if (it.IsGenericType && it.GetGenericTypeDefinition() == genericTypeDefinition)
-				{
-					return it;
-				}
-			}
-
-			if (givenType.IsGenericType && givenType.GetGenericTypeDefinition() == genericTypeDefinition)
-			{
-				// the given type has the same generic type of the fully constructed generic type
-				//  => check if the generic arguments are compatible (e.g. Nullable<int> and Nullable<DateTime>: int is not compatible with DateTime)
-				var givenTypeGenericsArgs = givenType.GenericTypeArguments;
-				var constructedGenericsArgs = constructedGenericType.GenericTypeArguments;
-				if (givenTypeGenericsArgs.Zip(constructedGenericsArgs, (g, c) => IsCompatibleWith(g, c)).Any(compatible => !compatible))
-					return null;
-
-				return givenType;
-			}
-
-			var baseType = givenType.BaseType;
-			if (baseType == null)
-				return null;
-
-			return FindAssignableGenericType(baseType, genericTypeDefinition);
-		}
-
-		private static bool HasParamsArrayType(ParameterInfo parameterInfo)
-		{
-			return parameterInfo.IsDefined(typeof(ParamArrayAttribute), false);
-		}
-
-		private static Type GetParameterType(ParameterInfo parameterInfo)
-		{
-			var isParamsArray = HasParamsArrayType(parameterInfo);
-			var type = isParamsArray
-				? parameterInfo.ParameterType.GetElementType()
-				: parameterInfo.ParameterType;
-			return type;
-		}
-
 		private static bool MethodHasPriority(Expression[] args, MethodData method, MethodData otherMethod)
 		{
 			var better = false;
@@ -2689,8 +2397,8 @@ namespace DynamicExpresso.Parsing
 				var arg = args[i];
 				var methodParam = method.Parameters[m];
 				var otherMethodParam = otherMethod.Parameters[o];
-				var methodParamType = GetParameterType(methodParam);
-				var otherMethodParamType = GetParameterType(otherMethodParam);
+				var methodParamType = ReflectionExtensions.GetParameterType(methodParam);
+				var otherMethodParamType = ReflectionExtensions.GetParameterType(otherMethodParam);
 
 				if (methodParamType.ContainsGenericParameters)
 					methodParamType = method.PromotedParameters[i].Type;
@@ -2698,14 +2406,14 @@ namespace DynamicExpresso.Parsing
 				if (otherMethodParamType.ContainsGenericParameters)
 					otherMethodParamType = otherMethod.PromotedParameters[i].Type;
 
-				var c = CompareConversions(arg.Type, methodParamType, otherMethodParamType);
+				var c = TypeUtils.CompareConversions(arg.Type, methodParamType, otherMethodParamType);
 				if (c < 0)
 					return false;
 				if (c > 0)
 					better = true;
 
-				if (!HasParamsArrayType(methodParam)) m++;
-				if (!HasParamsArrayType(otherMethodParam)) o++;
+				if (!ReflectionExtensions.HasParamsArrayType(methodParam)) m++;
+				if (!ReflectionExtensions.HasParamsArrayType(otherMethodParam)) o++;
 			}
 
 			if (better)
@@ -2738,31 +2446,6 @@ namespace DynamicExpresso.Parsing
 			}
 
 			return better;
-		}
-
-		// Return 1 if s -> t1 is a better conversion than s -> t2
-		// Return -1 if s -> t2 is a better conversion than s -> t1
-		// Return 0 if neither conversion is better
-		private static int CompareConversions(Type s, Type t1, Type t2)
-		{
-			if (t1 == t2) return 0;
-			if (s == t1) return 1;
-			if (s == t2) return -1;
-
-			var assignableT1 = t1.IsAssignableFrom(s);
-			var assignableT2 = t2.IsAssignableFrom(s);
-			if (assignableT1 && !assignableT2) return 1;
-			if (assignableT2 && !assignableT1) return -1;
-
-			var compatibleT1T2 = IsCompatibleWith(t1, t2);
-			var compatibleT2T1 = IsCompatibleWith(t2, t1);
-			if (compatibleT1T2 && !compatibleT2T1) return 1;
-			if (compatibleT2T1 && !compatibleT1T2) return -1;
-
-			if (IsSignedIntegralType(t1) && IsUnsignedIntegralType(t2)) return 1;
-			if (IsSignedIntegralType(t2) && IsUnsignedIntegralType(t1)) return -1;
-
-			return 0;
 		}
 
 		private Expression GenerateEqual(Expression left, Expression right)
@@ -2921,7 +2604,7 @@ namespace DynamicExpresso.Parsing
 			var errorPos = _token.pos;
 			var leftType = left.Type;
 			var rightType = right.Type;
-			var error = ParseException.Create(errorPos, ErrorMessages.AmbiguousBinaryOperatorInvocation, operatorName, GetTypeName(leftType), GetTypeName(rightType));
+			var error = ParseException.Create(errorPos, ErrorMessages.AmbiguousBinaryOperatorInvocation, operatorName, TypeUtils.GetTypeName(leftType), TypeUtils.GetTypeName(rightType));
 
 			var args = new[] { left, right };
 
@@ -2970,7 +2653,7 @@ namespace DynamicExpresso.Parsing
 
 		private static Expression ToStringOrNull(Expression expression)
 		{
-			var nullableExpression = IsNullableType(expression.Type) ?
+			var nullableExpression = TypeUtils.IsNullableType(expression.Type) ?
 				expression :
 				GenerateNullableTypeConversion(expression);
 
@@ -2994,14 +2677,10 @@ namespace DynamicExpresso.Parsing
 				: expression;
 		}
 
-		private static MethodInfo GetStaticMethod(string methodName, Expression left, Expression right)
-		{
-			return left.Type.GetMethod(methodName, new[] { left.Type, right.Type });
-		}
-
 		private static Expression GenerateStaticMethodCall(string methodName, Expression left, Expression right)
 		{
-			return Expression.Call(null, GetStaticMethod(methodName, left, right), new[] { left, right });
+			var staticMethod = left.Type.GetMethod(methodName, new[] { left.Type, right.Type });
+			return Expression.Call(null, staticMethod, new[] { left, right });
 		}
 
 		private void SetTextPos(int pos)
@@ -3415,8 +3094,7 @@ namespace DynamicExpresso.Parsing
 		{
 			var exprType = expr.Type;
 
-			if (IsNullableType(exprType) ||
-			    !exprType.IsValueType)
+			if (TypeUtils.IsNullableType(exprType) || !exprType.IsValueType)
 			{
 				return expr;
 			}
@@ -3513,7 +3191,7 @@ namespace DynamicExpresso.Parsing
 				var binder = Microsoft.CSharp.RuntimeBinder.Binder.GetMember(
 					Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags.None,
 					_propertyOrFieldName,
-					RemoveArrayType(args[0]?.GetType()),
+					TypeUtils.RemoveArrayType(args[0]?.GetType()),
 					new[] { Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags.None, null) }
 				);
 				return binder.Bind(args, parameters, returnLabel);
@@ -3538,7 +3216,7 @@ namespace DynamicExpresso.Parsing
 					Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags.None,
 					_methodName,
 					null,
-					RemoveArrayType(args[0]?.GetType()),
+					TypeUtils.RemoveArrayType(args[0]?.GetType()),
 					parameters.Select(x => Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags.None, null))
 				);
 				return binderM.Bind(args, parameters, returnLabel);
@@ -3554,7 +3232,7 @@ namespace DynamicExpresso.Parsing
 			{
 				var binder = Microsoft.CSharp.RuntimeBinder.Binder.GetIndex(
 					Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags.None,
-					RemoveArrayType(args[0]?.GetType()),
+					TypeUtils.RemoveArrayType(args[0]?.GetType()),
 					parameters.Select(x => Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags.None, null))
 				);
 				return binder.Bind(args, parameters, returnLabel);

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -264,14 +264,14 @@ namespace DynamicExpresso.Parsing
 
 
 				if (!IsWritable(left))
-					throw CreateParseException(_token.pos, ErrorMessages.ExpressionMustBeWritable);
+					throw ParseException.Create(_token.pos, ErrorMessages.ExpressionMustBeWritable);
 
 				NextToken();
 				var right = ParseAssignment();
 
 				var promoted = PromoteExpression(right, left.Type, true);
 				if (promoted == null)
-					throw CreateParseException(_token.pos, ErrorMessages.CannotConvertValue,
+					throw ParseException.Create(_token.pos, ErrorMessages.CannotConvertValue,
 						GetTypeName(right.Type), GetTypeName(left.Type));
 
 				left = Expression.Assign(left, promoted);
@@ -399,7 +399,7 @@ namespace DynamicExpresso.Parsing
 				//		}
 				//		else
 				//		{
-				//			throw CreateParseException(op.pos, ErrorMessages.IncompatibleOperands,
+				//			throw ParseException.Create(op.pos, ErrorMessages.IncompatibleOperands,
 				//				op.text, GetTypeName(left.Type), GetTypeName(right.Type));
 				//		}
 				//	}
@@ -419,7 +419,7 @@ namespace DynamicExpresso.Parsing
 				//		}
 				//		else
 				//		{
-				//			throw CreateParseException(op.pos, ErrorMessages.IncompatibleOperands,
+				//			throw ParseException.Create(op.pos, ErrorMessages.IncompatibleOperands,
 				//				op.text, GetTypeName(left.Type), GetTypeName(right.Type));
 				//		}
 				//	}
@@ -474,14 +474,14 @@ namespace DynamicExpresso.Parsing
 
 				Type knownType;
 				if (!TryParseKnownType(_token.text, out knownType))
-					throw CreateParseException(op.pos, ErrorMessages.TypeIdentifierExpected);
+					throw ParseException.Create(op.pos, ErrorMessages.TypeIdentifierExpected);
 
 				if (typeOperator == ParserConstants.KeywordIs)
 					left = Expression.TypeIs(left, knownType);
 				else if (typeOperator == ParserConstants.KeywordAs)
 					left = Expression.TypeAs(left, knownType);
 				else
-					throw CreateParseException(_token.pos, ErrorMessages.SyntaxError);
+					throw ParseException.Create(_token.pos, ErrorMessages.SyntaxError);
 			}
 
 			return left;
@@ -704,7 +704,7 @@ namespace DynamicExpresso.Parsing
 			// try to find the user defined operator on both operands
 			var applicableMethods = FindMethods(type, operatorName, true, args);
 			if (applicableMethods.Length > 1)
-				throw CreateParseException(errorPos, ErrorMessages.AmbiguousUnaryOperatorInvocation, operatorName, GetTypeName(type));
+				throw ParseException.Create(errorPos, ErrorMessages.AmbiguousUnaryOperatorInvocation, operatorName, GetTypeName(type));
 
 			MethodData userDefinedOperator = null;
 			if (applicableMethods.Length == 1)
@@ -764,7 +764,7 @@ namespace DynamicExpresso.Parsing
 					else if (typeof(Delegate).IsAssignableFrom(expr.Type))
 						expr = ParseDelegateInvocation(expr, tokenPos);
 					else
-						throw CreateParseException(tokenPos, ErrorMessages.InvalidMethodCall, GetTypeName(expr.Type));
+						throw ParseException.Create(tokenPos, ErrorMessages.InvalidMethodCall, GetTypeName(expr.Type));
 				}
 				else
 				{
@@ -803,7 +803,7 @@ namespace DynamicExpresso.Parsing
 				case TokenId.End:
 					return Expression.Empty();
 				default:
-					throw CreateParseException(_token.pos, ErrorMessages.ExpressionExpected);
+					throw ParseException.Create(_token.pos, ErrorMessages.ExpressionExpected);
 			}
 		}
 
@@ -815,7 +815,7 @@ namespace DynamicExpresso.Parsing
 			s = EvalEscapeStringLiteral(s);
 
 			if (s.Length != 1)
-				throw CreateParseException(_token.pos, ErrorMessages.InvalidCharacterLiteral);
+				throw ParseException.Create(_token.pos, ErrorMessages.InvalidCharacterLiteral);
 
 			NextToken();
 			return CreateLiteral(s[0]);
@@ -852,7 +852,7 @@ namespace DynamicExpresso.Parsing
 				if (c == '\\')
 				{
 					if ((i + 1) == source.Length)
-						throw CreateParseException(_token.pos, ErrorMessages.InvalidEscapeSequence);
+						throw ParseException.Create(_token.pos, ErrorMessages.InvalidEscapeSequence);
 
 					builder.Append(EvalEscapeChar(source[++i]));
 				}
@@ -890,7 +890,7 @@ namespace DynamicExpresso.Parsing
 				case 'v':
 					return '\v';
 				default:
-					throw CreateParseException(_token.pos, ErrorMessages.InvalidEscapeSequence);
+					throw ParseException.Create(_token.pos, ErrorMessages.InvalidEscapeSequence);
 			}
 		}
 
@@ -925,13 +925,13 @@ namespace DynamicExpresso.Parsing
 				{
 					var hex = text.Substring(2);
 					if (!ulong.TryParse(hex, ParseLiteralHexNumberStyle, ParseCulture, out value))
-						throw CreateParseException(_token.pos, ErrorMessages.InvalidIntegerLiteral, text);
+						throw ParseException.Create(_token.pos, ErrorMessages.InvalidIntegerLiteral, text);
 				}
 				else if (text.StartsWith("0b") || text.StartsWith("0B"))
 				{
 					var binary = text.Substring(2);
 					if (string.IsNullOrEmpty(binary))
-						throw CreateParseException(_token.pos, ErrorMessages.InvalidIntegerLiteral, text);
+						throw ParseException.Create(_token.pos, ErrorMessages.InvalidIntegerLiteral, text);
 
 					try
 					{
@@ -943,7 +943,7 @@ namespace DynamicExpresso.Parsing
 					}
 				}
 				else if (!ulong.TryParse(text, ParseLiteralUnsignedNumberStyle, ParseCulture, out value))
-					throw CreateParseException(_token.pos, ErrorMessages.InvalidIntegerLiteral, text);
+					throw ParseException.Create(_token.pos, ErrorMessages.InvalidIntegerLiteral, text);
 
 				NextToken();
 
@@ -959,7 +959,7 @@ namespace DynamicExpresso.Parsing
 			else
 			{
 				if (!long.TryParse(text, ParseLiteralNumberStyle, ParseCulture, out long value))
-					throw CreateParseException(_token.pos, ErrorMessages.InvalidIntegerLiteral, text);
+					throw ParseException.Create(_token.pos, ErrorMessages.InvalidIntegerLiteral, text);
 
 				NextToken();
 
@@ -1013,7 +1013,7 @@ namespace DynamicExpresso.Parsing
 			}
 
 			if (value == null)
-				throw CreateParseException(_token.pos, ErrorMessages.InvalidRealLiteral, text);
+				throw ParseException.Create(_token.pos, ErrorMessages.InvalidRealLiteral, text);
 
 			NextToken();
 
@@ -1131,11 +1131,11 @@ namespace DynamicExpresso.Parsing
 			NextToken();
 			var args = ParseArgumentList();
 			if (args.Length != 1)
-				throw CreateParseException(errorPos, ErrorMessages.TypeofRequiresOneArg);
+				throw ParseException.Create(errorPos, ErrorMessages.TypeofRequiresOneArg);
 
 			var constExp = args[0] as ConstantExpression;
 			if (constExp == null || !(constExp.Value is Type))
-				throw CreateParseException(errorPos, ErrorMessages.TypeofRequiresAType);
+				throw ParseException.Create(errorPos, ErrorMessages.TypeofRequiresAType);
 
 			return constExp;
 		}
@@ -1160,7 +1160,7 @@ namespace DynamicExpresso.Parsing
 				return GenerateConditionalDynamic(test, expr1, expr2,errorPos);
 
 			if (test.Type != typeof(bool))
-				throw CreateParseException(errorPos, ErrorMessages.FirstExprMustBeBool);
+				throw ParseException.Create(errorPos, ErrorMessages.FirstExprMustBeBool);
 			if (expr1.Type != expr2.Type)
 			{
 				var expr1As2 = expr2 != ParserConstants.NullLiteralExpression ? PromoteExpression(expr1, expr2.Type, true) : null;
@@ -1178,9 +1178,9 @@ namespace DynamicExpresso.Parsing
 					var type1 = expr1 != ParserConstants.NullLiteralExpression ? expr1.Type.Name : "null";
 					var type2 = expr2 != ParserConstants.NullLiteralExpression ? expr2.Type.Name : "null";
 					if (expr1As2 != null)
-						throw CreateParseException(errorPos, ErrorMessages.BothTypesConvertToOther, type1, type2);
+						throw ParseException.Create(errorPos, ErrorMessages.BothTypesConvertToOther, type1, type2);
 
-					throw CreateParseException(errorPos, ErrorMessages.NeitherTypeConvertsToOther, type1, type2);
+					throw ParseException.Create(errorPos, ErrorMessages.NeitherTypeConvertsToOther, type1, type2);
 				}
 			}
 			return Expression.Condition(test, expr1, expr2);
@@ -1206,7 +1206,7 @@ namespace DynamicExpresso.Parsing
 			if (newType.IsArray)
 			{
 				if (newType.GetArrayRank() != 1)
-					throw CreateParseException(_token.pos, ErrorMessages.UnsupportedMultidimensionalArrays, newType);
+					throw ParseException.Create(_token.pos, ErrorMessages.UnsupportedMultidimensionalArrays, newType);
 
 				args = ParseArrayInitializerList();
 				return Expression.NewArrayInit(newType.GetElementType(), args);
@@ -1222,10 +1222,10 @@ namespace DynamicExpresso.Parsing
 
 			var applicableConstructors = FindBestMethod(newType.GetConstructors(), args);
 			if (applicableConstructors.Length == 0)
-				throw CreateParseException(_token.pos, ErrorMessages.NoApplicableConstructor, newType);
+				throw ParseException.Create(_token.pos, ErrorMessages.NoApplicableConstructor, newType);
 
 			if (applicableConstructors.Length > 1)
-				throw CreateParseException(_token.pos, ErrorMessages.AmbiguousConstructorInvocation, newType);
+				throw ParseException.Create(_token.pos, ErrorMessages.AmbiguousConstructorInvocation, newType);
 
 			var constructor = applicableConstructors[0];
 			var newExpr = Expression.New((ConstructorInfo)constructor.MethodBase, constructor.PromotedParameters);
@@ -1299,7 +1299,7 @@ namespace DynamicExpresso.Parsing
 				{
 					if (actions.Count > 0)
 					{
-						throw CreateParseException(pos, ErrorMessages.InvalidInitializerMemberDeclarator);
+						throw ParseException.Create(pos, ErrorMessages.InvalidInitializerMemberDeclarator);
 					}
 				}
 				else if (_token.id != TokenId.Equal || _arguments.TryGetIdentifier(propertyOrFieldName, out _) || _arguments.TryGetParameters(propertyOrFieldName, out _))
@@ -1314,7 +1314,7 @@ namespace DynamicExpresso.Parsing
 			}
 			if (member == null)
 			{
-				throw CreateParseException(pos, ErrorMessages.UnknownPropertyOrField, propertyOrFieldName, GetTypeName(newType));
+				throw ParseException.Create(pos, ErrorMessages.UnknownPropertyOrField, propertyOrFieldName, GetTypeName(newType));
 			}
 			NextToken();
 
@@ -1329,11 +1329,11 @@ namespace DynamicExpresso.Parsing
 		{
 			if (!allowCollectionInit)
 			{
-				throw CreateParseException(_token.pos, ErrorMessages.CollectionInitializationNotSupported, newType, typeof(IEnumerable));
+				throw ParseException.Create(_token.pos, ErrorMessages.CollectionInitializationNotSupported, newType, typeof(IEnumerable));
 			}
 			if (bindingList.Count > 0)
 			{
-				throw CreateParseException(originalPos, ErrorMessages.InvalidInitializerMemberDeclarator);
+				throw ParseException.Create(originalPos, ErrorMessages.InvalidInitializerMemberDeclarator);
 			}
 			if (_token.id == TokenId.OpenCurlyBracket)
 			{
@@ -1346,7 +1346,7 @@ namespace DynamicExpresso.Parsing
 					NextToken();
 					if (_token.id == TokenId.Equal && !_arguments.TryGetIdentifier(identifierName, out _) && !_arguments.TryGetParameters(identifierName, out _))
 					{
-						throw CreateParseException(_token.pos, ErrorMessages.InvalidInitializerMemberDeclarator);
+						throw ParseException.Create(_token.pos, ErrorMessages.InvalidInitializerMemberDeclarator);
 					}
 					else
 					{
@@ -1367,7 +1367,7 @@ namespace DynamicExpresso.Parsing
 				var addMethod = ParseNormalMethodInvocation(newType, instance, _token.pos, "Add", args);
 				if (addMethod == null)
 				{
-					throw CreateParseException(_token.pos, ErrorMessages.UnableToFindAppropriateAddMethod, GetTypeName(newType));
+					throw ParseException.Create(_token.pos, ErrorMessages.UnableToFindAppropriateAddMethod, GetTypeName(newType));
 				}
 				actions.Add(addMethod);
 			}
@@ -1389,7 +1389,7 @@ namespace DynamicExpresso.Parsing
 
 			var invokeMethod = FindInvokeMethod(expr.Type);
 			if (invokeMethod == null || !CheckIfMethodIsApplicableAndPrepareIt(invokeMethod, args))
-				throw CreateParseException(errorPos, error);
+				throw ParseException.Create(errorPos, error);
 
 			return Expression.Invoke(expr, invokeMethod.PromotedParameters);
 		}
@@ -1416,10 +1416,10 @@ namespace DynamicExpresso.Parsing
 				applicableMethods = FindBestMethod(candidates.Select(_ => _.InvokeMethod), args);
 
 			if (applicableMethods.Length == 0)
-				throw CreateParseException(errorPos, ErrorMessages.ArgsIncompatibleWithDelegate);
+				throw ParseException.Create(errorPos, ErrorMessages.ArgsIncompatibleWithDelegate);
 
 			if (applicableMethods.Length > 1)
-				throw CreateParseException(errorPos, ErrorMessages.AmbiguousDelegateInvocation);
+				throw ParseException.Create(errorPos, ErrorMessages.AmbiguousDelegateInvocation);
 
 			var applicableMethod = applicableMethods[0];
 			var usedDeledate = candidates.Single(_ => new[] { _.Method, _.InvokeMethod?.MethodBase }.Any(m => m == applicableMethod.MethodBase)).Delegate;
@@ -1492,7 +1492,7 @@ namespace DynamicExpresso.Parsing
 			if (_token.id == TokenId.Question)
 			{
 				if (!type.IsValueType || IsNullableType(type))
-					throw CreateParseException(errorPos, ErrorMessages.TypeHasNoNullableForm, GetTypeName(type));
+					throw ParseException.Create(errorPos, ErrorMessages.TypeHasNoNullableForm, GetTypeName(type));
 				type = typeof(Nullable<>).MakeGenericType(type);
 
 				NextToken();
@@ -1668,7 +1668,7 @@ namespace DynamicExpresso.Parsing
 			}
 			catch (InvalidOperationException)
 			{
-				throw CreateParseException(errorPos, ErrorMessages.CannotConvertValue,
+				throw ParseException.Create(errorPos, ErrorMessages.CannotConvertValue,
 					GetTypeName(exprType), GetTypeName(type));
 			}
 		}
@@ -1703,7 +1703,7 @@ namespace DynamicExpresso.Parsing
 			if (IsDynamicType(type) || IsDynamicExpression(instance))
 				return ParseDynamicProperty(type, instance, propertyOrFieldName);
 
-			throw CreateParseException(errorPos, ErrorMessages.UnknownPropertyOrField, propertyOrFieldName, GetTypeName(type));
+			throw ParseException.Create(errorPos, ErrorMessages.UnknownPropertyOrField, propertyOrFieldName, GetTypeName(type));
 		}
 
 		private Expression ParseMethodInvocation(Type type, Expression instance, int errorPos, string methodName)
@@ -1738,7 +1738,7 @@ namespace DynamicExpresso.Parsing
 
 			var extensionMethods = FindExtensionMethods(id, extensionMethodsArguments);
 			if (extensionMethods.Length > 1)
-				throw CreateParseException(errorPos, ErrorMessages.AmbiguousMethodInvocation, id, GetTypeName(type));
+				throw ParseException.Create(errorPos, ErrorMessages.AmbiguousMethodInvocation, id, GetTypeName(type));
 
 			if (extensionMethods.Length == 1)
 			{
@@ -1756,7 +1756,7 @@ namespace DynamicExpresso.Parsing
 		{
 			var applicableMethods = FindMethods(type, id, instance == null, args);
 			if (applicableMethods.Length > 1)
-				throw CreateParseException(errorPos, ErrorMessages.AmbiguousMethodInvocation, id, GetTypeName(type));
+				throw ParseException.Create(errorPos, ErrorMessages.AmbiguousMethodInvocation, id, GetTypeName(type));
 
 			if (applicableMethods.Length == 1)
 			{
@@ -1863,7 +1863,7 @@ namespace DynamicExpresso.Parsing
 				if (_token.id != TokenId.Comma) break;
 				NextToken();
 				if (!allowTrailingComma && _token.id == closeToken)
-					throw CreateParseException(_token.pos, missingCloseTokenMsg);
+					throw ParseException.Create(_token.pos, missingCloseTokenMsg);
 			}
 			ValidateToken(closeToken, missingCloseTokenMsg);
 			NextToken();
@@ -1884,13 +1884,13 @@ namespace DynamicExpresso.Parsing
 			if (expr.Type.IsArray)
 			{
 				if (expr.Type.GetArrayRank() != args.Length)
-					throw CreateParseException(errorPos, ErrorMessages.IncorrectNumberOfIndexes);
+					throw ParseException.Create(errorPos, ErrorMessages.IncorrectNumberOfIndexes);
 
 				for (int i = 0; i < args.Length; i++)
 				{
 					args[i] = PromoteExpression(args[i], typeof(int), true);
 					if (args[i] == null)
-						throw CreateParseException(errorPos, ErrorMessages.InvalidIndex);
+						throw ParseException.Create(errorPos, ErrorMessages.InvalidIndex);
 				}
 
 				return Expression.ArrayAccess(expr, args);
@@ -1902,13 +1902,13 @@ namespace DynamicExpresso.Parsing
 			var applicableMethods = FindIndexer(expr.Type, args);
 			if (applicableMethods.Length == 0)
 			{
-				throw CreateParseException(errorPos, ErrorMessages.NoApplicableIndexer,
+				throw ParseException.Create(errorPos, ErrorMessages.NoApplicableIndexer,
 					GetTypeName(expr.Type));
 			}
 
 			if (applicableMethods.Length > 1)
 			{
-				throw CreateParseException(errorPos, ErrorMessages.AmbiguousIndexerInvocation,
+				throw ParseException.Create(errorPos, ErrorMessages.AmbiguousIndexerInvocation,
 					GetTypeName(expr.Type));
 			}
 
@@ -2280,13 +2280,13 @@ namespace DynamicExpresso.Parsing
 				method.HasParamsArray = true;
 				var paramsArrayElementType = paramsArrayTypeFound.GetElementType();
 				if (paramsArrayElementType == null)
-					throw CreateParseException(-1, ErrorMessages.ParamsArrayTypeNotAnArray);
+					throw ParseException.Create(-1, ErrorMessages.ParamsArrayTypeNotAnArray);
 
 				if (paramsArrayElementType.IsGenericParameter)
 				{
 					var actualTypes = paramsArrayPromotedArgument.Select(_ => _.Type).Distinct().ToArray();
 					if (actualTypes.Length != 1)
-						throw CreateParseException(-1, ErrorMessages.MethodTypeParametersCantBeInferred, method.MethodBase);
+						throw ParseException.Create(-1, ErrorMessages.MethodTypeParametersCantBeInferred, method.MethodBase);
 
 					paramsArrayElementType = actualTypes[0];
 				}
@@ -2921,7 +2921,7 @@ namespace DynamicExpresso.Parsing
 			var errorPos = _token.pos;
 			var leftType = left.Type;
 			var rightType = right.Type;
-			var error = CreateParseException(errorPos, ErrorMessages.AmbiguousBinaryOperatorInvocation, operatorName, GetTypeName(leftType), GetTypeName(rightType));
+			var error = ParseException.Create(errorPos, ErrorMessages.AmbiguousBinaryOperatorInvocation, operatorName, GetTypeName(leftType), GetTypeName(rightType));
 
 			var args = new[] { left, right };
 
@@ -3218,7 +3218,7 @@ namespace DynamicExpresso.Parsing
 					}
 
 					if (_parsePosition == _expressionTextLength)
-						throw CreateParseException(_parsePosition, ErrorMessages.UnterminatedStringLiteral);
+						throw ParseException.Create(_parsePosition, ErrorMessages.UnterminatedStringLiteral);
 
 					NextChar();
 
@@ -3236,7 +3236,7 @@ namespace DynamicExpresso.Parsing
 					}
 
 					if (_parsePosition == _expressionTextLength)
-						throw CreateParseException(_parsePosition, ErrorMessages.UnterminatedStringLiteral);
+						throw ParseException.Create(_parsePosition, ErrorMessages.UnterminatedStringLiteral);
 
 					NextChar();
 
@@ -3370,7 +3370,7 @@ namespace DynamicExpresso.Parsing
 						t = TokenId.End;
 						break;
 					}
-					throw CreateParseException(_parsePosition, ErrorMessages.InvalidCharacter, _parseChar);
+					throw ParseException.Create(_parsePosition, ErrorMessages.InvalidCharacter, _parseChar);
 			}
 			_token.id = t;
 			_token.text = _expressionText.Substring(tokenPos, _parsePosition - tokenPos);
@@ -3389,31 +3389,26 @@ namespace DynamicExpresso.Parsing
 		private void ValidateDigit()
 		{
 			if (!char.IsDigit(_parseChar))
-				throw CreateParseException(_parsePosition, ErrorMessages.DigitExpected);
+				throw ParseException.Create(_parsePosition, ErrorMessages.DigitExpected);
 		}
 
 		// ReSharper disable once UnusedParameter.Local
 		private void ValidateToken(TokenId t, string errorMessage)
 		{
 			if (_token.id != t)
-				throw CreateParseException(_token.pos, errorMessage);
+				throw ParseException.Create(_token.pos, errorMessage);
 		}
 
 		// ReSharper disable once UnusedParameter.Local
 		private void ValidateToken(TokenId t)
 		{
 			if (_token.id != t)
-				throw CreateParseException(_token.pos, ErrorMessages.SyntaxError);
+				throw ParseException.Create(_token.pos, ErrorMessages.SyntaxError);
 		}
 
 		private static Exception WrapWithParseException(int pos, string format, Exception ex, params object[] args)
 		{
 			return new ParseException(string.Format(format, args), pos, ex);
-		}
-
-		private static Exception CreateParseException(int pos, string format, params object[] args)
-		{
-			return new ParseException(string.Format(format, args), pos);
 		}
 
 		private static Expression GenerateNullableTypeConversion(Expression expr)

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1,14 +1,10 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Dynamic;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
 using System.Text;
 using DynamicExpresso.Exceptions;
 using DynamicExpresso.Reflection;
@@ -2590,71 +2586,5 @@ namespace DynamicExpresso.Parsing
 			var conversionType = typeof(Nullable<>).MakeGenericType(exprType);
 			return Expression.ConvertChecked(expr, conversionType);
 		}
-
-		/// <summary>
-		/// Binds to a member access of an instance as late as possible.  This allows the use of anonymous types on dynamic values.
-		/// </summary>
-		private class LateGetMemberCallSiteBinder : CallSiteBinder
-		{
-			private readonly string _propertyOrFieldName;
-
-			public LateGetMemberCallSiteBinder(string propertyOrFieldName)
-			{
-				_propertyOrFieldName = propertyOrFieldName;
-			}
-
-			public override Expression Bind(object[] args, ReadOnlyCollection<ParameterExpression> parameters, LabelTarget returnLabel)
-			{
-				var binder = Microsoft.CSharp.RuntimeBinder.Binder.GetMember(
-					Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags.None,
-					_propertyOrFieldName,
-					TypeUtils.RemoveArrayType(args[0]?.GetType()),
-					new[] { Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags.None, null) }
-				);
-				return binder.Bind(args, parameters, returnLabel);
-			}
-		}
-
-		/// <summary>
-		/// Binds to a method invocation of an instance as late as possible.  This allows the use of anonymous types on dynamic values.
-		/// </summary>
-		private class LateInvokeMethodCallSiteBinder : CallSiteBinder
-		{
-			private readonly string _methodName;
-
-			public LateInvokeMethodCallSiteBinder(string methodName)
-			{
-				_methodName = methodName;
-			}
-
-			public override Expression Bind(object[] args, ReadOnlyCollection<ParameterExpression> parameters, LabelTarget returnLabel)
-			{
-				var binderM = Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(
-					Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags.None,
-					_methodName,
-					null,
-					TypeUtils.RemoveArrayType(args[0]?.GetType()),
-					parameters.Select(x => Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags.None, null))
-				);
-				return binderM.Bind(args, parameters, returnLabel);
-			}
-		}
-
-		/// <summary>
-		/// Binds to an items invocation of an instance as late as possible.  This allows the use of anonymous types on dynamic values.
-		/// </summary>
-		private class LateInvokeIndexCallSiteBinder : CallSiteBinder
-		{
-			public override Expression Bind(object[] args, ReadOnlyCollection<ParameterExpression> parameters, LabelTarget returnLabel)
-			{
-				var binder = Microsoft.CSharp.RuntimeBinder.Binder.GetIndex(
-					Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags.None,
-					TypeUtils.RemoveArrayType(args[0]?.GetType()),
-					parameters.Select(x => Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags.None, null))
-				);
-				return binder.Bind(args, parameters, returnLabel);
-			}
-		}
-
 	}
 }

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -3496,56 +3496,6 @@ namespace DynamicExpresso.Parsing
 			}
 		}
 
-		private class MethodData
-		{
-			public MethodBase MethodBase;
-			public ParameterInfo[] Parameters;
-			public Expression[] PromotedParameters;
-			public bool HasParamsArray;
-
-			public static MethodData Gen(MethodBase method)
-			{
-				return new MethodData
-				{
-					MethodBase = method,
-					Parameters = method.GetParameters()
-				};
-			}
-
-			public override string ToString()
-			{
-				return MethodBase.ToString();
-			}
-		}
-
-		private class IndexerData : MethodData
-		{
-			public readonly PropertyInfo Indexer;
-
-			public IndexerData(PropertyInfo indexer)
-			{
-				Indexer = indexer;
-
-				var method = indexer.GetGetMethod();
-				if (method != null)
-				{
-					Parameters = method.GetParameters();
-				}
-				else
-				{
-					method = indexer.GetSetMethod();
-					Parameters = RemoveLast(method.GetParameters());
-				}
-			}
-
-			private static T[] RemoveLast<T>(T[] array)
-			{
-				T[] result = new T[array.Length - 1];
-				Array.Copy(array, 0, result, 0, result.Length);
-				return result;
-			}
-		}
-
 		/// <summary>
 		/// Binds to a member access of an instance as late as possible.  This allows the use of anonymous types on dynamic values.
 		/// </summary>

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -39,31 +39,6 @@ namespace DynamicExpresso.Parsing
 
 		private readonly ParserArguments _arguments;
 
-		private static readonly MethodInfo _concatMethod = GetConcatMethod();
-		private static readonly MethodInfo _toStringMethod = GetToStringMethod();
-
-		private static MethodInfo GetConcatMethod()
-		{
-			var methodInfo = typeof(string).GetMethod("Concat", new[] {typeof(string), typeof(string)});
-			if (methodInfo == null)
-			{
-				throw new Exception("String concat method not found");
-			}
-
-			return methodInfo;
-		}
-
-		private static MethodInfo GetToStringMethod()
-		{
-			var toStringMethod = typeof(object).GetMethod("ToString", Type.EmptyTypes);
-			if (toStringMethod == null)
-			{
-				throw new Exception("ToString method not found");
-			}
-
-			return toStringMethod;
-		}
-
 		// Working context implementation
 		//ParameterExpression it;
 
@@ -2647,7 +2622,7 @@ namespace DynamicExpresso.Parsing
 
 			return Expression.Call(
 				null,
-				_concatMethod,
+				ReflectionExtensions.StringConcatMethod,
 				new[] { leftObj, rightObj });
 		}
 
@@ -2667,7 +2642,7 @@ namespace DynamicExpresso.Parsing
 			return Expression.Condition(
 				condition,
 				stringNullConstant,
-				Expression.Call(expression, _toStringMethod));
+				Expression.Call(expression, ReflectionExtensions.ObjectToStringMethod));
 		}
 
 		private static Expression GenerateStringConcatOperand(Expression expression)

--- a/src/DynamicExpresso.Core/Reflection/IndexerData.cs
+++ b/src/DynamicExpresso.Core/Reflection/IndexerData.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Reflection;
+
+namespace DynamicExpresso.Reflection
+{
+	internal class IndexerData : MethodData
+	{
+		public readonly PropertyInfo Indexer;
+
+		public IndexerData(PropertyInfo indexer)
+		{
+			Indexer = indexer;
+
+			var method = indexer.GetGetMethod();
+			if (method != null)
+			{
+				Parameters = method.GetParameters();
+			}
+			else
+			{
+				method = indexer.GetSetMethod();
+				Parameters = RemoveLast(method.GetParameters());
+			}
+		}
+
+		private static T[] RemoveLast<T>(T[] array)
+		{
+			var result = new T[array.Length - 1];
+			Array.Copy(array, 0, result, 0, result.Length);
+			return result;
+		}
+	}
+}

--- a/src/DynamicExpresso.Core/Reflection/MemberFinder.cs
+++ b/src/DynamicExpresso.Core/Reflection/MemberFinder.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using DynamicExpresso.Resolution;
+
+namespace DynamicExpresso.Reflection
+{
+	internal class MemberFinder
+	{
+		private readonly ParserArguments _arguments;
+		private readonly BindingFlags _bindingCase;
+		private readonly MemberFilter _memberFilterCase;
+
+		public MemberFinder(ParserArguments arguments)
+		{
+			_arguments = arguments;
+			_bindingCase = arguments.Settings.CaseInsensitive ? BindingFlags.IgnoreCase : BindingFlags.Default;
+			_memberFilterCase = arguments.Settings.CaseInsensitive ? Type.FilterNameIgnoreCase : Type.FilterName;
+		}
+
+		public MemberInfo FindPropertyOrField(Type type, string memberName, bool staticAccess)
+		{
+			var flags = BindingFlags.Public | BindingFlags.DeclaredOnly |
+						(staticAccess ? BindingFlags.Static : BindingFlags.Instance) | _bindingCase;
+
+			foreach (var t in SelfAndBaseTypes(type))
+			{
+				var members = t.FindMembers(MemberTypes.Property | MemberTypes.Field, flags, _memberFilterCase, memberName);
+				if (members.Length != 0)
+					return members[0];
+			}
+			return null;
+		}
+
+		public MethodData[] FindMethods(Type type, string methodName, bool staticAccess, Expression[] args)
+		{
+			var flags = BindingFlags.Public | BindingFlags.DeclaredOnly |
+						(staticAccess ? BindingFlags.Static : BindingFlags.Instance) | _bindingCase;
+			foreach (var t in SelfAndBaseTypes(type))
+			{
+				var members = t.FindMembers(MemberTypes.Method, flags, _memberFilterCase, methodName);
+				var applicableMethods = MethodResolution.FindBestMethod(members.Cast<MethodBase>(), args);
+
+				if (applicableMethods.Length > 0)
+					return applicableMethods;
+			}
+
+			return new MethodData[0];
+		}
+
+		public MethodData FindInvokeMethod(Type type)
+		{
+			var flags = BindingFlags.Public | BindingFlags.DeclaredOnly |
+						BindingFlags.Instance | _bindingCase;
+			foreach (var t in SelfAndBaseTypes(type))
+			{
+				var method = t.FindMembers(MemberTypes.Method, flags, _memberFilterCase, "Invoke")
+					.Cast<MethodBase>()
+					.SingleOrDefault();
+
+				if (method != null)
+					return MethodData.Gen(method);
+			}
+
+			return null;
+		}
+
+		public MethodData[] FindExtensionMethods(string methodName, Expression[] args)
+		{
+			var matchMethods = _arguments.GetExtensionMethods(methodName);
+
+			return MethodResolution.FindBestMethod(matchMethods, args);
+		}
+
+		public MethodData[] FindIndexer(Type type, Expression[] args)
+		{
+			foreach (var t in SelfAndBaseTypes(type))
+			{
+				var members = t.GetDefaultMembers();
+				if (members.Length != 0)
+				{
+					var methods = members.
+						OfType<PropertyInfo>().
+						Select(p => (MethodData)new IndexerData(p));
+
+					var applicableMethods = MethodResolution.FindBestMethod(methods, args);
+					if (applicableMethods.Length > 0)
+						return applicableMethods;
+				}
+			}
+
+			return new MethodData[0];
+		}
+
+		private static IEnumerable<Type> SelfAndBaseTypes(Type type)
+		{
+			if (type.IsInterface)
+			{
+				var types = new List<Type>();
+				AddInterface(types, type);
+
+				types.Add(typeof(object));
+
+				return types;
+			}
+			return SelfAndBaseClasses(type);
+		}
+
+		private static IEnumerable<Type> SelfAndBaseClasses(Type type)
+		{
+			while (type != null)
+			{
+				yield return type;
+				type = type.BaseType;
+			}
+		}
+
+		private static void AddInterface(List<Type> types, Type type)
+		{
+			if (!types.Contains(type))
+			{
+				types.Add(type);
+				foreach (var t in type.GetInterfaces())
+				{
+					AddInterface(types, t);
+				}
+			}
+		}
+	}
+}

--- a/src/DynamicExpresso.Core/Reflection/MethodData.cs
+++ b/src/DynamicExpresso.Core/Reflection/MethodData.cs
@@ -1,0 +1,27 @@
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace DynamicExpresso.Reflection
+{
+	internal class MethodData
+	{
+		public MethodBase MethodBase;
+		public ParameterInfo[] Parameters;
+		public Expression[] PromotedParameters;
+		public bool HasParamsArray;
+
+		public static MethodData Gen(MethodBase method)
+		{
+			return new MethodData
+			{
+				MethodBase = method,
+				Parameters = method.GetParameters()
+			};
+		}
+
+		public override string ToString()
+		{
+			return MethodBase.ToString();
+		}
+	}
+}

--- a/src/DynamicExpresso.Core/Reflection/ReflectionExtensions.cs
+++ b/src/DynamicExpresso.Core/Reflection/ReflectionExtensions.cs
@@ -7,6 +7,9 @@ namespace DynamicExpresso.Reflection
 {
 	internal static class ReflectionExtensions
 	{
+		public static readonly MethodInfo StringConcatMethod = GetStringConcatMethod();
+		public static readonly MethodInfo ObjectToStringMethod = GetObjectToStringMethod();
+
 		public static DelegateInfo GetDelegateInfo(Type delegateType, params string[] parametersNames)
 		{
 			MethodInfo method = delegateType.GetMethod("Invoke");
@@ -55,6 +58,28 @@ namespace DynamicExpresso.Reflection
 
 			public Type ReturnType { get; private set; }
 			public Parameter[] Parameters { get; private set; }
+		}
+
+		private static MethodInfo GetStringConcatMethod()
+		{
+			var methodInfo = typeof(string).GetMethod("Concat", new[] { typeof(string), typeof(string) });
+			if (methodInfo == null)
+			{
+				throw new Exception("String concat method not found");
+			}
+
+			return methodInfo;
+		}
+
+		private static MethodInfo GetObjectToStringMethod()
+		{
+			var toStringMethod = typeof(object).GetMethod("ToString", Type.EmptyTypes);
+			if (toStringMethod == null)
+			{
+				throw new Exception("ToString method not found");
+			}
+
+			return toStringMethod;
 		}
 
 		public static Type GetFuncType(int parameterCount)

--- a/src/DynamicExpresso.Core/Reflection/ReflectionExtensions.cs
+++ b/src/DynamicExpresso.Core/Reflection/ReflectionExtensions.cs
@@ -67,5 +67,19 @@ namespace DynamicExpresso.Reflection
 		{
 			return typeof(Action<>).Assembly.GetType($"System.Action`{parameterCount}");
 		}
+
+		public static bool HasParamsArrayType(ParameterInfo parameterInfo)
+		{
+			return parameterInfo.IsDefined(typeof(ParamArrayAttribute), false);
+		}
+
+		public static Type GetParameterType(ParameterInfo parameterInfo)
+		{
+			var isParamsArray = HasParamsArrayType(parameterInfo);
+			var type = isParamsArray
+				? parameterInfo.ParameterType.GetElementType()
+				: parameterInfo.ParameterType;
+			return type;
+		}
 	}
 }

--- a/src/DynamicExpresso.Core/Reflection/TypeUtils.cs
+++ b/src/DynamicExpresso.Core/Reflection/TypeUtils.cs
@@ -1,0 +1,315 @@
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace DynamicExpresso.Reflection
+{
+	internal static class TypeUtils
+	{
+		public static bool IsNullableType(Type type)
+		{
+			return Nullable.GetUnderlyingType(type) != null;
+		}
+
+		public static bool IsDynamicType(Type type)
+		{
+			return typeof(IDynamicMetaObjectProvider).IsAssignableFrom(type);
+		}
+
+		public static Type GetNonNullableType(Type type)
+		{
+			return IsNullableType(type) ? type.GetGenericArguments()[0] : type;
+		}
+
+		public static string GetTypeName(Type type)
+		{
+			var baseType = GetNonNullableType(type);
+			var s = baseType.Name;
+			if (type != baseType) s += '?';
+			return s;
+		}
+
+		public static bool IsNumericType(Type type)
+		{
+			return GetNumericTypeKind(type) != 0;
+		}
+
+		public static bool IsSignedIntegralType(Type type)
+		{
+			return GetNumericTypeKind(type) == 2;
+		}
+
+		public static bool IsUnsignedIntegralType(Type type)
+		{
+			return GetNumericTypeKind(type) == 3;
+		}
+
+		private static int GetNumericTypeKind(Type type)
+		{
+			type = GetNonNullableType(type);
+			if (type.IsEnum) return 0;
+			switch (Type.GetTypeCode(type))
+			{
+				case TypeCode.Char:
+				case TypeCode.Single:
+				case TypeCode.Double:
+				case TypeCode.Decimal:
+					return 1;
+				case TypeCode.SByte:
+				case TypeCode.Int16:
+				case TypeCode.Int32:
+				case TypeCode.Int64:
+					return 2;
+				case TypeCode.Byte:
+				case TypeCode.UInt16:
+				case TypeCode.UInt32:
+				case TypeCode.UInt64:
+					return 3;
+				default:
+					return 0;
+			}
+		}
+
+		public static bool IsCompatibleWith(Type source, Type target)
+		{
+			if (source == target)
+			{
+				return true;
+			}
+
+			if (target.IsGenericParameter)
+			{
+				return true;
+			}
+
+			if (!target.IsValueType)
+			{
+				return target.IsAssignableFrom(source);
+			}
+			var st = GetNonNullableType(source);
+			var tt = GetNonNullableType(target);
+			if (st != source && tt == target) return false;
+			var sc = st.IsEnum ? TypeCode.Object : Type.GetTypeCode(st);
+			var tc = tt.IsEnum ? TypeCode.Object : Type.GetTypeCode(tt);
+			switch (sc)
+			{
+				case TypeCode.SByte:
+					switch (tc)
+					{
+						case TypeCode.SByte:
+						case TypeCode.Int16:
+						case TypeCode.Int32:
+						case TypeCode.Int64:
+						case TypeCode.Single:
+						case TypeCode.Double:
+						case TypeCode.Decimal:
+							return true;
+					}
+					break;
+				case TypeCode.Byte:
+					switch (tc)
+					{
+						case TypeCode.Byte:
+						case TypeCode.Int16:
+						case TypeCode.UInt16:
+						case TypeCode.Int32:
+						case TypeCode.UInt32:
+						case TypeCode.Int64:
+						case TypeCode.UInt64:
+						case TypeCode.Single:
+						case TypeCode.Double:
+						case TypeCode.Decimal:
+							return true;
+					}
+					break;
+				case TypeCode.Int16:
+					switch (tc)
+					{
+						case TypeCode.Int16:
+						case TypeCode.Int32:
+						case TypeCode.Int64:
+						case TypeCode.Single:
+						case TypeCode.Double:
+						case TypeCode.Decimal:
+							return true;
+					}
+					break;
+				case TypeCode.UInt16:
+					switch (tc)
+					{
+						case TypeCode.UInt16:
+						case TypeCode.Int32:
+						case TypeCode.UInt32:
+						case TypeCode.Int64:
+						case TypeCode.UInt64:
+						case TypeCode.Single:
+						case TypeCode.Double:
+						case TypeCode.Decimal:
+							return true;
+					}
+					break;
+				case TypeCode.Int32:
+					switch (tc)
+					{
+						case TypeCode.Int32:
+						case TypeCode.Int64:
+						case TypeCode.Single:
+						case TypeCode.Double:
+						case TypeCode.Decimal:
+							return true;
+					}
+					break;
+				case TypeCode.UInt32:
+					switch (tc)
+					{
+						case TypeCode.UInt32:
+						case TypeCode.Int64:
+						case TypeCode.UInt64:
+						case TypeCode.Single:
+						case TypeCode.Double:
+						case TypeCode.Decimal:
+							return true;
+					}
+					break;
+				case TypeCode.Int64:
+					switch (tc)
+					{
+						case TypeCode.Int64:
+						case TypeCode.Single:
+						case TypeCode.Double:
+						case TypeCode.Decimal:
+							return true;
+					}
+					break;
+				case TypeCode.UInt64:
+					switch (tc)
+					{
+						case TypeCode.UInt64:
+						case TypeCode.Single:
+						case TypeCode.Double:
+						case TypeCode.Decimal:
+							return true;
+					}
+					break;
+				case TypeCode.Single:
+					switch (tc)
+					{
+						case TypeCode.Single:
+						case TypeCode.Double:
+							return true;
+					}
+					break;
+				default:
+					if (st == tt) return true;
+					break;
+			}
+			return false;
+		}
+
+		// Return 1 if s -> t1 is a better conversion than s -> t2
+		// Return -1 if s -> t2 is a better conversion than s -> t1
+		// Return 0 if neither conversion is better
+		public static int CompareConversions(Type s, Type t1, Type t2)
+		{
+			if (t1 == t2) return 0;
+			if (s == t1) return 1;
+			if (s == t2) return -1;
+
+			var assignableT1 = t1.IsAssignableFrom(s);
+			var assignableT2 = t2.IsAssignableFrom(s);
+			if (assignableT1 && !assignableT2) return 1;
+			if (assignableT2 && !assignableT1) return -1;
+
+			var compatibleT1T2 = IsCompatibleWith(t1, t2);
+			var compatibleT2T1 = IsCompatibleWith(t2, t1);
+			if (compatibleT1T2 && !compatibleT2T1) return 1;
+			if (compatibleT2T1 && !compatibleT1T2) return -1;
+
+			if (IsSignedIntegralType(t1) && IsUnsignedIntegralType(t2)) return 1;
+			if (IsSignedIntegralType(t2) && IsUnsignedIntegralType(t1)) return -1;
+
+			return 0;
+		}
+
+		/// <summary>
+		/// Returns null if <paramref name="t"/> is an Array type.  Needed because the <seealso cref="Microsoft.CSharp.RuntimeBinder.Binder"/> lookup methods fail with a <seealso cref="InvalidCastException"/> if the array type is used.
+		/// Everything still miraculously works on the array if null is given for the type.
+		/// </summary>
+		/// <param name="t"></param>
+		/// <returns></returns>
+		public static Type RemoveArrayType(Type t)
+		{
+			if (t == null || t.IsArray)
+			{
+				return null;
+			}
+			return t;
+		}
+
+		// from http://stackoverflow.com/a/1075059/209727
+		public static Type FindAssignableGenericType(Type givenType, Type constructedGenericType)
+		{
+			var genericTypeDefinition = constructedGenericType.GetGenericTypeDefinition();
+			var interfaceTypes = givenType.GetInterfaces();
+
+			foreach (var it in interfaceTypes)
+			{
+				if (it.IsGenericType && it.GetGenericTypeDefinition() == genericTypeDefinition)
+				{
+					return it;
+				}
+			}
+
+			if (givenType.IsGenericType && givenType.GetGenericTypeDefinition() == genericTypeDefinition)
+			{
+				// the given type has the same generic type of the fully constructed generic type
+				//  => check if the generic arguments are compatible (e.g. Nullable<int> and Nullable<DateTime>: int is not compatible with DateTime)
+				var givenTypeGenericsArgs = givenType.GenericTypeArguments;
+				var constructedGenericsArgs = constructedGenericType.GenericTypeArguments;
+				if (givenTypeGenericsArgs.Zip(constructedGenericsArgs, (g, c) => TypeUtils.IsCompatibleWith(g, c)).Any(compatible => !compatible))
+					return null;
+
+				return givenType;
+			}
+
+			var baseType = givenType.BaseType;
+			if (baseType == null)
+				return null;
+
+			return FindAssignableGenericType(baseType, genericTypeDefinition);
+		}
+
+		public static Type GetConcreteTypeForGenericMethod(Type type, List<Expression> promotedArgs, MethodData method)
+		{
+			if (type.IsGenericType)
+			{
+				//Generic<T> type
+				var genericArguments = type.GetGenericArguments();
+				var concreteTypeParameters = new Type[genericArguments.Length];
+
+				for (var i = 0; i < genericArguments.Length; i++)
+				{
+					concreteTypeParameters[i] = GetConcreteTypeForGenericMethod(genericArguments[i], promotedArgs, method);
+				}
+
+				return type.GetGenericTypeDefinition().MakeGenericType(concreteTypeParameters);
+			}
+			else if (type.ContainsGenericParameters)
+			{
+				//T case
+				//try finding an actual parameter for the generic
+				for (var i = 0; i < promotedArgs.Count; i++)
+				{
+					if (method.Parameters[i].ParameterType == type)
+					{
+						return promotedArgs[i].Type;
+					}
+				}
+			}
+
+			return type;//already a concrete type
+		}
+	}
+}

--- a/src/DynamicExpresso.Core/Resolution/ExpressionUtils.cs
+++ b/src/DynamicExpresso.Core/Resolution/ExpressionUtils.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Linq.Expressions;
+using DynamicExpresso.Parsing;
+using DynamicExpresso.Reflection;
+
+namespace DynamicExpresso.Resolution
+{
+	internal static class ExpressionUtils
+	{
+		public static Expression PromoteExpression(Expression expr, Type type, bool exact)
+		{
+			if (expr.Type == type) return expr;
+			if (expr is ConstantExpression)
+			{
+				var ce = (ConstantExpression)expr;
+				if (ce == ParserConstants.NullLiteralExpression)
+				{
+					if (type.ContainsGenericParameters)
+						return null;
+					if (!type.IsValueType || TypeUtils.IsNullableType(type))
+						return Expression.Constant(null, type);
+				}
+			}
+
+			if (expr is InterpreterExpression ie)
+			{
+				if (!ie.IsCompatibleWithDelegate(type))
+					return null;
+
+				if (!type.ContainsGenericParameters)
+					return ie.EvalAs(type);
+
+				return expr;
+			}
+
+			if (type.IsGenericType && !TypeUtils.IsNumericType(type))
+			{
+				var genericType = TypeUtils.FindAssignableGenericType(expr.Type, type);
+				if (genericType != null)
+					return Expression.Convert(expr, genericType);
+			}
+
+			if (TypeUtils.IsCompatibleWith(expr.Type, type) || expr is DynamicExpression)
+			{
+				if (type.IsValueType || exact)
+				{
+					return Expression.Convert(expr, type);
+				}
+				return expr;
+			}
+
+			return null;
+		}
+	}
+}

--- a/src/DynamicExpresso.Core/Resolution/LateBinders.cs
+++ b/src/DynamicExpresso.Core/Resolution/LateBinders.cs
@@ -1,0 +1,71 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using DynamicExpresso.Reflection;
+using Microsoft.CSharp.RuntimeBinder;
+
+namespace DynamicExpresso.Resolution
+{
+	internal class LateGetMemberCallSiteBinder : CallSiteBinder
+	{
+		private readonly string _propertyOrFieldName;
+
+		public LateGetMemberCallSiteBinder(string propertyOrFieldName)
+		{
+			_propertyOrFieldName = propertyOrFieldName;
+		}
+
+		public override Expression Bind(object[] args, ReadOnlyCollection<ParameterExpression> parameters, LabelTarget returnLabel)
+		{
+			var binder = Binder.GetMember(
+				CSharpBinderFlags.None,
+				_propertyOrFieldName,
+				TypeUtils.RemoveArrayType(args[0]?.GetType()),
+				new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) }
+			);
+			return binder.Bind(args, parameters, returnLabel);
+		}
+	}
+
+	/// <summary>
+	/// Binds to a method invocation of an instance as late as possible.  This allows the use of anonymous types on dynamic values.
+	/// </summary>
+	internal class LateInvokeMethodCallSiteBinder : CallSiteBinder
+	{
+		private readonly string _methodName;
+
+		public LateInvokeMethodCallSiteBinder(string methodName)
+		{
+			_methodName = methodName;
+		}
+
+		public override Expression Bind(object[] args, ReadOnlyCollection<ParameterExpression> parameters, LabelTarget returnLabel)
+		{
+			var binderM = Binder.InvokeMember(
+				CSharpBinderFlags.None,
+				_methodName,
+				null,
+				TypeUtils.RemoveArrayType(args[0]?.GetType()),
+				parameters.Select(x => CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null))
+			);
+			return binderM.Bind(args, parameters, returnLabel);
+		}
+	}
+
+	/// <summary>
+	/// Binds to an items invocation of an instance as late as possible.  This allows the use of anonymous types on dynamic values.
+	/// </summary>
+	internal class LateInvokeIndexCallSiteBinder : CallSiteBinder
+	{
+		public override Expression Bind(object[] args, ReadOnlyCollection<ParameterExpression> parameters, LabelTarget returnLabel)
+		{
+			var binder = Binder.GetIndex(
+				CSharpBinderFlags.None,
+				TypeUtils.RemoveArrayType(args[0]?.GetType()),
+				parameters.Select(x => CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null))
+			);
+			return binder.Bind(args, parameters, returnLabel);
+		}
+	}
+}

--- a/src/DynamicExpresso.Core/Resolution/MethodResolution.cs
+++ b/src/DynamicExpresso.Core/Resolution/MethodResolution.cs
@@ -1,0 +1,333 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Linq;
+using System.Reflection;
+using System.Security;
+using System.Text;
+using DynamicExpresso.Exceptions;
+using DynamicExpresso.Parsing;
+using DynamicExpresso.Reflection;
+using DynamicExpresso.Resources;
+
+namespace DynamicExpresso.Resolution
+{
+	internal static class MethodResolution
+	{
+		public static MethodData[] FindBestMethod(IEnumerable<MethodBase> methods, Expression[] args)
+		{
+			return FindBestMethod(methods.Select(MethodData.Gen), args);
+		}
+
+		public static MethodData[] FindBestMethod(IEnumerable<MethodData> methods, Expression[] args)
+		{
+			var applicable = methods.
+				Where(m => CheckIfMethodIsApplicableAndPrepareIt(m, args)).
+				ToArray();
+			if (applicable.Length > 1)
+			{
+				var bestCandidates = applicable
+					.Where(m => applicable.All(n => m == n || MethodHasPriority(args, m, n)))
+					.ToArray();
+
+				// bestCandidates.Length == 0 means that no applicable method has priority
+				// we don't return bestCandidates to prevent callers from thinking no method was found
+				if (bestCandidates.Length > 0)
+					return bestCandidates;
+			}
+
+			return applicable;
+		}
+
+		public static bool CheckIfMethodIsApplicableAndPrepareIt(MethodData method, Expression[] args)
+		{
+			if (method.Parameters.Count(y => !y.HasDefaultValue && !ReflectionExtensions.HasParamsArrayType(y)) > args.Length)
+				return false;
+
+			var promotedArgs = new List<Expression>();
+			var declaredWorkingParameters = 0;
+
+			Type paramsArrayTypeFound = null;
+			List<Expression> paramsArrayPromotedArgument = null;
+
+			foreach (var currentArgument in args)
+			{
+				Type parameterType;
+
+				if (paramsArrayTypeFound != null)
+				{
+					parameterType = paramsArrayTypeFound;
+				}
+				else
+				{
+					if (declaredWorkingParameters >= method.Parameters.Length)
+					{
+						return false;
+					}
+
+					var parameterDeclaration = method.Parameters[declaredWorkingParameters];
+					if (parameterDeclaration.IsOut)
+					{
+						return false;
+					}
+
+					parameterType = parameterDeclaration.ParameterType;
+
+					if (ReflectionExtensions.HasParamsArrayType(parameterDeclaration))
+					{
+						paramsArrayTypeFound = parameterType;
+					}
+
+					declaredWorkingParameters++;
+				}
+
+				if (paramsArrayPromotedArgument == null && (paramsArrayTypeFound == null || args.Length == method.Parameters.Length))
+				{
+					if (parameterType.IsGenericParameter)
+					{
+						// an interpreter expression can only be matched to a parameter of type Func
+						if (currentArgument is InterpreterExpression)
+							return false;
+
+						promotedArgs.Add(currentArgument);
+						continue;
+					}
+
+					var promoted = ExpressionUtils.PromoteExpression(currentArgument, parameterType, true);
+					if (promoted != null)
+					{
+						promotedArgs.Add(promoted);
+						continue;
+					}
+				}
+
+				if (paramsArrayTypeFound != null)
+				{
+					var paramsArrayElementType = paramsArrayTypeFound.GetElementType();
+					if (paramsArrayElementType.IsGenericParameter)
+					{
+						paramsArrayPromotedArgument = paramsArrayPromotedArgument ?? new List<Expression>();
+						paramsArrayPromotedArgument.Add(currentArgument);
+						continue;
+					}
+
+					var promoted = ExpressionUtils.PromoteExpression(currentArgument, paramsArrayElementType, true);
+					if (promoted != null)
+					{
+						paramsArrayPromotedArgument = paramsArrayPromotedArgument ?? new List<Expression>();
+						paramsArrayPromotedArgument.Add(promoted);
+						continue;
+					}
+				}
+
+				return false;
+			}
+
+			if (paramsArrayPromotedArgument != null)
+			{
+				method.HasParamsArray = true;
+				var paramsArrayElementType = paramsArrayTypeFound.GetElementType();
+				if (paramsArrayElementType == null)
+					throw ParseException.Create(-1, ErrorMessages.ParamsArrayTypeNotAnArray);
+
+				if (paramsArrayElementType.IsGenericParameter)
+				{
+					var actualTypes = paramsArrayPromotedArgument.Select(_ => _.Type).Distinct().ToArray();
+					if (actualTypes.Length != 1)
+						throw ParseException.Create(-1, ErrorMessages.MethodTypeParametersCantBeInferred, method.MethodBase);
+
+					paramsArrayElementType = actualTypes[0];
+				}
+
+				promotedArgs.Add(Expression.NewArrayInit(paramsArrayElementType, paramsArrayPromotedArgument));
+			}
+
+			// Add default params, if needed.
+			promotedArgs.AddRange(method.Parameters.Skip(promotedArgs.Count).Select<ParameterInfo, Expression>(x =>
+			{
+				if (x.HasDefaultValue)
+				{
+					var parameterType = TypeUtils.GetConcreteTypeForGenericMethod(x.ParameterType, promotedArgs, method);
+
+					return Expression.Constant(x.DefaultValue, parameterType);
+				}
+
+
+				if (ReflectionExtensions.HasParamsArrayType(x))
+				{
+					method.HasParamsArray = true;
+					return Expression.NewArrayInit(x.ParameterType.GetElementType());
+				}
+
+				throw new Exception("No default value found!");
+			}));
+
+			method.PromotedParameters = promotedArgs.ToArray();
+
+			if (method.MethodBase != null && method.MethodBase.IsGenericMethodDefinition &&
+				method.MethodBase is MethodInfo)
+			{
+				var genericMethod = MakeGenericMethod(method);
+				if (genericMethod == null)
+					return false;
+
+				// we have all the type information we can get, update interpreter expressions and evaluate them
+				var actualMethodParameters = genericMethod.GetParameters();
+				for (var i = 0; i < method.PromotedParameters.Length; i++)
+				{
+					if (method.PromotedParameters[i] is InterpreterExpression ie)
+					{
+						var actualParamInfo = actualMethodParameters[i];
+						var lambdaExpr = ie.EvalAs(actualParamInfo.ParameterType);
+						if (lambdaExpr == null)
+							return false;
+
+						method.PromotedParameters[i] = lambdaExpr;
+
+						// we have inferred all types, update the method definition
+						genericMethod = MakeGenericMethod(method);
+					}
+				}
+
+				method.MethodBase = genericMethod;
+			}
+
+			return true;
+		}
+
+		private static bool MethodHasPriority(Expression[] args, MethodData method, MethodData otherMethod)
+		{
+			var better = false;
+
+			// check conversion from argument list to parameter list
+			for (int i = 0, m = 0, o = 0; i < args.Length; i++)
+			{
+				var arg = args[i];
+				var methodParam = method.Parameters[m];
+				var otherMethodParam = otherMethod.Parameters[o];
+				var methodParamType = ReflectionExtensions.GetParameterType(methodParam);
+				var otherMethodParamType = ReflectionExtensions.GetParameterType(otherMethodParam);
+
+				if (methodParamType.ContainsGenericParameters)
+					methodParamType = method.PromotedParameters[i].Type;
+
+				if (otherMethodParamType.ContainsGenericParameters)
+					otherMethodParamType = otherMethod.PromotedParameters[i].Type;
+
+				var c = TypeUtils.CompareConversions(arg.Type, methodParamType, otherMethodParamType);
+				if (c < 0)
+					return false;
+				if (c > 0)
+					better = true;
+
+				if (!ReflectionExtensions.HasParamsArrayType(methodParam)) m++;
+				if (!ReflectionExtensions.HasParamsArrayType(otherMethodParam)) o++;
+			}
+
+			if (better)
+				return true;
+
+			if (method.MethodBase != null &&
+				otherMethod.MethodBase != null &&
+				!method.MethodBase.IsGenericMethod &&
+				otherMethod.MethodBase.IsGenericMethod)
+				return true;
+
+			if (!method.HasParamsArray && otherMethod.HasParamsArray)
+				return true;
+
+			// if a method has a params parameter, it can have less parameters than the number of arguments
+			if (method.HasParamsArray && otherMethod.HasParamsArray && method.Parameters.Length > otherMethod.Parameters.Length)
+				return true;
+
+			if (method is IndexerData indexer && otherMethod is IndexerData otherIndexer)
+			{
+				var declaringType = indexer.Indexer.DeclaringType;
+				var otherDeclaringType = otherIndexer.Indexer.DeclaringType;
+
+				var isOtherIndexerIsInParentType = otherDeclaringType.IsAssignableFrom(declaringType);
+				if (isOtherIndexerIsInParentType)
+				{
+					var isIndexerIsInDescendantType = !declaringType.IsAssignableFrom(otherDeclaringType);
+					return isIndexerIsInDescendantType;
+				}
+			}
+
+			return better;
+		}
+
+		private static MethodInfo MakeGenericMethod(MethodData method)
+		{
+			var methodInfo = (MethodInfo)method.MethodBase;
+			var actualGenericArgs = ExtractActualGenericArguments(
+				method.Parameters.Select(p => p.ParameterType).ToArray(),
+				method.PromotedParameters.Select(p => p.Type).ToArray());
+
+			var genericArgs = methodInfo.GetGenericArguments()
+				.Select(p => actualGenericArgs.TryGetValue(p.Name, out var typ) ? typ : typeof(object))
+				.ToArray();
+
+			MethodInfo genericMethod = null;
+			try
+			{
+				genericMethod = methodInfo.MakeGenericMethod(genericArgs);
+			}
+			catch (ArgumentException e) when (e.InnerException is VerificationException)
+			{
+				// this exception is thrown when a generic argument violates the generic constraints
+				return null;
+			}
+
+			return genericMethod;
+		}
+
+		private static Dictionary<string, Type> ExtractActualGenericArguments(
+			Type[] methodGenericParameters,
+			Type[] methodActualParameters)
+		{
+			var extractedGenericTypes = new Dictionary<string, Type>();
+
+			for (var i = 0; i < methodGenericParameters.Length; i++)
+			{
+				var requestedType = methodGenericParameters[i];
+				var actualType = methodActualParameters[i];
+
+				if (requestedType.IsGenericParameter)
+				{
+					if (!actualType.IsGenericParameter)
+						extractedGenericTypes[requestedType.Name] = actualType;
+				}
+				else if (requestedType.IsArray && actualType.IsArray)
+				{
+					var innerGenericTypes = ExtractActualGenericArguments(
+						new[] { requestedType.GetElementType() },
+						new[] { actualType.GetElementType()
+					});
+
+					foreach (var innerGenericType in innerGenericTypes)
+						extractedGenericTypes[innerGenericType.Key] = innerGenericType.Value;
+				}
+				else if (requestedType.ContainsGenericParameters)
+				{
+					if (actualType.IsGenericParameter)
+					{
+						extractedGenericTypes[actualType.Name] = requestedType;
+					}
+					else
+					{
+						var requestedInnerGenericArgs = requestedType.GetGenericArguments();
+						var actualInnerGenericArgs = actualType.GetGenericArguments();
+						if (requestedInnerGenericArgs.Length != actualInnerGenericArgs.Length)
+							continue;
+
+						var innerGenericTypes = ExtractActualGenericArguments(requestedInnerGenericArgs, actualInnerGenericArgs);
+						foreach (var innerGenericType in innerGenericTypes)
+							extractedGenericTypes[innerGenericType.Key] = innerGenericType.Value;
+					}
+				}
+			}
+
+			return extractedGenericTypes;
+		}
+	}
+}


### PR DESCRIPTION
The `Parser.cs` class is huge, which prevents code reuse: for example, we could imagine reuse the resolution logic in the late binders for dynamic objects.

In any case, having smaller files should make the code easier to understand. Let me know what you think :)

The PR has been split into several smaller commits to make it easier to review (and to validate each step).
