### PR TITLE
feat(detectIdentifiers): re-introduce boundary check

### DIFF
--- a/src/DynamicExpresso.Core/Detector.cs
+++ b/src/DynamicExpresso.Core/Detector.cs
@@ -12,10 +12,10 @@ namespace DynamicExpresso
 		private readonly ParserSettings _settings;
 
 		private static readonly Regex RootIdentifierDetectionRegex =
-			new Regex(@"(?<id>@?[\p{L}\p{Nl}_][\p{L}\p{Nl}\p{Nd}\p{Mn}\p{Mc}\p{Pc}\p{Cf}_]*)", RegexOptions.Compiled);
+			new Regex(@"(?<=[^\w@]|^)(?<id>@?[\p{L}\p{Nl}_][\p{L}\p{Nl}\p{Nd}\p{Mn}\p{Mc}\p{Pc}\p{Cf}_]*)", RegexOptions.Compiled);
 
 		private static readonly Regex ChildIdentifierDetectionRegex = new Regex(
-			@"(?<id>@?[\p{L}\p{Nl}_][\p{L}\p{Nl}\p{Nd}\p{Mn}\p{Mc}\p{Pc}\p{Cf}_]*(\.[\p{L}\p{Nl}_][\p{L}\p{Nl}\p{Nd}\p{Mn}\p{Mc}\p{Pc}\p{Cf}_]*)*)",
+			@"(?<=[^\w@]|^)(?<id>@?[\p{L}\p{Nl}_][\p{L}\p{Nl}\p{Nd}\p{Mn}\p{Mc}\p{Pc}\p{Cf}_]*(\.[\p{L}\p{Nl}_][\p{L}\p{Nl}\p{Nd}\p{Mn}\p{Mc}\p{Pc}\p{Cf}_]*)*)",
 			RegexOptions.Compiled);
 
 


### PR DESCRIPTION
This improves the regex evaluation back to when we still had `\b` in front, while (hopefully) doing as it should.
For the test referenced in #331, this change drops us back to 90ms, which is still twice as slow as originally, but there's also more features supported now, so I find this acceptable.

@metoule Please check that this is doing what you meant. If I understood your comment about `\b` right, you had to remove it because that also matched `@`, so even though `@?` is included in the identifier part it was never captured. If so, then this lookbehind should model the same as `\b` but it respects `@` in front. Demo: https://regex101.com/r/WhA5GM/2

Close #291