### PR TITLE
Revert changes introduced in #296

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -228,7 +228,7 @@ namespace DynamicExpresso.Parsing
 				NextToken();
 				var right = ParseAssignment();
 
-				var promoted = ExpressionUtils.PromoteExpression(right, left.Type, true);
+				var promoted = ExpressionUtils.PromoteExpression(right, left.Type);
 				if (promoted == null)
 					throw ParseException.Create(_token.pos, ErrorMessages.CannotConvertValue,
 						TypeUtils.GetTypeName(right.Type), TypeUtils.GetTypeName(left.Type));
@@ -1122,8 +1122,8 @@ namespace DynamicExpresso.Parsing
 				throw ParseException.Create(errorPos, ErrorMessages.FirstExprMustBeBool);
 			if (expr1.Type != expr2.Type)
 			{
-				var expr1As2 = expr2 != ParserConstants.NullLiteralExpression ? ExpressionUtils.PromoteExpression(expr1, expr2.Type, true) : null;
-				var expr2As1 = expr1 != ParserConstants.NullLiteralExpression ? ExpressionUtils.PromoteExpression(expr2, expr1.Type, true) : null;
+				var expr1As2 = expr2 != ParserConstants.NullLiteralExpression ? ExpressionUtils.PromoteExpression(expr1, expr2.Type) : null;
+				var expr2As1 = expr1 != ParserConstants.NullLiteralExpression ? ExpressionUtils.PromoteExpression(expr2, expr1.Type) : null;
 				if (expr1As2 != null && expr2As1 == null)
 				{
 					expr1 = expr1As2;
@@ -1838,7 +1838,7 @@ namespace DynamicExpresso.Parsing
 
 				for (int i = 0; i < args.Length; i++)
 				{
-					args[i] = ExpressionUtils.PromoteExpression(args[i], typeof(int), true);
+					args[i] = ExpressionUtils.PromoteExpression(args[i], typeof(int));
 					if (args[i] == null)
 						throw ParseException.Create(errorPos, ErrorMessages.InvalidIndex);
 				}

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -336,8 +336,8 @@ namespace DynamicExpresso.Parsing
 		{
 			var left = ParseTypeTesting();
 			while (_token.id == TokenId.DoubleEqual || _token.id == TokenId.ExclamationEqual ||
-			       _token.id == TokenId.GreaterThan || _token.id == TokenId.GreaterThanEqual ||
-			       _token.id == TokenId.LessThan || _token.id == TokenId.LessThanEqual)
+				   _token.id == TokenId.GreaterThan || _token.id == TokenId.GreaterThanEqual ||
+				   _token.id == TokenId.LessThan || _token.id == TokenId.LessThanEqual)
 			{
 				var op = _token;
 				NextToken();
@@ -424,7 +424,7 @@ namespace DynamicExpresso.Parsing
 		{
 			var left = ParseShift();
 			while (_token.text == ParserConstants.KeywordIs
-			       || _token.text == ParserConstants.KeywordAs)
+				|| _token.text == ParserConstants.KeywordAs)
 			{
 				var typeOperator = _token.text;
 
@@ -523,7 +523,7 @@ namespace DynamicExpresso.Parsing
 		{
 			var left = ParseUnary();
 			while (_token.id == TokenId.Asterisk || _token.id == TokenId.Slash ||
-			       _token.id == TokenId.Percent)
+				   _token.id == TokenId.Percent)
 			{
 				var op = _token;
 				NextToken();
@@ -1053,7 +1053,7 @@ namespace DynamicExpresso.Parsing
 					return ParseMemberAccess(thisParameterExpression);
 				}
 			}
-			catch(ParseException)
+			catch (ParseException)
 			{
 				// ignore
 			}
@@ -1116,7 +1116,7 @@ namespace DynamicExpresso.Parsing
 		private Expression GenerateConditional(Expression test, Expression expr1, Expression expr2, int errorPos)
 		{
 			if (IsDynamicExpression(test))
-				return GenerateConditionalDynamic(test, expr1, expr2,errorPos);
+				return GenerateConditionalDynamic(test, expr1, expr2, errorPos);
 
 			if (test.Type != typeof(bool))
 				throw ParseException.Create(errorPos, ErrorMessages.FirstExprMustBeBool);
@@ -1958,8 +1958,6 @@ namespace DynamicExpresso.Parsing
 			}
 			return GenerateBinary(ExpressionType.GreaterThan, left, right);
 		}
-
-		
 
 		private Expression GenerateGreaterThanEqual(Expression left, Expression right)
 		{

--- a/src/DynamicExpresso.Core/Resolution/ExpressionUtils.cs
+++ b/src/DynamicExpresso.Core/Resolution/ExpressionUtils.cs
@@ -36,7 +36,7 @@ namespace DynamicExpresso.Resolution
 					return Expression.Convert(expr, genericType);
 			}
 
-			if (TypeUtils.IsCompatibleWith(expr.Type, type) || expr is DynamicExpression)
+			if (TypeUtils.IsCompatibleWith(expr.Type, type))
 			{
 				return Expression.Convert(expr, type);
 			}

--- a/src/DynamicExpresso.Core/Resolution/ExpressionUtils.cs
+++ b/src/DynamicExpresso.Core/Resolution/ExpressionUtils.cs
@@ -7,19 +7,15 @@ namespace DynamicExpresso.Resolution
 {
 	internal static class ExpressionUtils
 	{
-		public static Expression PromoteExpression(Expression expr, Type type, bool exact)
+		public static Expression PromoteExpression(Expression expr, Type type)
 		{
 			if (expr.Type == type) return expr;
-			if (expr is ConstantExpression)
+			if (expr is ConstantExpression ce && ce == ParserConstants.NullLiteralExpression)
 			{
-				var ce = (ConstantExpression)expr;
-				if (ce == ParserConstants.NullLiteralExpression)
-				{
-					if (type.ContainsGenericParameters)
-						return null;
-					if (!type.IsValueType || TypeUtils.IsNullableType(type))
-						return Expression.Constant(null, type);
-				}
+				if (type.ContainsGenericParameters)
+					return null;
+				if (!type.IsValueType || TypeUtils.IsNullableType(type))
+					return Expression.Constant(null, type);
 			}
 
 			if (expr is InterpreterExpression ie)
@@ -42,11 +38,7 @@ namespace DynamicExpresso.Resolution
 
 			if (TypeUtils.IsCompatibleWith(expr.Type, type) || expr is DynamicExpression)
 			{
-				if (type.IsValueType || exact)
-				{
-					return Expression.Convert(expr, type);
-				}
-				return expr;
+				return Expression.Convert(expr, type);
 			}
 
 			return null;

--- a/src/DynamicExpresso.Core/Resolution/MethodResolution.cs
+++ b/src/DynamicExpresso.Core/Resolution/MethodResolution.cs
@@ -92,7 +92,7 @@ namespace DynamicExpresso.Resolution
 						continue;
 					}
 
-					var promoted = ExpressionUtils.PromoteExpression(currentArgument, parameterType, true);
+					var promoted = ExpressionUtils.PromoteExpression(currentArgument, parameterType);
 					if (promoted != null)
 					{
 						promotedArgs.Add(promoted);
@@ -110,7 +110,7 @@ namespace DynamicExpresso.Resolution
 						continue;
 					}
 
-					var promoted = ExpressionUtils.PromoteExpression(currentArgument, paramsArrayElementType, true);
+					var promoted = ExpressionUtils.PromoteExpression(currentArgument, paramsArrayElementType);
 					if (promoted != null)
 					{
 						paramsArrayPromotedArgument = paramsArrayPromotedArgument ?? new List<Expression>();

--- a/src/DynamicExpresso.Core/Resolution/MethodResolution.cs
+++ b/src/DynamicExpresso.Core/Resolution/MethodResolution.cs
@@ -1,10 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Security;
-using System.Text;
 using DynamicExpresso.Exceptions;
 using DynamicExpresso.Parsing;
 using DynamicExpresso.Reflection;

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -775,6 +775,7 @@ namespace DynamicExpresso.UnitTest
 		}
 
 		[Test]
+		[Ignore("The fix suggested in #296 break other use cases, so let's ignore this test for now")]
 		public void GitHub_Issue_295()
 		{
 			var evaluator = new Interpreter();
@@ -848,6 +849,21 @@ namespace DynamicExpresso.UnitTest
 
 			var exception2 = Assert.Throws<UnknownIdentifierException>(() => interpreter.Eval("b > 1"));
 			Assert.AreEqual("b", exception2.Identifier);
+		}
+
+		[Test]
+		public void GitHub_Issue_325()
+		{
+			var options = InterpreterOptions.Default | InterpreterOptions.LateBindObject;
+			var interpreter = new Interpreter(options);
+
+			var input = new
+			{
+				Prop1 = 4,
+			};
+
+			var expressionDelegate = interpreter.ParseAsDelegate<Func<object, bool>>($"input.Prop1 == null", "input");
+			Assert.IsFalse(expressionDelegate(input));
 		}
 	}
 

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -1,12 +1,12 @@
-using DynamicExpresso.Exceptions;
-using NUnit.Framework;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using System.Dynamic;
+using DynamicExpresso.Exceptions;
+using NUnit.Framework;
 
 // ReSharper disable SpecifyACultureInStringConversionExplicitly
 
@@ -775,7 +775,8 @@ namespace DynamicExpresso.UnitTest
 		}
 
 		[Test]
-		public void GitHub_Issue_295() {
+		public void GitHub_Issue_295()
+		{
 			var evaluator = new Interpreter();
 
 			// create path helper functions in expressions...
@@ -787,10 +788,10 @@ namespace DynamicExpresso.UnitTest
 			globalSettings.MyTestPath = "C:\\delme\\";
 			evaluator.SetVariable("GlobalSettings", globalSettings);
 
-			var works = (string) evaluator.Eval("StringConcat((string)GlobalSettings.MyTestPath,\"test.txt\")");
+			var works = (string)evaluator.Eval("StringConcat((string)GlobalSettings.MyTestPath,\"test.txt\")");
 			Assert.That(works, Is.EqualTo("C:\\delme\\test.txt"));
 
-			var doesntWork = (string) evaluator.Eval("StringConcat(GlobalSettings.MyTestPath,\"test.txt\")");
+			var doesntWork = (string)evaluator.Eval("StringConcat(GlobalSettings.MyTestPath,\"test.txt\")");
 			Assert.That(doesntWork, Is.EqualTo("C:\\delme\\test.txt"));
 		}
 


### PR DESCRIPTION
The changes introduced in #296 caused #324 and #325, so this PR revert it. The proper fix will come in a later PR, because it will require creating a late binding expression, and it's a bit complex.