### PR TITLE
Update test targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: '0' # all
-    - name: Setup .NET 8.0
+    - name: Setup .NET 9.0
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '9.0.x'
     - name: Setup gitversion
       run: dotnet tool install --global GitVersion.Tool
     - name: Calculate version
@@ -30,25 +30,23 @@ jobs:
       run: dotnet build DynamicExpresso.sln --no-restore -c Release /p:Version=${{steps.calc_version.outputs.PROJECT_VERSION}}
     - name: Test .net core 8.0
       run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release --verbosity normal -f net8.0
+    - name: Test .net core 9.0
+      run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release --verbosity normal -f net9.0
   test-win:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v4
-    - name: Setup .NET 7.0
+    - name: Setup .NET 9.0
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '7.0.x'
-    - name: Setup .NET 8.0
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '9.0.x'
     - name: Restore packages
       run: dotnet restore DynamicExpresso.sln
     - name: Build
       run: dotnet build DynamicExpresso.sln --no-restore -c Release
-    - name: Test .net 4.6.1
-      run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release --verbosity normal -f net461
-    - name: Test .net 4.5
-      run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release --verbosity normal -f net45
+    - name: Test .net 4.6.2
+      run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release --verbosity normal -f net462
     - name: Test .net core 8.0
       run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release --verbosity normal -f net8.0
+    - name: Test .net core 9.0
+      run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release --verbosity normal -f net9.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,10 @@ jobs:
       with:
         ref: "${{ github.event.inputs.ref }}"
         fetch-depth: '0' # all
-    - name: Setup .NET Core 8.0
+    - name: Setup .NET Core 9.0
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '9.0.x'
     - name: Setup gitversion
       run: dotnet tool install --global GitVersion.Tool
     - name: Calculate version
@@ -35,8 +35,8 @@ jobs:
       run: dotnet restore DynamicExpresso.sln
     - name: Build
       run: dotnet build DynamicExpresso.sln --no-restore -c Release /p:Version=${{steps.calc_version.outputs.PROJECT_VERSION}}
-    - name: Test .net core 8.0
-      run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release /p:Version=${{steps.calc_version.outputs.PROJECT_VERSION}} --verbosity normal -f net8.0
+    - name: Test .net core 9.0
+      run: dotnet test DynamicExpresso.sln --no-build --no-restore -c Release /p:Version=${{steps.calc_version.outputs.PROJECT_VERSION}} --verbosity normal -f net9.0
     - name: Setup nuget sources
       run: dotnet nuget add source --name github "https://nuget.pkg.github.com/dynamicexpresso/index.json"
     - name: Pack

--- a/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
+++ b/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net7.0;net5.0;net462</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net462</TargetFrameworks>
 
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-		<PackageReference Include="NUnit" Version="3.9.0" />
-		<PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
+++ b/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net462</TargetFrameworks>
+		<TargetFrameworks>net9.0;net8.0;net462</TargetFrameworks>
 
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+		<PackageReference Include="NUnit" Version="3.9.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <ProjectReference Include="..\..\src\DynamicExpresso.Core\DynamicExpresso.Core.csproj" />
+		<ProjectReference Include="..\..\src\DynamicExpresso.Core\DynamicExpresso.Core.csproj" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
.NET5, .NET6 and .NET7 are out of support, so we can remove them from the list of TargetFrameworks of the Unit Test project.
This PR updates the Github actions accordingly.