### PR TITLE
Fix cast expression grammar

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -997,7 +997,9 @@ namespace DynamicExpresso.Parsing
 			if (constExp != null && constExp.Value is Type)
 			{
 				NextToken();
-				var nextExpression = ParseExpressionSegment();
+
+				// we're in a cast expression, the next expression can only be a unary expression
+				var nextExpression = ParseUnary();
 
 				// cast: (constExp)nextExpression
 				return Expression.Convert(nextExpression, (Type)constExp.Value);

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -865,6 +865,17 @@ namespace DynamicExpresso.UnitTest
 			var expressionDelegate = interpreter.ParseAsDelegate<Func<object, bool>>($"input.Prop1 == null", "input");
 			Assert.IsFalse(expressionDelegate(input));
 		}
+
+		[Test]
+		public void GitHub_Issue_341()
+		{
+			var interpreter = new Interpreter();
+
+			var x = 1L;
+			interpreter.SetVariable("x", x);
+
+			Assert.AreEqual((int)x == 1, interpreter.Eval<bool>($"(int)x == 1"));
+		}
 	}
 
 	internal static class GithubIssuesTestExtensionsMethods

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -874,7 +874,7 @@ namespace DynamicExpresso.UnitTest
 			var x = 1L;
 			interpreter.SetVariable("x", x);
 
-			Assert.AreEqual((int)x == 1, interpreter.Eval<bool>($"(int)x == 1"));
+			Assert.AreEqual((int)x == 1, interpreter.Eval<bool>("(int)x == 1"));
 		}
 	}
 


### PR DESCRIPTION
According [to the specs](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/expressions#1297-cast-expressions), a cast expression is:

```
cast_expression
    : '(' type ')' unary_expression
    ;
```

In the current implementation, the grammar is 

```
cast_expression
    : '(' type ')' expression
    ;
```

which is incorrect.

Fixes #341 