### PR TITLE
NUnit: migrate to constraints model

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Variables can be used inside expressions with `Interpreter.SetVariable` method:
 ```csharp
 var target = new Interpreter().SetVariable("myVar", 23);
 
-Assert.AreEqual(23, target.Eval("myVar"));
+Assert.That(target.Eval("myVar"), Is.EqualTo(23));
 ```
 Variables can be primitive types or custom complex types (classes, structures, delegates, arrays, collections, ...).
 
@@ -84,7 +84,7 @@ Custom functions can be passed with delegate variables using `Interpreter.SetFun
 Func<double, double, double> pow = (x, y) => Math.Pow(x, y);
 var target = new Interpreter().SetFunction("pow", pow);
 
-Assert.AreEqual(9.0, target.Eval("pow(3, 2)"));
+Assert.That(target.Eval("pow(3, 2)"), Is.EqualTo(9.0));
 ```
 Custom [Expression](http://msdn.microsoft.com/en-us/library/system.linq.expressions.expression.aspx) can be passed by using `Interpreter.SetExpression` method.
 
@@ -99,7 +99,7 @@ var parameters = new[] {
 	new Parameter("y", 7)
 };
 
-Assert.AreEqual(30, interpreter.Eval("x + y", parameters));
+Assert.That(interpreter.Eval("x + y", parameters), Is.EqualTo(30));
 ```
 Parameters can be primitive types or custom types. You can parse an expression once and invoke it multiple times with different parameter values:
 ```csharp
@@ -112,8 +112,8 @@ var parameters = new[] {
 
 var myFunc = target.Parse("x + y", parameters);
 
-Assert.AreEqual(30, myFunc.Invoke(23, 7));
-Assert.AreEqual(30, myFunc.Invoke(32, -2));
+Assert.That(myFunc.Invoke(23, 7), Is.EqualTo(30));
+Assert.That(myFunc.Invoke(32, -2), Is.EqualTo(30));
 ```
 
 ### Special identifiers
@@ -129,10 +129,10 @@ var target = new Interpreter();
 target.SetVariable("this", new Customer { Name = "John" });
 
 // explicit context reference via 'this' variable
-Assert.AreEqual("John", target.Eval("this.Name"));
+Assert.That(target.Eval("this.Name"), Is.EqualTo("John"));
 
 // 'this' variable is referenced implicitly
-Assert.AreEqual("John", target.Eval("Name"));
+Assert.That(target.Eval("Name"), Is.EqualTo("John"));
 ```
 
 ### Built-in types and custom types
@@ -153,8 +153,8 @@ You can reference any other custom .NET type by using `Interpreter.Reference` me
 ```csharp
 var target = new Interpreter().Reference(typeof(Uri));
 
-Assert.AreEqual(typeof(Uri), target.Eval("typeof(Uri)"));
-Assert.AreEqual(Uri.UriSchemeHttp, target.Eval("Uri.UriSchemeHttp"));
+Assert.That(target.Eval("typeof(Uri)"), Is.EqualTo(typeof(Uri)));
+Assert.That(target.Eval("Uri.UriSchemeHttp"), Is.EqualTo(Uri.UriSchemeHttp));
 ```
 
 ### Generate dynamic delegates
@@ -184,7 +184,7 @@ public void Linq_Where()
 	var interpreter = new Interpreter();
 	Func<Customer, bool> dynamicWhere = interpreter.ParseAsDelegate<Func<Customer, bool>>(whereExpression, "customer");
 
-	Assert.AreEqual(1, customers.Where(dynamicWhere).Count());
+	Assert.That(customers.Where(dynamicWhere).Count(), Is.EqualTo(1));
 }
 ```
 This is the preferred way to parse an expression that you known at compile time what parameters can accept and what value must return.
@@ -217,7 +217,7 @@ public void Linq_Queryable_Expression_Where()
 	var interpreter = new Interpreter();
 	Expression<Func<Customer, bool>> expression = interpreter.ParseAsExpression<Func<Customer, bool>>(whereExpression, "customer");
 
-	Assert.AreEqual(1, customers.Where(expression).Count());
+	Assert.That(customers.Where(expression).Count(), Is.EqualTo(1));
 }
 ```
 
@@ -332,18 +332,18 @@ var target = new Interpreter()
   .SetVariable("x", service)
   .SetVariable("this", context);
 
-Assert.AreEqual(service.HelloWorld(), target.Eval("x.HelloWorld()"));
-Assert.AreEqual(service.AProperty, target.Eval("x.AProperty"));
-Assert.AreEqual(service.AField, target.Eval("x.AField"));
+Assert.That(target.Eval("x.HelloWorld()"), Is.EqualTo(service.HelloWorld()));
+Assert.That(target.Eval("x.AProperty"), Is.EqualTo(service.AProperty));
+Assert.That(target.Eval("x.AField"), Is.EqualTo(service.AField));
 
 // implicit context reference
-Assert.AreEqual(context.GetContextId(), target.Eval("GetContextId()"));
-Assert.AreEqual(context.ContextName, target.Eval("ContextName"));
-Assert.AreEqual(context.ContextField, target.Eval("ContextField"));
+Assert.That(target.Eval("GetContextId()"), Is.EqualTo(context.GetContextId()));
+Assert.That(target.Eval("ContextName"), Is.EqualTo(context.ContextName));
+Assert.That(target.Eval("ContextField"), Is.EqualTo(context.ContextField));
 ```
 ```csharp
 var target = new Interpreter();
-Assert.AreEqual(new DateTime(2015, 1, 24), target.Eval("new DateTime(2015, 1, 24)"));
+Assert.That(1, 24), target.Eval("new DateTime(2015, 1, 24)"), Is.EqualTo(new DateTime(2015));
 ```
 Dynamic Expresso also supports:
 
@@ -353,7 +353,7 @@ var x = new int[] { 10, 30, 4 };
 var target = new Interpreter()
 	.Reference(typeof(System.Linq.Enumerable))
 	.SetVariable("x", x);
-Assert.AreEqual(x.Count(), target.Eval("x.Count()"));
+Assert.That(target.Eval("x.Count()"), Is.EqualTo(x.Count()));
 ```
 - Indexer methods (like `array[0]`)
 - Generics, only partially supported (only implicit, you cannot invoke an explicit generic method)
@@ -369,7 +369,7 @@ var target = new Interpreter(options)
 	.SetVariable("x", x);
 
 var results = target.Eval<IEnumerable<string>>("x.Where(str => str.Length > 5).Select(str => str.ToUpper())");
-Assert.AreEqual(new[] { "AWESOME" }, results);
+Assert.That(results, Is.EqualTo(new[] { "AWESOME" }));
 ```
 
 Note that parsing lambda expressions is disabled by default, because it has a slight performance cost.
@@ -383,7 +383,7 @@ var target = new Interpreter(options)
 	.SetVariable("increment", 3); // access a variable from the lambda expression
 
 var myFunc = target.Eval<Func<int, string, string>>("(i, str) => str.ToUpper() + (i + increment)");
-Assert.AreEqual("TEST8", lambda.Invoke(5, "test"));
+Assert.That(lambda.Invoke(5, "test"), Is.EqualTo("TEST8"));
 ```
 
 ### Case sensitive/insensitive
@@ -397,8 +397,8 @@ var parameters = new[] {
 	new Parameter("x", x.GetType(), x)
 };
 
-Assert.AreEqual(x, target.Eval("x", parameters));
-Assert.AreEqual(x, target.Eval("X", parameters));
+Assert.That(target.Eval("x", parameters), Is.EqualTo(x));
+Assert.That(target.Eval("X", parameters), Is.EqualTo(x));
 ```
 
 
@@ -431,7 +431,7 @@ var target = new Interpreter();
 target.SetDefaultNumberType(DefaultNumberType.Decimal);
 
 Assert.IsInstanceOf(typeof(System.Decimal), target.Eval("45"));
-Assert.AreEqual(10M/3M, target.Eval("10/3")); // 3.33333333333 instead of 3
+Assert.That(target.Eval("10/3"), Is.EqualTo(10M/3M)); // 3.33333333333 instead of 3
 ```
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Assert.That(target.Eval("ContextField"), Is.EqualTo(context.ContextField));
 ```
 ```csharp
 var target = new Interpreter();
-Assert.That(1, 24), target.Eval("new DateTime(2015, 1, 24)"), Is.EqualTo(new DateTime(2015));
+Assert.That(target.Eval("new DateTime(2015, 1, 24)"), Is.EqualTo(new DateTime(2015, 1, 24));
 ```
 Dynamic Expresso also supports:
 
@@ -414,8 +414,8 @@ var target = new Interpreter();
 
 var detectedIdentifiers = target.DetectIdentifiers("x + y");
 
-CollectionAssert.AreEqual(new[] { "x", "y" }, 
-			  detectedIdentifiers.UnknownIdentifiers.ToArray());
+Assert.That(detectedIdentifiers.UnknownIdentifiers, 
+        Is.EqualTo(new[] { "x", "y" });
 ```
 
 ## Default number type
@@ -430,7 +430,7 @@ var target = new Interpreter();
 
 target.SetDefaultNumberType(DefaultNumberType.Decimal);
 
-Assert.IsInstanceOf(typeof(System.Decimal), target.Eval("45"));
+Assert.That(target.Eval("45"), Is.InstanceOf<System.Decimal>());
 Assert.That(target.Eval("10/3"), Is.EqualTo(10M/3M)); // 3.33333333333 instead of 3
 ```
 

--- a/test/DynamicExpresso.UnitTest/CaseInsensitivePropertyTest.cs
+++ b/test/DynamicExpresso.UnitTest/CaseInsensitivePropertyTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 
 namespace DynamicExpresso.UnitTest
 {
@@ -10,7 +10,7 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.IsFalse(target.CaseInsensitive);
+			Assert.That(target.CaseInsensitive, Is.False);
 		}
 
 		[Test]
@@ -18,7 +18,7 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter(InterpreterOptions.DefaultCaseInsensitive);
 
-			Assert.IsTrue(target.CaseInsensitive);
+			Assert.That(target.CaseInsensitive, Is.True);
 		}
 
 	}

--- a/test/DynamicExpresso.UnitTest/CollectionHelperTests.cs
+++ b/test/DynamicExpresso.UnitTest/CollectionHelperTests.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using NUnit.Framework;
-using System.Linq;
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
 
 namespace DynamicExpresso.UnitTest
 {
@@ -20,8 +20,8 @@ namespace DynamicExpresso.UnitTest
 			var results = target.Eval("IntCollectionHelper.Where(list, \"x > 19\")", new Parameter("list", list))
 									as IEnumerable<int>;
 
-			Assert.AreEqual(1, results.Count());
-			Assert.AreEqual(21, results.First());
+			Assert.That(results.Count(), Is.EqualTo(1));
+			Assert.That(results.First(), Is.EqualTo(21));
 		}
 	}
 

--- a/test/DynamicExpresso.UnitTest/ConstructorTest.cs
+++ b/test/DynamicExpresso.UnitTest/ConstructorTest.cs
@@ -216,13 +216,16 @@ namespace DynamicExpresso.UnitTest
 				intProp.Value
 			};
 			Assert.That(
-				target.Parse("new MyClassAdder(){{ 1, 2, 3, 4, 5},{StrProp = \"6\" },7}", strProp, intProp).Invoke(args), Is.EqualTo(new MyClassAdder() { { 1, 2, 3, 4, 5 }, "6", 7 }));
+				target.Parse("new MyClassAdder(){{ 1, 2, 3, 4, 5},{StrProp = \"6\" },7}", strProp, intProp).Invoke(args),
+				Is.EqualTo(new MyClassAdder() { { 1, 2, 3, 4, 5 }, "6", 7 }));
 			Assert.That(
-				target.Eval<MyClassAdder>("new MyClassAdder(){{ 1, 2, 3, 4, 5},string.Empty, 7}"), Is.EqualTo(new MyClassAdder() { { 1, 2, 3, 4, 5 }, string.Empty, 7 }));
+				target.Eval<MyClassAdder>("new MyClassAdder(){{ 1, 2, 3, 4, 5},string.Empty, 7}"),
+				Is.EqualTo(new MyClassAdder() { { 1, 2, 3, 4, 5 }, string.Empty, 7 }));
 
 			var IntField = int.MaxValue;
 			Assert.That(
-				target.Parse("new MyClassAdder(){ { IntField = 5 }, { 1, 2, 3, 4, 5},{StrProp = \"6\" }, IntField}", strProp, intProp).Invoke(args), Is.EqualTo(new MyClassAdder() { { IntField = 5 }, { 1, 2, 3, 4, IntField }, "6" }));
+				target.Parse("new MyClassAdder(){ { IntField = 5 }, { 1, 2, 3, 4, 5},{StrProp = \"6\" }, IntField}", strProp, intProp).Invoke(args),
+				Is.EqualTo(new MyClassAdder() { { IntField = 5 }, { 1, 2, 3, 4, IntField }, "6" }));
 		}
 
 		[Test]
@@ -232,7 +235,8 @@ namespace DynamicExpresso.UnitTest
 			target.Reference(typeof(MyClassAdder));
 			target.Reference(typeof(MyClass));
 			Assert.That(
-				target.Eval<MyClassAdder>("new MyClassAdder() {StrProp = string.Empty, MyArr = new int[] {1, 2, 3, 4, 5}, IntField = int.MinValue }"), Is.EqualTo(new MyClassAdder() { StrProp = string.Empty, MyArr = new[] { 1, 2, 3, 4, 5 }, IntField = int.MinValue }));
+				target.Eval<MyClassAdder>("new MyClassAdder() {StrProp = string.Empty, MyArr = new int[] {1, 2, 3, 4, 5}, IntField = int.MinValue }"),
+				Is.EqualTo(new MyClassAdder() { StrProp = string.Empty, MyArr = new[] { 1, 2, 3, 4, 5 }, IntField = int.MinValue }));
 		}
 
 		[Test]
@@ -278,7 +282,7 @@ namespace DynamicExpresso.UnitTest
 			{
 				if (ex.Message.Contains("The best overloaded Add "))
 				{
-					Assert.That(ex.Message.Contains("Add"), Is.True);
+					Assert.That(ex.Message, Does.Contain("Add"));
 				}
 				else
 				{

--- a/test/DynamicExpresso.UnitTest/ConstructorTest.cs
+++ b/test/DynamicExpresso.UnitTest/ConstructorTest.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections;
+using System.Linq;
 using DynamicExpresso.Exceptions;
 using NUnit.Framework;
-using System.Linq;
 
 namespace DynamicExpresso.UnitTest
 {
@@ -14,8 +14,8 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(new DateTime(2015, 1, 24), target.Eval("new DateTime(2015, 1, 24)"));
-			Assert.AreEqual(new string('a', 10), target.Eval("new string('a', 10)"));
+			Assert.That(target.Eval("new DateTime(2015, 1, 24)"), Is.EqualTo(new DateTime(2015, 1, 24)));
+			Assert.That(target.Eval("new string('a', 10)"), Is.EqualTo(new string('a', 10)));
 		}
 
 		[Test]
@@ -25,7 +25,7 @@ namespace DynamicExpresso.UnitTest
 
 			target.Reference(typeof(Uri));
 
-			Assert.AreEqual(new Uri("http://www.google.com"), target.Eval("new Uri(\"http://www.google.com\")"));
+			Assert.That(target.Eval("new Uri(\"http://www.google.com\")"), Is.EqualTo(new Uri("http://www.google.com")));
 		}
 
 		[Test]
@@ -33,8 +33,8 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(new DateTime(2015, 1, 24).Month, target.Eval("new DateTime(2015,   1, 24).Month"));
-			Assert.AreEqual(new DateTime(2015, 1, 24).Month + 34, target.Eval("new DateTime( 2015, 1, 24).Month + 34"));
+			Assert.That(target.Eval("new DateTime(2015,   1, 24).Month"), Is.EqualTo(new DateTime(2015, 1, 24).Month));
+			Assert.That(target.Eval("new DateTime( 2015, 1, 24).Month + 34"), Is.EqualTo(new DateTime(2015, 1, 24).Month + 34));
 		}
 
 		[Test]
@@ -59,9 +59,9 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter();
 			target.Reference(typeof(MyClass));
 
-			Assert.AreEqual(new MyClass() { }, target.Eval("new MyClass() {}"));
-			Assert.AreEqual(new MyClass("test") { }, target.Eval("new MyClass(\"test\") {}"));
-			Assert.AreEqual(new MyClass { }, target.Eval("new MyClass{}"));
+			Assert.That(target.Eval("new MyClass() {}"), Is.EqualTo(new MyClass() { }));
+			Assert.That(target.Eval("new MyClass(\"test\") {}"), Is.EqualTo(new MyClass("test") { }));
+			Assert.That(target.Eval("new MyClass{}"), Is.EqualTo(new MyClass { }));
 		}
 
 		[Test]
@@ -71,14 +71,14 @@ namespace DynamicExpresso.UnitTest
 			target.Reference(typeof(MyClass));
 
 			// each member initializer can end with a comma, even if there's nothing afterwards
-			Assert.AreEqual(new MyClass { StrProp = "test", }, target.Eval("new MyClass { StrProp = \"test\", }"));
-			Assert.AreEqual(new MyClass { StrProp = "test" }, target.Eval("new MyClass { StrProp = \"test\" }"));
+			Assert.That(target.Eval("new MyClass { StrProp = \"test\", }"), Is.EqualTo(new MyClass { StrProp = "test", }));
+			Assert.That(target.Eval("new MyClass { StrProp = \"test\" }"), Is.EqualTo(new MyClass { StrProp = "test" }));
 
-			Assert.AreEqual(new MyClass("test") { IntField = 5, }, target.Eval("new MyClass(\"test\") { IntField = 5, }"));
-			Assert.AreEqual(new MyClass("test") { IntField = 5 }, target.Eval("new MyClass(\"test\") { IntField = 5 }"));
+			Assert.That(target.Eval("new MyClass(\"test\") { IntField = 5, }"), Is.EqualTo(new MyClass("test") { IntField = 5, }));
+			Assert.That(target.Eval("new MyClass(\"test\") { IntField = 5 }"), Is.EqualTo(new MyClass("test") { IntField = 5 }));
 
-			Assert.AreEqual(new MyClass() { StrProp = "test", IntField = 5, }, target.Eval("new MyClass() { StrProp = \"test\", IntField = 5, }"));
-			Assert.AreEqual(new MyClass() { StrProp = "test", IntField = 5 }, target.Eval("new MyClass() { StrProp = \"test\", IntField = 5 }"));
+			Assert.That(target.Eval("new MyClass() { StrProp = \"test\", IntField = 5, }"), Is.EqualTo(new MyClass() { StrProp = "test", IntField = 5, }));
+			Assert.That(target.Eval("new MyClass() { StrProp = \"test\", IntField = 5 }"), Is.EqualTo(new MyClass() { StrProp = "test", IntField = 5 }));
 		}
 
 		[Test]
@@ -88,9 +88,9 @@ namespace DynamicExpresso.UnitTest
 			target.Reference(typeof(Tuple<>));
 			target.Reference(typeof(Tuple<,>));
 			target.Reference(typeof(Tuple<,,>));
-			Assert.AreEqual(1, target.Eval("new Tuple<int>(1).Item1"));
-			Assert.AreEqual("My str item", target.Eval("new Tuple<int, string>(5, \"My str item\").Item2"));
-			Assert.AreEqual(3, target.Eval("new Tuple<int, int, int>(1, 2, 3).Item3"));
+			Assert.That(target.Eval("new Tuple<int>(1).Item1"), Is.EqualTo(1));
+			Assert.That(target.Eval("new Tuple<int, string>(5, \"My str item\").Item2"), Is.EqualTo("My str item"));
+			Assert.That(target.Eval("new Tuple<int, int, int>(1, 2, 3).Item3"), Is.EqualTo(3));
 		}
 
 		[Test]
@@ -100,9 +100,9 @@ namespace DynamicExpresso.UnitTest
 			target.Reference(typeof(Tuple<>), "Toto`1");
 			target.Reference(typeof(Tuple<,>), "Toto`2");
 			target.Reference(typeof(Tuple<,,>), "Toto`3");
-			Assert.AreEqual(1, target.Eval("new Toto<int>(1).Item1"));
-			Assert.AreEqual("My str item", target.Eval("new Toto<int, string>(5, \"My str item\").Item2"));
-			Assert.AreEqual(3, target.Eval("new Toto<int, int, int>(1, 2, 3).Item3"));
+			Assert.That(target.Eval("new Toto<int>(1).Item1"), Is.EqualTo(1));
+			Assert.That(target.Eval("new Toto<int, string>(5, \"My str item\").Item2"), Is.EqualTo("My str item"));
+			Assert.That(target.Eval("new Toto<int, int, int>(1, 2, 3).Item3"), Is.EqualTo(3));
 		}
 
 		[Test]
@@ -110,12 +110,12 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 			target.Reference(typeof(Tuple<,>), "Tuple");
-			Assert.AreEqual("My str item", target.Eval("new Tuple<int, string>(5, \"My str item\").Item2"));
+			Assert.That(target.Eval("new Tuple<int, string>(5, \"My str item\").Item2"), Is.EqualTo("My str item"));
 
 			target.Reference(typeof(Tuple<>), "Tuple1");
 			target.Reference(typeof(Tuple<,,>), "Tuple3");
-			Assert.AreEqual(1, target.Eval("new Tuple1<int>(1).Item1"));
-			Assert.AreEqual(3, target.Eval("new Tuple3<int, int, int>(1, 2, 3).Item3"));
+			Assert.That(target.Eval("new Tuple1<int>(1).Item1"), Is.EqualTo(1));
+			Assert.That(target.Eval("new Tuple3<int, int, int>(1, 2, 3).Item3"), Is.EqualTo(3));
 		}
 
 		[Test]
@@ -139,7 +139,7 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 			target.Reference(typeof(MyClass));
-			Assert.AreEqual(new MyClass(6, 5, 4, 3).MyArr, target.Eval("new MyClass(6, 5, 4, 3).MyArr"));
+			Assert.That(target.Eval("new MyClass(6, 5, 4, 3).MyArr"), Is.EqualTo(new MyClass(6, 5, 4, 3).MyArr));
 		}
 
 		[Test]
@@ -147,9 +147,9 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 			var arr = target.Eval<int[]>("new int[] { 1, 2 }");
-			Assert.AreEqual(2, arr.Length);
-			Assert.AreEqual(1, arr[0]);
-			Assert.AreEqual(2, arr[1]);
+			Assert.That(arr.Length, Is.EqualTo(2));
+			Assert.That(arr[0], Is.EqualTo(1));
+			Assert.That(arr[1], Is.EqualTo(2));
 		}
 
 		[Test]
@@ -165,11 +165,11 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 			var arr = target.Eval<int[][]>("new int[][] { new int[] { 1, 2, }, new int[] { 3, 4, }, }");
-			Assert.AreEqual(2, arr.Length);
-			Assert.AreEqual(1, arr[0][0]);
-			Assert.AreEqual(2, arr[0][1]);
-			Assert.AreEqual(3, arr[1][0]);
-			Assert.AreEqual(4, arr[1][1]);
+			Assert.That(arr.Length, Is.EqualTo(2));
+			Assert.That(arr[0][0], Is.EqualTo(1));
+			Assert.That(arr[0][1], Is.EqualTo(2));
+			Assert.That(arr[1][0], Is.EqualTo(3));
+			Assert.That(arr[1][1], Is.EqualTo(4));
 		}
 
 		[Test]
@@ -186,10 +186,10 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter();
 			target.Reference(typeof(System.Collections.Generic.Dictionary<,>));
 			var l = target.Eval<System.Collections.Generic.Dictionary<int, string>>("new Dictionary<int, string>(){{1, \"1\"}, {2, \"2\"}, {3, \"3\"}, {4, \"4\"}, {5, \"5\"}}");
-			Assert.AreEqual(5, l.Count);
+			Assert.That(l.Count, Is.EqualTo(5));
 			for (int i = 0; i < l.Count; ++i)
 			{
-				Assert.AreEqual(i + 1 + "", l[i + 1]);
+				Assert.That(l[i + 1], Is.EqualTo(i + 1 + ""));
 			}
 		}
 
@@ -199,7 +199,7 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter();
 			target.Reference(typeof(MyClassAdder));
 
-			Assert.AreEqual(new MyClassAdder() { { 1, 2, 3, 4, 5 }, { "6" }, 7 }, target.Eval<MyClassAdder>("new MyClassAdder(){{ 1, 2, 3, 4, 5},{\"6\" },7	}.Add(true)"));
+			Assert.That(target.Eval<MyClassAdder>("new MyClassAdder(){{ 1, 2, 3, 4, 5},{\"6\" },7	}.Add(true)"), Is.EqualTo(new MyClassAdder() { { 1, 2, 3, 4, 5 }, { "6" }, 7 }));
 		}
 
 		[Test]
@@ -215,17 +215,14 @@ namespace DynamicExpresso.UnitTest
 				strProp.Value,
 				intProp.Value
 			};
-			Assert.AreEqual(
-				new MyClassAdder() { { 1, 2, 3, 4, 5 }, "6", 7 },
-				target.Parse("new MyClassAdder(){{ 1, 2, 3, 4, 5},{StrProp = \"6\" },7}", strProp, intProp).Invoke(args));
-			Assert.AreEqual(
-				new MyClassAdder() { { 1, 2, 3, 4, 5 }, string.Empty, 7 },
-				target.Eval<MyClassAdder>("new MyClassAdder(){{ 1, 2, 3, 4, 5},string.Empty, 7}"));
+			Assert.That(
+				target.Parse("new MyClassAdder(){{ 1, 2, 3, 4, 5},{StrProp = \"6\" },7}", strProp, intProp).Invoke(args), Is.EqualTo(new MyClassAdder() { { 1, 2, 3, 4, 5 }, "6", 7 }));
+			Assert.That(
+				target.Eval<MyClassAdder>("new MyClassAdder(){{ 1, 2, 3, 4, 5},string.Empty, 7}"), Is.EqualTo(new MyClassAdder() { { 1, 2, 3, 4, 5 }, string.Empty, 7 }));
 
 			var IntField = int.MaxValue;
-			Assert.AreEqual(
-				new MyClassAdder() { { IntField = 5 }, { 1, 2, 3, 4, IntField }, "6" },
-				target.Parse("new MyClassAdder(){ { IntField = 5 }, { 1, 2, 3, 4, 5},{StrProp = \"6\" }, IntField}", strProp, intProp).Invoke(args));
+			Assert.That(
+				target.Parse("new MyClassAdder(){ { IntField = 5 }, { 1, 2, 3, 4, 5},{StrProp = \"6\" }, IntField}", strProp, intProp).Invoke(args), Is.EqualTo(new MyClassAdder() { { IntField = 5 }, { 1, 2, 3, 4, IntField }, "6" }));
 		}
 
 		[Test]
@@ -234,9 +231,8 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter();
 			target.Reference(typeof(MyClassAdder));
 			target.Reference(typeof(MyClass));
-			Assert.AreEqual(
-				new MyClassAdder() { StrProp = string.Empty, MyArr = new[] { 1, 2, 3, 4, 5 }, IntField = int.MinValue },
-				target.Eval<MyClassAdder>("new MyClassAdder() {StrProp = string.Empty, MyArr = new int[] {1, 2, 3, 4, 5}, IntField = int.MinValue }"));
+			Assert.That(
+				target.Eval<MyClassAdder>("new MyClassAdder() {StrProp = string.Empty, MyArr = new int[] {1, 2, 3, 4, 5}, IntField = int.MinValue }"), Is.EqualTo(new MyClassAdder() { StrProp = string.Empty, MyArr = new[] { 1, 2, 3, 4, 5 }, IntField = int.MinValue }));
 		}
 
 		[Test]
@@ -282,7 +278,7 @@ namespace DynamicExpresso.UnitTest
 			{
 				if (ex.Message.Contains("The best overloaded Add "))
 				{
-					Assert.IsTrue(ex.Message.Contains("Add"));
+					Assert.That(ex.Message.Contains("Add"), Is.True);
 				}
 				else
 				{
@@ -310,10 +306,10 @@ namespace DynamicExpresso.UnitTest
 					var evalText = $"new List<{typeof(TObject).Name}>(){{{string.Join(",", items.Skip(min).Take(count))}}}";
 					System.Collections.Generic.List<TObject> eval = null;
 					Assert.DoesNotThrow(() => eval = target.Eval<System.Collections.Generic.List<TObject>>(evalText), evalText);
-					Assert.AreEqual(count, eval.Count);
+					Assert.That(eval.Count, Is.EqualTo(count));
 					for (var i = 0; i < count; ++i)
 					{
-						Assert.AreEqual(actual[i + min], eval[i]);
+						Assert.That(eval[i], Is.EqualTo(actual[i + min]));
 					}
 				}
 			}
@@ -325,17 +321,17 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter();
 			target.Reference(typeof(System.Collections.Generic.List<>));
 			var list = target.Eval<System.Collections.Generic.List<string>>("new List<string>(){string.Empty}");
-			Assert.AreEqual(1, list.Count);
+			Assert.That(list.Count, Is.EqualTo(1));
 			for (int i = 0; i < list.Count; ++i)
 			{
-				Assert.AreSame(string.Empty, list[i]);
+				Assert.That(list[i], Is.SameAs(string.Empty));
 			}
 			list = target.Eval<System.Collections.Generic.List<string>>("new List<string>(){StrProp = string.Empty}", new Parameter("StrProp", "0"));
-			Assert.AreSame(string.Empty, list[0]);
+			Assert.That(list[0], Is.SameAs(string.Empty));
 			list = target.Eval<System.Collections.Generic.List<string>>("new List<string>(){{StrProp = string.Empty}}", new Parameter("StrProp", "0"));
-			Assert.AreSame(string.Empty, list[0]);
+			Assert.That(list[0], Is.SameAs(string.Empty));
 			list = target.Eval<System.Collections.Generic.List<string>>("new List<string>(){StrValue()}", new Parameter("StrValue", new Func<string>(() => "Func")));
-			Assert.AreEqual("Func", list[0]);
+			Assert.That(list[0], Is.EqualTo("Func"));
 		}
 
 

--- a/test/DynamicExpresso.UnitTest/DefaultOperatorTest.cs
+++ b/test/DynamicExpresso.UnitTest/DefaultOperatorTest.cs
@@ -10,39 +10,39 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(default(bool), target.Eval("default(bool)"));
-			Assert.AreEqual(default(char), target.Eval("default(char)"));
-			Assert.AreEqual(default(sbyte), target.Eval("default(sbyte)"));
-			Assert.AreEqual(default(byte), target.Eval("default(byte)"));
-			Assert.AreEqual(default(short), target.Eval("default(short)"));
-			Assert.AreEqual(default(ushort), target.Eval("default(ushort)"));
-			Assert.AreEqual(default(int), target.Eval("default(int)"));
-			Assert.AreEqual(default(uint), target.Eval("default(uint)"));
-			Assert.AreEqual(default(long), target.Eval("default(long)"));
-			Assert.AreEqual(default(ulong), target.Eval("default(ulong)"));
-			Assert.AreEqual(default(float), target.Eval("default(float)"));
-			Assert.AreEqual(default(double), target.Eval("default(double)"));
-			Assert.AreEqual(default(decimal), target.Eval("default(decimal)"));
-			Assert.AreEqual(default(System.DateTime), target.Eval("default(DateTime)"));
-			Assert.AreEqual(default(System.TimeSpan), target.Eval("default(TimeSpan)"));
-			Assert.AreEqual(default(System.Guid), target.Eval("default(Guid)"));
+			Assert.That(target.Eval("default(bool)"), Is.EqualTo(default(bool)));
+			Assert.That(target.Eval("default(char)"), Is.EqualTo(default(char)));
+			Assert.That(target.Eval("default(sbyte)"), Is.EqualTo(default(sbyte)));
+			Assert.That(target.Eval("default(byte)"), Is.EqualTo(default(byte)));
+			Assert.That(target.Eval("default(short)"), Is.EqualTo(default(short)));
+			Assert.That(target.Eval("default(ushort)"), Is.EqualTo(default(ushort)));
+			Assert.That(target.Eval("default(int)"), Is.EqualTo(default(int)));
+			Assert.That(target.Eval("default(uint)"), Is.EqualTo(default(uint)));
+			Assert.That(target.Eval("default(long)"), Is.EqualTo(default(long)));
+			Assert.That(target.Eval("default(ulong)"), Is.EqualTo(default(ulong)));
+			Assert.That(target.Eval("default(float)"), Is.EqualTo(default(float)));
+			Assert.That(target.Eval("default(double)"), Is.EqualTo(default(double)));
+			Assert.That(target.Eval("default(decimal)"), Is.EqualTo(default(decimal)));
+			Assert.That(target.Eval("default(DateTime)"), Is.EqualTo(default(System.DateTime)));
+			Assert.That(target.Eval("default(TimeSpan)"), Is.EqualTo(default(System.TimeSpan)));
+			Assert.That(target.Eval("default(Guid)"), Is.EqualTo(default(System.Guid)));
 
-			Assert.AreEqual(typeof(bool), target.Eval("default(bool)").GetType());
-			Assert.AreEqual(typeof(char), target.Eval("default(char)").GetType());
-			Assert.AreEqual(typeof(sbyte), target.Eval("default(sbyte)").GetType());
-			Assert.AreEqual(typeof(byte), target.Eval("default(byte)").GetType());
-			Assert.AreEqual(typeof(short), target.Eval("default(short)").GetType());
-			Assert.AreEqual(typeof(ushort), target.Eval("default(ushort)").GetType());
-			Assert.AreEqual(typeof(int), target.Eval("default(int)").GetType());
-			Assert.AreEqual(typeof(uint), target.Eval("default(uint)").GetType());
-			Assert.AreEqual(typeof(long), target.Eval("default(long)").GetType());
-			Assert.AreEqual(typeof(ulong), target.Eval("default(ulong)").GetType());
-			Assert.AreEqual(typeof(float), target.Eval("default(float)").GetType());
-			Assert.AreEqual(typeof(double), target.Eval("default(double)").GetType());
-			Assert.AreEqual(typeof(decimal), target.Eval("default(decimal)").GetType());
-			Assert.AreEqual(typeof(System.DateTime), target.Eval("default(DateTime)").GetType());
-			Assert.AreEqual(typeof(System.TimeSpan), target.Eval("default(TimeSpan)").GetType());
-			Assert.AreEqual(typeof(System.Guid), target.Eval("default(Guid)").GetType());
+			Assert.That(target.Eval("default(bool)").GetType(), Is.EqualTo(typeof(bool)));
+			Assert.That(target.Eval("default(char)").GetType(), Is.EqualTo(typeof(char)));
+			Assert.That(target.Eval("default(sbyte)").GetType(), Is.EqualTo(typeof(sbyte)));
+			Assert.That(target.Eval("default(byte)").GetType(), Is.EqualTo(typeof(byte)));
+			Assert.That(target.Eval("default(short)").GetType(), Is.EqualTo(typeof(short)));
+			Assert.That(target.Eval("default(ushort)").GetType(), Is.EqualTo(typeof(ushort)));
+			Assert.That(target.Eval("default(int)").GetType(), Is.EqualTo(typeof(int)));
+			Assert.That(target.Eval("default(uint)").GetType(), Is.EqualTo(typeof(uint)));
+			Assert.That(target.Eval("default(long)").GetType(), Is.EqualTo(typeof(long)));
+			Assert.That(target.Eval("default(ulong)").GetType(), Is.EqualTo(typeof(ulong)));
+			Assert.That(target.Eval("default(float)").GetType(), Is.EqualTo(typeof(float)));
+			Assert.That(target.Eval("default(double)").GetType(), Is.EqualTo(typeof(double)));
+			Assert.That(target.Eval("default(decimal)").GetType(), Is.EqualTo(typeof(decimal)));
+			Assert.That(target.Eval("default(DateTime)").GetType(), Is.EqualTo(typeof(System.DateTime)));
+			Assert.That(target.Eval("default(TimeSpan)").GetType(), Is.EqualTo(typeof(System.TimeSpan)));
+			Assert.That(target.Eval("default(Guid)").GetType(), Is.EqualTo(typeof(System.Guid)));
 		}
 
 		[Test]
@@ -50,8 +50,8 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(default(object), target.Eval("default(object)"));
-			Assert.AreEqual(default(string), target.Eval("default(string)"));
+			Assert.That(target.Eval("default(object)"), Is.EqualTo(default(object)));
+			Assert.That(target.Eval("default(string)"), Is.EqualTo(default(string)));
 		}
 
 		[Test]
@@ -59,9 +59,9 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(default(int?), target.Eval("default(int?)"));
-			Assert.AreEqual(default(double?), target.Eval("default(double?)"));
-			Assert.AreEqual(default(System.DateTime?), target.Eval("default(DateTime?)"));
+			Assert.That(target.Eval("default(int?)"), Is.EqualTo(default(int?)));
+			Assert.That(target.Eval("default(double?)"), Is.EqualTo(default(double?)));
+			Assert.That(target.Eval("default(DateTime?)"), Is.EqualTo(default(System.DateTime?)));
 		}
 	}
 }

--- a/test/DynamicExpresso.UnitTest/DetectIdentifiersTest.cs
+++ b/test/DynamicExpresso.UnitTest/DetectIdentifiersTest.cs
@@ -14,9 +14,9 @@ namespace DynamicExpresso.UnitTest
 
 			var detectedIdentifiers = target.DetectIdentifiers("");
 
-			Assert.AreEqual(0, detectedIdentifiers.UnknownIdentifiers.Count());
-			Assert.AreEqual(0, detectedIdentifiers.Identifiers.Count());
-			Assert.AreEqual(0, detectedIdentifiers.Types.Count());
+			Assert.That(detectedIdentifiers.UnknownIdentifiers.Count(), Is.EqualTo(0));
+			Assert.That(detectedIdentifiers.Identifiers.Count(), Is.EqualTo(0));
+			Assert.That(detectedIdentifiers.Types.Count(), Is.EqualTo(0));
 		}
 
 		[Test]
@@ -26,9 +26,9 @@ namespace DynamicExpresso.UnitTest
 
 			var detectedIdentifiers = target.DetectIdentifiers(null);
 
-			Assert.AreEqual(0, detectedIdentifiers.UnknownIdentifiers.Count());
-			Assert.AreEqual(0, detectedIdentifiers.Identifiers.Count());
-			Assert.AreEqual(0, detectedIdentifiers.Types.Count());
+			Assert.That(detectedIdentifiers.UnknownIdentifiers.Count(), Is.EqualTo(0));
+			Assert.That(detectedIdentifiers.Identifiers.Count(), Is.EqualTo(0));
+			Assert.That(detectedIdentifiers.Types.Count(), Is.EqualTo(0));
 		}
 
 		[Test]
@@ -38,9 +38,9 @@ namespace DynamicExpresso.UnitTest
 
 			var detectedIdentifiers = target.DetectIdentifiers("x + y");
 
-			CollectionAssert.AreEqual(
-				new[] { "x", "y" },
-				detectedIdentifiers.UnknownIdentifiers.ToArray());
+			Assert.That(
+				detectedIdentifiers.UnknownIdentifiers,
+				Is.EqualTo(new[] { "x", "y" }));
 		}
 
 		[Test]
@@ -51,9 +51,9 @@ namespace DynamicExpresso.UnitTest
 			var detectedIdentifiers = target.DetectIdentifiers("Contact.Personal.Year_of_birth = 1987",
 				DetectorOptions.IncludeChildren);
 
-			CollectionAssert.AreEqual(
-				new[] { "Contact.Personal.Year_of_birth" },
-				detectedIdentifiers.UnknownIdentifiers.ToArray());
+			Assert.That(
+				detectedIdentifiers.UnknownIdentifiers,
+				Is.EqualTo(new[] { "Contact.Personal.Year_of_birth" }));
 		}
 
 		[Test]
@@ -67,9 +67,9 @@ namespace DynamicExpresso.UnitTest
 			{
 				var detectedIdentifiers = target.DetectIdentifiers(name);
 
-				CollectionAssert.AreEqual(
-					new[] { name },
-					detectedIdentifiers.UnknownIdentifiers.ToArray());
+				Assert.That(
+					detectedIdentifiers.UnknownIdentifiers,
+					Is.EqualTo(new[] { name }));
 			}
 		}
 
@@ -80,9 +80,9 @@ namespace DynamicExpresso.UnitTest
 
 			var detectedIdentifiers = target.DetectIdentifiers("x + x");
 
-			CollectionAssert.AreEqual(
-				new[] { "x" },
-				detectedIdentifiers.UnknownIdentifiers.ToArray());
+			Assert.That(
+				detectedIdentifiers.UnknownIdentifiers,
+				Is.EqualTo(new[] { "x" }));
 		}
 
 		[Test]
@@ -92,9 +92,9 @@ namespace DynamicExpresso.UnitTest
 
 			var detectedIdentifiers = target.DetectIdentifiers("x + X");
 
-			CollectionAssert.AreEqual(
-				new[] { "x" },
-				detectedIdentifiers.UnknownIdentifiers.ToArray());
+			Assert.That(
+				detectedIdentifiers.UnknownIdentifiers,
+				Is.EqualTo(new[] { "x" }));
 		}
 
 		[Test]
@@ -105,9 +105,9 @@ namespace DynamicExpresso.UnitTest
 
 			var detectedIdentifiers = target.DetectIdentifiers("x + x");
 
-			CollectionAssert.AreEqual(
-				new[] { "x" },
-				detectedIdentifiers.Identifiers.Select(p => p.Name).ToArray());
+			Assert.That(
+				detectedIdentifiers.Identifiers.Select(p => p.Name).ToArray(),
+				Is.EqualTo(new[] { "x" }));
 		}
 
 		[Test]
@@ -118,9 +118,9 @@ namespace DynamicExpresso.UnitTest
 
 			var detectedIdentifiers = target.DetectIdentifiers("x + X");
 
-			CollectionAssert.AreEqual(
-				new[] { "x" },
-				detectedIdentifiers.Identifiers.Select(p => p.Name).ToArray());
+			Assert.That(
+				detectedIdentifiers.Identifiers.Select(p => p.Name).ToArray(),
+				Is.EqualTo(new[] { "x" }));
 		}
 
 		[Test]
@@ -130,9 +130,9 @@ namespace DynamicExpresso.UnitTest
 
 			var detectedIdentifiers = target.DetectIdentifiers("string.Empty + string.Empty");
 
-			CollectionAssert.AreEqual(
-				new[] { "string" },
-				detectedIdentifiers.Types.Select(p => p.Name).ToArray());
+			Assert.That(
+				detectedIdentifiers.Types.Select(p => p.Name).ToArray(),
+				Is.EqualTo(new[] { "string" }));
 		}
 
 		[Test]
@@ -142,9 +142,9 @@ namespace DynamicExpresso.UnitTest
 
 			var detectedIdentifiers = target.DetectIdentifiers("string.Empty + STRING.Empty");
 
-			CollectionAssert.AreEqual(
-				new[] { "string" },
-				detectedIdentifiers.Types.Select(p => p.Name).ToArray());
+			Assert.That(
+				detectedIdentifiers.Types.Select(p => p.Name).ToArray(),
+				Is.EqualTo(new[] { "string" }));
 		}
 
 		[Test]
@@ -156,9 +156,9 @@ namespace DynamicExpresso.UnitTest
 
 			var detectedIdentifiers = target.DetectIdentifiers("x + y");
 
-			Assert.AreEqual(2, detectedIdentifiers.Identifiers.Count());
-			Assert.AreEqual("x", detectedIdentifiers.Identifiers.ElementAt(0).Name);
-			Assert.AreEqual("y", detectedIdentifiers.Identifiers.ElementAt(1).Name);
+			Assert.That(detectedIdentifiers.Identifiers.Count(), Is.EqualTo(2));
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(0).Name, Is.EqualTo("x"));
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(1).Name, Is.EqualTo("y"));
 		}
 
 		[Test]
@@ -168,9 +168,9 @@ namespace DynamicExpresso.UnitTest
 
 			var detectedIdentifiers = target.DetectIdentifiers("string.Empty");
 
-			Assert.AreEqual(1, detectedIdentifiers.Types.Count());
-			Assert.AreEqual("string", detectedIdentifiers.Types.ElementAt(0).Name);
-			Assert.AreEqual(typeof(string), detectedIdentifiers.Types.ElementAt(0).Type);
+			Assert.That(detectedIdentifiers.Types.Count(), Is.EqualTo(1));
+			Assert.That(detectedIdentifiers.Types.ElementAt(0).Name, Is.EqualTo("string"));
+			Assert.That(detectedIdentifiers.Types.ElementAt(0).Type, Is.EqualTo(typeof(string)));
 		}
 
 		[Test]
@@ -195,9 +195,9 @@ namespace DynamicExpresso.UnitTest
 
 			var detectedIdentifiers = target.DetectIdentifiers(testCase);
 
-			Assert.AreEqual(2, detectedIdentifiers.UnknownIdentifiers.Count());
-			Assert.AreEqual("x", detectedIdentifiers.UnknownIdentifiers.ElementAt(0));
-			Assert.AreEqual("y", detectedIdentifiers.UnknownIdentifiers.ElementAt(1));
+			Assert.That(detectedIdentifiers.UnknownIdentifiers.Count(), Is.EqualTo(2));
+			Assert.That(detectedIdentifiers.UnknownIdentifiers.ElementAt(0), Is.EqualTo("x"));
+			Assert.That(detectedIdentifiers.UnknownIdentifiers.ElementAt(1), Is.EqualTo("y"));
 		}
 
 		[Test]
@@ -207,18 +207,18 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("list", new List<string>());
 
 			var detectedIdentifiers = target.DetectIdentifiers("list.Any(x => x == null)");
-			Assert.IsEmpty(detectedIdentifiers.UnknownIdentifiers);
+			Assert.That(detectedIdentifiers.UnknownIdentifiers, Is.Empty);
 
-			Assert.AreEqual(3, detectedIdentifiers.Identifiers.Count());
+			Assert.That(detectedIdentifiers.Identifiers.Count(), Is.EqualTo(3));
 
-			Assert.AreEqual("list", detectedIdentifiers.Identifiers.ElementAt(0).Name);
-			Assert.AreEqual(typeof(List<string>), detectedIdentifiers.Identifiers.ElementAt(0).Expression.Type);
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(0).Name, Is.EqualTo("list"));
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(0).Expression.Type, Is.EqualTo(typeof(List<string>)));
 
-			Assert.AreEqual("x", detectedIdentifiers.Identifiers.ElementAt(1).Name);
-			Assert.AreEqual(typeof(object), detectedIdentifiers.Identifiers.ElementAt(1).Expression.Type);
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(1).Name, Is.EqualTo("x"));
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(1).Expression.Type, Is.EqualTo(typeof(object)));
 
-			Assert.AreEqual("null", detectedIdentifiers.Identifiers.ElementAt(2).Name);
-			Assert.AreEqual(typeof(object), detectedIdentifiers.Identifiers.ElementAt(2).Expression.Type);
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(2).Name, Is.EqualTo("null"));
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(2).Expression.Type, Is.EqualTo(typeof(object)));
 		}
 
 		[Test]
@@ -227,12 +227,12 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
 
 			var detectedIdentifiers = target.DetectIdentifiers("x => x + 5");
-			Assert.IsEmpty(detectedIdentifiers.UnknownIdentifiers);
+			Assert.That(detectedIdentifiers.UnknownIdentifiers, Is.Empty);
 
-			Assert.AreEqual(1, detectedIdentifiers.Identifiers.Count());
+			Assert.That(detectedIdentifiers.Identifiers.Count(), Is.EqualTo(1));
 
-			Assert.AreEqual("x", detectedIdentifiers.Identifiers.ElementAt(0).Name);
-			Assert.AreEqual(typeof(object), detectedIdentifiers.Identifiers.ElementAt(0).Expression.Type);
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(0).Name, Is.EqualTo("x"));
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(0).Expression.Type, Is.EqualTo(typeof(object)));
 		}
 
 		[Test]
@@ -241,15 +241,15 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
 
 			var detectedIdentifiers = target.DetectIdentifiers("(x, _1y) => x + _1y");
-			Assert.IsEmpty(detectedIdentifiers.UnknownIdentifiers);
+			Assert.That(detectedIdentifiers.UnknownIdentifiers, Is.Empty);
 
-			Assert.AreEqual(2, detectedIdentifiers.Identifiers.Count());
+			Assert.That(detectedIdentifiers.Identifiers.Count(), Is.EqualTo(2));
 
-			Assert.AreEqual("x", detectedIdentifiers.Identifiers.ElementAt(0).Name);
-			Assert.AreEqual(typeof(object), detectedIdentifiers.Identifiers.ElementAt(0).Expression.Type);
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(0).Name, Is.EqualTo("x"));
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(0).Expression.Type, Is.EqualTo(typeof(object)));
 
-			Assert.AreEqual("_1y", detectedIdentifiers.Identifiers.ElementAt(1).Name);
-			Assert.AreEqual(typeof(object), detectedIdentifiers.Identifiers.ElementAt(1).Expression.Type);
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(1).Name, Is.EqualTo("_1y"));
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(1).Expression.Type, Is.EqualTo(typeof(object)));
 		}
 
 		[Test]
@@ -258,21 +258,21 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
 
 			var detectedIdentifiers = target.DetectIdentifiers("(int x, string @class) => x + @class");
-			Assert.IsEmpty(detectedIdentifiers.UnknownIdentifiers);
+			Assert.That(detectedIdentifiers.UnknownIdentifiers, Is.Empty);
 
-			Assert.AreEqual(2, detectedIdentifiers.Types.Count());
-			Assert.AreEqual("int", detectedIdentifiers.Types.ElementAt(0).Name);
-			Assert.AreEqual(typeof(int), detectedIdentifiers.Types.ElementAt(0).Type);
-			Assert.AreEqual("string", detectedIdentifiers.Types.ElementAt(1).Name);
-			Assert.AreEqual(typeof(string), detectedIdentifiers.Types.ElementAt(1).Type);
+			Assert.That(detectedIdentifiers.Types.Count(), Is.EqualTo(2));
+			Assert.That(detectedIdentifiers.Types.ElementAt(0).Name, Is.EqualTo("int"));
+			Assert.That(detectedIdentifiers.Types.ElementAt(0).Type, Is.EqualTo(typeof(int)));
+			Assert.That(detectedIdentifiers.Types.ElementAt(1).Name, Is.EqualTo("string"));
+			Assert.That(detectedIdentifiers.Types.ElementAt(1).Type, Is.EqualTo(typeof(string)));
 
-			Assert.AreEqual(2, detectedIdentifiers.Identifiers.Count());
+			Assert.That(detectedIdentifiers.Identifiers.Count(), Is.EqualTo(2));
 
-			Assert.AreEqual("x", detectedIdentifiers.Identifiers.ElementAt(0).Name);
-			Assert.AreEqual(typeof(int), detectedIdentifiers.Identifiers.ElementAt(0).Expression.Type);
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(0).Name, Is.EqualTo("x"));
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(0).Expression.Type, Is.EqualTo(typeof(int)));
 
-			Assert.AreEqual("@class", detectedIdentifiers.Identifiers.ElementAt(1).Name);
-			Assert.AreEqual(typeof(string), detectedIdentifiers.Identifiers.ElementAt(1).Expression.Type);
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(1).Name, Is.EqualTo("@class"));
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(1).Expression.Type, Is.EqualTo(typeof(string)));
 		}
 
 		[Test]
@@ -283,30 +283,30 @@ namespace DynamicExpresso.UnitTest
 			var detectedIdentifiers =
 				target.DetectIdentifiers(
 					"(x, int y, z, int a) => x.Select(z => z + y).Select((string a, string b) => b)");
-			Assert.IsEmpty(detectedIdentifiers.UnknownIdentifiers);
+			Assert.That(detectedIdentifiers.UnknownIdentifiers, Is.Empty);
 
-			Assert.AreEqual(2, detectedIdentifiers.Types.Count());
-			Assert.AreEqual("int", detectedIdentifiers.Types.ElementAt(0).Name);
-			Assert.AreEqual(typeof(int), detectedIdentifiers.Types.ElementAt(0).Type);
-			Assert.AreEqual("string", detectedIdentifiers.Types.ElementAt(1).Name);
-			Assert.AreEqual(typeof(string), detectedIdentifiers.Types.ElementAt(1).Type);
+			Assert.That(detectedIdentifiers.Types.Count(), Is.EqualTo(2));
+			Assert.That(detectedIdentifiers.Types.ElementAt(0).Name, Is.EqualTo("int"));
+			Assert.That(detectedIdentifiers.Types.ElementAt(0).Type, Is.EqualTo(typeof(int)));
+			Assert.That(detectedIdentifiers.Types.ElementAt(1).Name, Is.EqualTo("string"));
+			Assert.That(detectedIdentifiers.Types.ElementAt(1).Type, Is.EqualTo(typeof(string)));
 
-			Assert.AreEqual(5, detectedIdentifiers.Identifiers.Count());
+			Assert.That(detectedIdentifiers.Identifiers.Count(), Is.EqualTo(5));
 
-			Assert.AreEqual("x", detectedIdentifiers.Identifiers.ElementAt(0).Name);
-			Assert.AreEqual(typeof(object), detectedIdentifiers.Identifiers.ElementAt(0).Expression.Type);
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(0).Name, Is.EqualTo("x"));
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(0).Expression.Type, Is.EqualTo(typeof(object)));
 
-			Assert.AreEqual("y", detectedIdentifiers.Identifiers.ElementAt(1).Name);
-			Assert.AreEqual(typeof(int), detectedIdentifiers.Identifiers.ElementAt(1).Expression.Type);
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(1).Name, Is.EqualTo("y"));
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(1).Expression.Type, Is.EqualTo(typeof(int)));
 
-			Assert.AreEqual("z", detectedIdentifiers.Identifiers.ElementAt(2).Name);
-			Assert.AreEqual(typeof(object), detectedIdentifiers.Identifiers.ElementAt(2).Expression.Type);
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(2).Name, Is.EqualTo("z"));
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(2).Expression.Type, Is.EqualTo(typeof(object)));
 
-			Assert.AreEqual("a", detectedIdentifiers.Identifiers.ElementAt(3).Name);
-			Assert.AreEqual(typeof(object), detectedIdentifiers.Identifiers.ElementAt(3).Expression.Type);
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(3).Name, Is.EqualTo("a"));
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(3).Expression.Type, Is.EqualTo(typeof(object)));
 
-			Assert.AreEqual("b", detectedIdentifiers.Identifiers.ElementAt(4).Name);
-			Assert.AreEqual(typeof(string), detectedIdentifiers.Identifiers.ElementAt(4).Expression.Type);
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(4).Name, Is.EqualTo("b"));
+			Assert.That(detectedIdentifiers.Identifiers.ElementAt(4).Expression.Type, Is.EqualTo(typeof(string)));
 		}
 
 		[Test]
@@ -323,8 +323,8 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
 			var detectedIdentifiers = target.DetectIdentifiers(code);
 
-			Assert.AreEqual(1, detectedIdentifiers.UnknownIdentifiers.Count());
-			Assert.AreEqual(identifier, detectedIdentifiers.UnknownIdentifiers.ElementAt(0));
+			Assert.That(detectedIdentifiers.UnknownIdentifiers.Count(), Is.EqualTo(1));
+			Assert.That(detectedIdentifiers.UnknownIdentifiers.ElementAt(0), Is.EqualTo(identifier));
 		}
 
 		[Test]
@@ -336,8 +336,8 @@ namespace DynamicExpresso.UnitTest
 			var detectedIdentifiers = target.DetectIdentifiers(code);
 
 			// @class should be detected as an identifier, but not the @if because it's a member
-			Assert.AreEqual(1, detectedIdentifiers.UnknownIdentifiers.Count());
-			Assert.AreEqual("@class", detectedIdentifiers.UnknownIdentifiers.ElementAt(0));
+			Assert.That(detectedIdentifiers.UnknownIdentifiers.Count(), Is.EqualTo(1));
+			Assert.That(detectedIdentifiers.UnknownIdentifiers.ElementAt(0), Is.EqualTo("@class"));
 		}
 
 
@@ -354,7 +354,7 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
 			var detectedIdentifiers = target.DetectIdentifiers(code);
-			Assert.IsEmpty(detectedIdentifiers.UnknownIdentifiers);
+			Assert.That(detectedIdentifiers.UnknownIdentifiers, Is.Empty);
 		}
 	}
 }

--- a/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
+++ b/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
@@ -8,8 +8,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.6.0" />
+		<PackageReference Include="NUnit" Version="4.3.2" />
+		<PackageReference Include="NUnit.Analyzers" Version="4.6.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
 	</ItemGroup>
 

--- a/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
+++ b/test/DynamicExpresso.UnitTest/DynamicExpresso.UnitTest.csproj
@@ -7,9 +7,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-		<PackageReference Include="NUnit" Version="3.9.0" />
-		<PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/test/DynamicExpresso.UnitTest/DynamicTest.cs
+++ b/test/DynamicExpresso.UnitTest/DynamicTest.cs
@@ -1,10 +1,10 @@
-using Microsoft.CSharp.RuntimeBinder;
-using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq.Expressions;
-using System.Collections.Generic;
 using DynamicExpresso.Exceptions;
+using Microsoft.CSharp.RuntimeBinder;
+using NUnit.Framework;
 
 namespace DynamicExpresso.UnitTest
 {
@@ -20,7 +20,7 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter()
 				.SetVariable("dyn", (object)dyn);
 
-			Assert.AreEqual(dyn.Foo, interpreter.Eval("dyn.Foo"));
+			Assert.That(interpreter.Eval("dyn.Foo"), Is.EqualTo(dyn.Foo));
 		}
 
 		[Test]
@@ -29,7 +29,7 @@ namespace DynamicExpresso.UnitTest
 			dynamic dyn = new ExpandoObject();
 			dyn.Sub = new { Foo = new { Bar = new { Foo2 = "bar" } } };
 			var interpreter = new Interpreter().SetVariable("dyn", (object)dyn);
-			Assert.AreEqual(dyn.Sub.Foo.Bar.Foo2, interpreter.Eval("dyn.Sub.Foo.Bar.Foo2"));
+			Assert.That(interpreter.Eval("dyn.Sub.Foo.Bar.Foo2"), Is.EqualTo(dyn.Sub.Foo.Bar.Foo2));
 		}
 
 		[Test]
@@ -42,7 +42,7 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter()
 					.SetVariable("dyn", (object)dyn);
 
-			Assert.AreEqual(dyn.Sub.Foo, interpreter.Eval("dyn.Sub.Foo"));
+			Assert.That(interpreter.Eval("dyn.Sub.Foo"), Is.EqualTo(dyn.Sub.Foo));
 		}
 
 		//[Test]
@@ -55,7 +55,7 @@ namespace DynamicExpresso.UnitTest
 
 		//	interpreter.Eval("dyn.Foo = 6");
 
-		//	Assert.AreEqual(6, dyn.Foo);
+		//	Assert.That(dyn.Foo, Is.EqualTo(6));
 		//}
 
 		[Test]
@@ -67,7 +67,7 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter()
 				.SetVariable("dyn", dyn);
 
-			Assert.AreEqual(dyn.RealProperty, interpreter.Eval("dyn.RealProperty"));
+			Assert.That(interpreter.Eval("dyn.RealProperty"), Is.EqualTo(dyn.RealProperty));
 		}
 
 		[Test]
@@ -79,7 +79,7 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter()
 				.SetVariable("dyn", dyn);
 
-			Assert.AreEqual(dyn.Foo(), interpreter.Eval("dyn.Foo()"));
+			Assert.That(interpreter.Eval("dyn.Foo()"), Is.EqualTo(dyn.Foo()));
 		}
 
 		[Test]
@@ -92,7 +92,7 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter()
 					.SetVariable("dyn", dyn);
 
-			Assert.AreEqual(dyn.Sub.Foo(), interpreter.Eval("dyn.Sub.Foo()"));
+			Assert.That(interpreter.Eval("dyn.Sub.Foo()"), Is.EqualTo(dyn.Sub.Foo()));
 		}
 
 		[Test]
@@ -105,7 +105,7 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter()
 					.SetVariable("dyn", dyn);
 
-			Assert.AreEqual(dyn.Sub.Foo.Func(), interpreter.Eval("dyn.Sub.Foo.Func()"));
+			Assert.That(interpreter.Eval("dyn.Sub.Foo.Func()"), Is.EqualTo(dyn.Sub.Foo.Func()));
 		}
 
 		[Test]
@@ -116,7 +116,7 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter()
 				.SetVariable("dyn", dyn);
 
-			Assert.AreEqual(dyn.ToString(), interpreter.Eval("dyn.ToString()"));
+			Assert.That(interpreter.Eval("dyn.ToString()"), Is.EqualTo(dyn.ToString()));
 		}
 
 		[Test]
@@ -133,9 +133,9 @@ namespace DynamicExpresso.UnitTest
 		public void Get_value_of_a_nested_array()
 		{
 			dynamic dyn = new ExpandoObject();
-			dyn.Sub = new int[] {42};
+			dyn.Sub = new int[] { 42 };
 			var interpreter = new Interpreter().SetVariable("dyn", (object)dyn);
-			Assert.AreEqual(dyn.Sub[0], interpreter.Eval("dyn.Sub[0]"));
+			Assert.That(interpreter.Eval("dyn.Sub[0]"), Is.EqualTo(dyn.Sub[0]));
 		}
 
 		[Test]
@@ -144,9 +144,9 @@ namespace DynamicExpresso.UnitTest
 			dynamic dyn = new ExpandoObject();
 			dyn.Sub = new { Foo = new int[] { 42 }, Bar = new { Sub = new int[] { 43 } } };
 			var interpreter = new Interpreter().SetVariable("dyn", (object)dyn);
-			Assert.AreEqual(dyn.Sub.Foo[0], interpreter.Eval("dyn.Sub.Foo[0]"));
-			Assert.AreEqual(dyn.Sub.Bar.Sub[0], interpreter.Eval("dyn.Sub.Bar.Sub[0]"));
-			Assert.AreEqual(dyn.Sub.Bar.Sub.Length, interpreter.Eval("dyn.Sub.Bar.Sub.Length"));
+			Assert.That(interpreter.Eval("dyn.Sub.Foo[0]"), Is.EqualTo(dyn.Sub.Foo[0]));
+			Assert.That(interpreter.Eval("dyn.Sub.Bar.Sub[0]"), Is.EqualTo(dyn.Sub.Bar.Sub[0]));
+			Assert.That(interpreter.Eval("dyn.Sub.Bar.Sub.Length"), Is.EqualTo(dyn.Sub.Bar.Sub.Length));
 		}
 
 		[Test]
@@ -166,28 +166,28 @@ namespace DynamicExpresso.UnitTest
 				ObjArr = new object[] { "Test", anonType1 }
 			};
 			var interpreter = new Interpreter().SetVariable("dyn", (object)dyn);
-			Assert.AreSame(dyn.Sub.Arg1.Foo, interpreter.Eval("dyn.Sub.Arg1.Foo"));
-			Assert.AreSame(dyn.Sub.Arg2.Foo, interpreter.Eval("dyn.Sub.Arg2.Foo"));
+			Assert.That(interpreter.Eval("dyn.Sub.Arg1.Foo"), Is.SameAs(dyn.Sub.Arg1.Foo));
+			Assert.That(interpreter.Eval("dyn.Sub.Arg2.Foo"), Is.SameAs(dyn.Sub.Arg2.Foo));
 			Assert.Throws<RuntimeBinderException>(() => Console.WriteLine(dyn.Sub.Arg3.Foo));
 			Assert.Throws<RuntimeBinderException>(() => interpreter.Eval("dyn.Sub.Arg3.Foo"));
-			Assert.AreSame(dyn.Sub.Arr[0].Foo, interpreter.Eval("dyn.Sub.Arr[0].Foo"));
-			Assert.AreSame(dyn.Sub.Arr[1].Foo, interpreter.Eval("dyn.Sub.Arr[1].Foo"));
+			Assert.That(interpreter.Eval("dyn.Sub.Arr[0].Foo"), Is.SameAs(dyn.Sub.Arr[0].Foo));
+			Assert.That(interpreter.Eval("dyn.Sub.Arr[1].Foo"), Is.SameAs(dyn.Sub.Arr[1].Foo));
 
 			Assert.Throws<RuntimeBinderException>(() => Console.WriteLine(dyn.Sub.Arr[2].Foo));
 			Assert.Throws<RuntimeBinderException>(() => interpreter.Eval("dyn.Sub.Arr[2].Foo"));
 
-			Assert.AreSame(dyn.Sub.ObjArr[0], interpreter.Eval("dyn.Sub.ObjArr[0]"));
-			Assert.AreEqual(dyn.Sub.ObjArr[0].Length, interpreter.Eval("dyn.Sub.ObjArr[0].Length"));
+			Assert.That(interpreter.Eval("dyn.Sub.ObjArr[0]"), Is.SameAs(dyn.Sub.ObjArr[0]));
+			Assert.That(interpreter.Eval("dyn.Sub.ObjArr[0].Length"), Is.EqualTo(dyn.Sub.ObjArr[0].Length));
 
-			Assert.AreSame(dyn.Sub.ObjArr[1], interpreter.Eval("dyn.Sub.ObjArr[1]"));
-			Assert.AreSame(dyn.Sub.ObjArr[1].Foo, interpreter.Eval("dyn.Sub.ObjArr[1].Foo"));
+			Assert.That(interpreter.Eval("dyn.Sub.ObjArr[1]"), Is.SameAs(dyn.Sub.ObjArr[1]));
+			Assert.That(interpreter.Eval("dyn.Sub.ObjArr[1].Foo"), Is.SameAs(dyn.Sub.ObjArr[1].Foo));
 		}
 
 		[Test]
 		public void Get_value_of_a_nested_array_error()
 		{
 			dynamic dyn = new ExpandoObject();
-			dyn.Sub = new int[] {42};
+			dyn.Sub = new int[] { 42 };
 			dyn.Bar = 123;
 			var interpreter = new Interpreter().SetVariable("dyn", (object)dyn);
 			Assert.Throws<RuntimeBinderException>(() => interpreter.Eval("dyn.Bar[0]")); // use index for a property that is not an array
@@ -208,7 +208,7 @@ namespace DynamicExpresso.UnitTest
 			var methodCallExpression = Expression.Call(Expression.Constant(myInstance), methodInfo);
 			var expression = Expression.Lambda(methodCallExpression);
 
-			Assert.AreEqual(myInstance.ToUniversalTime(), expression.Compile().DynamicInvoke());
+			Assert.That(expression.Compile().DynamicInvoke(), Is.EqualTo(myInstance.ToUniversalTime()));
 		}
 
 		[Test]
@@ -227,7 +227,7 @@ namespace DynamicExpresso.UnitTest
 			var methodCallExpression = Expression.Dynamic(binder, typeof(object), Expression.Constant(myInstance));
 			var expression = Expression.Lambda(methodCallExpression);
 
-			Assert.AreEqual(myInstance.MyMethod(), expression.Compile().DynamicInvoke());
+			Assert.That(expression.Compile().DynamicInvoke(), Is.EqualTo(myInstance.MyMethod()));
 		}
 
 		[Test]
@@ -236,8 +236,8 @@ namespace DynamicExpresso.UnitTest
 			DynamicIndexAccess globals = new DynamicIndexAccess();
 			Interpreter interpreter = new Interpreter()
 				.SetVariable("Values", new DynamicIndexAccess());
-			
-			Assert.AreEqual(globals.Values["Hello"], interpreter.Eval<string>("Values[\"Hello\"]"));
+
+			Assert.That(interpreter.Eval<string>("Values[\"Hello\"]"), Is.EqualTo(globals.Values["Hello"]));
 		}
 
 		[Test]
@@ -249,26 +249,26 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter()
 				.SetVariable("dyn", (object)dyn);
 
-			Assert.AreEqual(dyn.Foo == 500, interpreter.Eval("dyn.Foo == 500"));
-			Assert.AreEqual(500 == dyn.Foo, interpreter.Eval("500 == dyn.Foo"));
+			Assert.That(interpreter.Eval("dyn.Foo == 500"), Is.EqualTo(dyn.Foo == 500));
+			Assert.That(interpreter.Eval("500 == dyn.Foo"), Is.EqualTo(500 == dyn.Foo));
 
-			Assert.AreEqual(dyn.Foo != 200, interpreter.Eval("dyn.Foo != 200"));
-			Assert.AreEqual(200 != dyn.Foo, interpreter.Eval("200 != dyn.Foo"));
+			Assert.That(interpreter.Eval("dyn.Foo != 200"), Is.EqualTo(dyn.Foo != 200));
+			Assert.That(interpreter.Eval("200 != dyn.Foo"), Is.EqualTo(200 != dyn.Foo));
 
-			Assert.AreEqual(dyn.Foo > 200, interpreter.Eval("dyn.Foo > 200"));
-			Assert.AreEqual(600 > dyn.Foo, interpreter.Eval("600 > dyn.Foo"));
+			Assert.That(interpreter.Eval("dyn.Foo > 200"), Is.EqualTo(dyn.Foo > 200));
+			Assert.That(interpreter.Eval("600 > dyn.Foo"), Is.EqualTo(600 > dyn.Foo));
 
-			Assert.AreEqual(dyn.Foo < 600, interpreter.Eval("dyn.Foo < 600"));
-			Assert.AreEqual(200 < dyn.Foo, interpreter.Eval("200 < dyn.Foo"));
+			Assert.That(interpreter.Eval("dyn.Foo < 600"), Is.EqualTo(dyn.Foo < 600));
+			Assert.That(interpreter.Eval("200 < dyn.Foo"), Is.EqualTo(200 < dyn.Foo));
 
-			Assert.AreEqual(dyn.Foo >= 500, interpreter.Eval("dyn.Foo >= 500"));
-			Assert.AreEqual(500 >= dyn.Foo, interpreter.Eval("500 >= dyn.Foo"));
+			Assert.That(interpreter.Eval("dyn.Foo >= 500"), Is.EqualTo(dyn.Foo >= 500));
+			Assert.That(interpreter.Eval("500 >= dyn.Foo"), Is.EqualTo(500 >= dyn.Foo));
 
-			Assert.AreEqual(dyn.Foo <= 500, interpreter.Eval("dyn.Foo <= 500"));
-			Assert.AreEqual(500 <= dyn.Foo, interpreter.Eval("500 <= dyn.Foo"));
+			Assert.That(interpreter.Eval("dyn.Foo <= 500"), Is.EqualTo(dyn.Foo <= 500));
+			Assert.That(interpreter.Eval("500 <= dyn.Foo"), Is.EqualTo(500 <= dyn.Foo));
 
-			Assert.AreEqual(dyn.Foo + 500, interpreter.Eval("dyn.Foo + 500"));
-			Assert.AreEqual(500 + dyn.Foo, interpreter.Eval("500 + dyn.Foo"));
+			Assert.That(interpreter.Eval("dyn.Foo + 500"), Is.EqualTo(dyn.Foo + 500));
+			Assert.That(interpreter.Eval("500 + dyn.Foo"), Is.EqualTo(500 + dyn.Foo));
 		}
 
 		[Test]
@@ -281,7 +281,7 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter()
 				.SetVariable("dyn", (object)dyn);
 
-			Assert.AreEqual(dyn.Bar>0?100:200, interpreter.Eval("dyn.Bar>0?100:200"));
+			Assert.That(interpreter.Eval("dyn.Bar>0?100:200"), Is.EqualTo(dyn.Bar > 0 ? 100 : 200));
 		}
 
 		[Test]
@@ -294,22 +294,22 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter()
 				.SetVariable("dyn", (object)dyn);
 
-			Assert.AreEqual(dyn.Foo == 500 && dyn.Bar == 100, interpreter.Eval("dyn.Foo == 500 && dyn.Bar == 100"));
-			Assert.AreEqual(dyn.Foo == 500 && dyn.Bar != 100, interpreter.Eval("dyn.Foo == 500 && dyn.Bar != 100"));
-			Assert.AreEqual(dyn.Foo != 500 && dyn.Bar == 100, interpreter.Eval("dyn.Foo != 500 && dyn.Bar == 100"));
-			Assert.AreEqual(dyn.Foo != 500 && dyn.Bar != 100, interpreter.Eval("dyn.Foo != 500 && dyn.Bar != 100"));
+			Assert.That(interpreter.Eval("dyn.Foo == 500 && dyn.Bar == 100"), Is.EqualTo(dyn.Foo == 500 && dyn.Bar == 100));
+			Assert.That(interpreter.Eval("dyn.Foo == 500 && dyn.Bar != 100"), Is.EqualTo(dyn.Foo == 500 && dyn.Bar != 100));
+			Assert.That(interpreter.Eval("dyn.Foo != 500 && dyn.Bar == 100"), Is.EqualTo(dyn.Foo != 500 && dyn.Bar == 100));
+			Assert.That(interpreter.Eval("dyn.Foo != 500 && dyn.Bar != 100"), Is.EqualTo(dyn.Foo != 500 && dyn.Bar != 100));
 
 			//check non dynamic right side
-			Assert.AreEqual(dyn.Foo == 500 && 100 == 100, interpreter.Eval("dyn.Foo == 500 && 100 == 100"));
-			Assert.AreEqual(dyn.Foo == 500 && 100 != 100, interpreter.Eval("dyn.Foo == 500 && 100 != 100"));
-			Assert.AreEqual(dyn.Foo != 500 && 100 == 100, interpreter.Eval("dyn.Foo != 500 && 100 == 100"));
-			Assert.AreEqual(dyn.Foo != 500 && 100 != 100, interpreter.Eval("dyn.Foo != 500 && 100 != 100"));
+			Assert.That(interpreter.Eval("dyn.Foo == 500 && 100 == 100"), Is.EqualTo(dyn.Foo == 500 && 100 == 100));
+			Assert.That(interpreter.Eval("dyn.Foo == 500 && 100 != 100"), Is.EqualTo(dyn.Foo == 500 && 100 != 100));
+			Assert.That(interpreter.Eval("dyn.Foo != 500 && 100 == 100"), Is.EqualTo(dyn.Foo != 500 && 100 == 100));
+			Assert.That(interpreter.Eval("dyn.Foo != 500 && 100 != 100"), Is.EqualTo(dyn.Foo != 500 && 100 != 100));
 
 			//check non dynamic left side
-			Assert.AreEqual(100 == 100 && dyn.Foo == 500, interpreter.Eval("100 == 100 && dyn.Foo == 500"));
-			Assert.AreEqual(100 != 100 && dyn.Foo == 500, interpreter.Eval("100 != 100 && dyn.Foo == 500"));
-			Assert.AreEqual(100 == 100 && dyn.Foo != 500, interpreter.Eval("100 == 100 && dyn.Foo != 500"));
-			Assert.AreEqual(100 != 100 && dyn.Foo != 500, interpreter.Eval("100 != 100 && dyn.Foo != 500"));
+			Assert.That(interpreter.Eval("100 == 100 && dyn.Foo == 500"), Is.EqualTo(100 == 100 && dyn.Foo == 500));
+			Assert.That(interpreter.Eval("100 != 100 && dyn.Foo == 500"), Is.EqualTo(100 != 100 && dyn.Foo == 500));
+			Assert.That(interpreter.Eval("100 == 100 && dyn.Foo != 500"), Is.EqualTo(100 == 100 && dyn.Foo != 500));
+			Assert.That(interpreter.Eval("100 != 100 && dyn.Foo != 500"), Is.EqualTo(100 != 100 && dyn.Foo != 500));
 		}
 
 		[Test]
@@ -322,22 +322,22 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter()
 				.SetVariable("dyn", (object)dyn);
 
-			Assert.AreEqual(dyn.Foo == 500 || dyn.Bar == 100, interpreter.Eval("dyn.Foo == 500 || dyn.Bar == 100"));
-			Assert.AreEqual(dyn.Foo == 500 || dyn.Bar != 100, interpreter.Eval("dyn.Foo == 500 || dyn.Bar != 100"));
-			Assert.AreEqual(dyn.Foo != 500 || dyn.Bar == 100, interpreter.Eval("dyn.Foo != 500 || dyn.Bar == 100"));
-			Assert.AreEqual(dyn.Foo != 500 || dyn.Bar != 100, interpreter.Eval("dyn.Foo != 500 || dyn.Bar != 100"));
+			Assert.That(interpreter.Eval("dyn.Foo == 500 || dyn.Bar == 100"), Is.EqualTo(dyn.Foo == 500 || dyn.Bar == 100));
+			Assert.That(interpreter.Eval("dyn.Foo == 500 || dyn.Bar != 100"), Is.EqualTo(dyn.Foo == 500 || dyn.Bar != 100));
+			Assert.That(interpreter.Eval("dyn.Foo != 500 || dyn.Bar == 100"), Is.EqualTo(dyn.Foo != 500 || dyn.Bar == 100));
+			Assert.That(interpreter.Eval("dyn.Foo != 500 || dyn.Bar != 100"), Is.EqualTo(dyn.Foo != 500 || dyn.Bar != 100));
 
 			//check non dynamic right side
-			Assert.AreEqual(dyn.Foo == 500 || 100 == 100, interpreter.Eval("dyn.Foo == 500 || 100 == 100"));
-			Assert.AreEqual(dyn.Foo == 500 || 100 != 100, interpreter.Eval("dyn.Foo == 500 || 100 != 100"));
-			Assert.AreEqual(dyn.Foo != 500 || 100 == 100, interpreter.Eval("dyn.Foo != 500 || 100 == 100"));
-			Assert.AreEqual(dyn.Foo != 500 || 100 != 100, interpreter.Eval("dyn.Foo != 500 || 100 != 100"));
+			Assert.That(interpreter.Eval("dyn.Foo == 500 || 100 == 100"), Is.EqualTo(dyn.Foo == 500 || 100 == 100));
+			Assert.That(interpreter.Eval("dyn.Foo == 500 || 100 != 100"), Is.EqualTo(dyn.Foo == 500 || 100 != 100));
+			Assert.That(interpreter.Eval("dyn.Foo != 500 || 100 == 100"), Is.EqualTo(dyn.Foo != 500 || 100 == 100));
+			Assert.That(interpreter.Eval("dyn.Foo != 500 || 100 != 100"), Is.EqualTo(dyn.Foo != 500 || 100 != 100));
 
 			//check non dynamic left side
-			Assert.AreEqual(100 == 100 || dyn.Foo == 500, interpreter.Eval("100 == 100 || dyn.Foo == 500"));
-			Assert.AreEqual(100 != 100 || dyn.Foo == 500, interpreter.Eval("100 != 100 || dyn.Foo == 500"));
-			Assert.AreEqual(100 == 100 || dyn.Foo != 500, interpreter.Eval("100 == 100 || dyn.Foo != 500"));
-			Assert.AreEqual(100 != 100 || dyn.Foo != 500, interpreter.Eval("100 != 100 || dyn.Foo != 500"));
+			Assert.That(interpreter.Eval("100 == 100 || dyn.Foo == 500"), Is.EqualTo(100 == 100 || dyn.Foo == 500));
+			Assert.That(interpreter.Eval("100 != 100 || dyn.Foo == 500"), Is.EqualTo(100 != 100 || dyn.Foo == 500));
+			Assert.That(interpreter.Eval("100 == 100 || dyn.Foo != 500"), Is.EqualTo(100 == 100 || dyn.Foo != 500));
+			Assert.That(interpreter.Eval("100 != 100 || dyn.Foo != 500"), Is.EqualTo(100 != 100 || dyn.Foo != 500));
 		}
 
 		[Test]
@@ -349,37 +349,38 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter()
 				.SetVariable("dyn", (object)dyn);
 
-			Assert.AreEqual(dyn.Foo + 500, interpreter.Eval("dyn.Foo + 500"));
-			Assert.AreEqual(500 + dyn.Foo, interpreter.Eval("500 + dyn.Foo"));
+			Assert.That(interpreter.Eval("dyn.Foo + 500"), Is.EqualTo(dyn.Foo + 500));
+			Assert.That(interpreter.Eval("500 + dyn.Foo"), Is.EqualTo(500 + dyn.Foo));
 
-			Assert.AreEqual(dyn.Foo - 500, interpreter.Eval("dyn.Foo - 500"));
-			Assert.AreEqual(500 - dyn.Foo, interpreter.Eval("500 - dyn.Foo"));
+			Assert.That(interpreter.Eval("dyn.Foo - 500"), Is.EqualTo(dyn.Foo - 500));
+			Assert.That(interpreter.Eval("500 - dyn.Foo"), Is.EqualTo(500 - dyn.Foo));
 
-			Assert.AreEqual(dyn.Foo / 500, interpreter.Eval("dyn.Foo / 500"));
-			Assert.AreEqual(500 / dyn.Foo, interpreter.Eval("500 / dyn.Foo"));
+			Assert.That(interpreter.Eval("dyn.Foo / 500"), Is.EqualTo(dyn.Foo / 500));
+			Assert.That(interpreter.Eval("500 / dyn.Foo"), Is.EqualTo(500 / dyn.Foo));
 
-			Assert.AreEqual(dyn.Foo * 500, interpreter.Eval("dyn.Foo * 500"));
-			Assert.AreEqual(500 * dyn.Foo, interpreter.Eval("500 * dyn.Foo"));
+			Assert.That(interpreter.Eval("dyn.Foo * 500"), Is.EqualTo(dyn.Foo * 500));
+			Assert.That(interpreter.Eval("500 * dyn.Foo"), Is.EqualTo(500 * dyn.Foo));
 
-			Assert.AreEqual(dyn.Foo % 500, interpreter.Eval("dyn.Foo % 500"));
-			Assert.AreEqual(500 % dyn.Foo, interpreter.Eval("500 % dyn.Foo"));
+			Assert.That(interpreter.Eval("dyn.Foo % 500"), Is.EqualTo(dyn.Foo % 500));
+			Assert.That(interpreter.Eval("500 % dyn.Foo"), Is.EqualTo(500 % dyn.Foo));
 		}
 
 		public class ClassWithObjectProperties
-        {
+		{
 			public object Foo => 100;
 			public object Bar() => 100;
-        }
+		}
 
 		[Test]
 		public void ObjectLateBinding()
 		{
-			
+
 
 			var classWithObjectProperties = new ClassWithObjectProperties();
-						
 
-			Assert.Throws<ParseException>(() => {
+
+			Assert.Throws<ParseException>(() =>
+			{
 
 				var noLateBindingInterpreter = new Interpreter();
 				var noLateBindingDel = noLateBindingInterpreter.ParseAsDelegate<Func<ClassWithObjectProperties, int>>("d.Foo+d.Bar()", new[] { "d" });
@@ -388,19 +389,19 @@ namespace DynamicExpresso.UnitTest
 			});
 
 
-			var lateBindingInterpreter = new Interpreter(InterpreterOptions.Default|InterpreterOptions.LateBindObject);
+			var lateBindingInterpreter = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LateBindObject);
 			var lateBindingInterpreterDel = lateBindingInterpreter.ParseAsDelegate<Func<ClassWithObjectProperties, int>>("d.Foo+d.Bar()", new[] { "d" });
 			var lateBindingResult = lateBindingInterpreterDel.Invoke(classWithObjectProperties);
-			Assert.AreEqual((dynamic)classWithObjectProperties.Foo + (dynamic)classWithObjectProperties.Bar(), lateBindingResult);
+			Assert.That(lateBindingResult, Is.EqualTo((dynamic)classWithObjectProperties.Foo + (dynamic)classWithObjectProperties.Bar()));
 
 
 			lateBindingInterpreter.SetVariable("d", classWithObjectProperties);
 			var evalResult = lateBindingInterpreter.Eval("d.Foo+d.Bar()");
-			Assert.IsTrue(evalResult.GetType() == typeof(int));
-			Assert.AreEqual((dynamic)classWithObjectProperties.Foo + (dynamic)classWithObjectProperties.Bar(), evalResult);
+			Assert.That(evalResult.GetType(), Is.EqualTo(typeof(int)));
+			Assert.That(evalResult, Is.EqualTo((dynamic)classWithObjectProperties.Foo + (dynamic)classWithObjectProperties.Bar()));
 
 		}
-	
+
 
 		[Test]
 		public void Bitwise_with_dynamic_properties()
@@ -411,15 +412,15 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter()
 				.SetVariable("dyn", (object)dyn);
 
-			Assert.AreEqual(dyn.Foo & 500, interpreter.Eval("dyn.Foo & 500"));
-			Assert.AreEqual(500 & dyn.Foo, interpreter.Eval("500 & dyn.Foo"));
+			Assert.That(interpreter.Eval("dyn.Foo & 500"), Is.EqualTo(dyn.Foo & 500));
+			Assert.That(interpreter.Eval("500 & dyn.Foo"), Is.EqualTo(500 & dyn.Foo));
 
-			Assert.AreEqual(dyn.Foo | 500, interpreter.Eval("dyn.Foo | 500"));
-			Assert.AreEqual(500 | dyn.Foo, interpreter.Eval("500 | dyn.Foo"));
+			Assert.That(interpreter.Eval("dyn.Foo | 500"), Is.EqualTo(dyn.Foo | 500));
+			Assert.That(interpreter.Eval("500 | dyn.Foo"), Is.EqualTo(500 | dyn.Foo));
 
-			Assert.AreEqual(dyn.Foo ^ 500, interpreter.Eval("dyn.Foo ^ 500"));
-			Assert.AreEqual(500 ^ dyn.Foo, interpreter.Eval("500 ^ dyn.Foo"));
-			
+			Assert.That(interpreter.Eval("dyn.Foo ^ 500"), Is.EqualTo(dyn.Foo ^ 500));
+			Assert.That(interpreter.Eval("500 ^ dyn.Foo"), Is.EqualTo(500 ^ dyn.Foo));
+
 		}
 
 		[Test]
@@ -432,8 +433,8 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter()
 				.SetVariable("dyn", (object)dyn);
 
-			Assert.AreEqual(!dyn.Foo, interpreter.Eval("!dyn.Foo"));
-			Assert.AreEqual(-dyn.Bar, interpreter.Eval("-dyn.Bar"));
+			Assert.That(interpreter.Eval("!dyn.Foo"), Is.EqualTo(!dyn.Foo));
+			Assert.That(interpreter.Eval("-dyn.Bar"), Is.EqualTo(-dyn.Bar));
 
 
 
@@ -457,13 +458,13 @@ namespace DynamicExpresso.UnitTest
 			}
 		}
 
-		public class DynamicIndexAccess : DynamicObject 
+		public class DynamicIndexAccess : DynamicObject
 		{
-			public dynamic Values 
-			{ 
-				get 
-				{ 
-					return _values; 
+			public dynamic Values
+			{
+				get
+				{
+					return _values;
 				}
 			}
 			private readonly IReadOnlyDictionary<string, object> _values;

--- a/test/DynamicExpresso.UnitTest/EnumerableTest.cs
+++ b/test/DynamicExpresso.UnitTest/EnumerableTest.cs
@@ -16,13 +16,13 @@ namespace DynamicExpresso.UnitTest
 									.Reference(typeof(System.Linq.Enumerable))
 									.SetVariable("x", x);
 
-			Assert.AreEqual(x.Count(), target.Eval("x.Count()"));
-			Assert.AreEqual(x.Average(), target.Eval("x.Average()"));
-			Assert.AreEqual(x.First(), target.Eval("x.First()"));
-			Assert.AreEqual(x.Last(), target.Eval("x.Last()"));
-			Assert.AreEqual(x.Max(), target.Eval("x.Max()"));
-			CollectionAssert.AreEqual(x.Skip(2).ToArray(), target.Eval<IEnumerable<int>>("x.Skip(2)").ToArray());
-			CollectionAssert.AreEqual(x.Skip(2).ToArray(), target.Eval<IEnumerable<int>>("x.Skip(2)").ToArray());
+			Assert.That(target.Eval("x.Count()"), Is.EqualTo(x.Count()));
+			Assert.That(target.Eval("x.Average()"), Is.EqualTo(x.Average()));
+			Assert.That(target.Eval("x.First()"), Is.EqualTo(x.First()));
+			Assert.That(target.Eval("x.Last()"), Is.EqualTo(x.Last()));
+			Assert.That(target.Eval("x.Max()"), Is.EqualTo(x.Max()));
+			Assert.That(target.Eval<IEnumerable<int>>("x.Skip(2)").ToArray(), Is.EqualTo(x.Skip(2).ToArray()).AsCollection);
+			Assert.That(target.Eval<IEnumerable<int>>("x.Skip(2)").ToArray(), Is.EqualTo(x.Skip(2).ToArray()).AsCollection);
 		}
 	}
 }

--- a/test/DynamicExpresso.UnitTest/EnumerableTest.cs
+++ b/test/DynamicExpresso.UnitTest/EnumerableTest.cs
@@ -1,6 +1,6 @@
-﻿using System.Linq;
-using NUnit.Framework;
 using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
 
 namespace DynamicExpresso.UnitTest
 {
@@ -21,8 +21,8 @@ namespace DynamicExpresso.UnitTest
 			Assert.That(target.Eval("x.First()"), Is.EqualTo(x.First()));
 			Assert.That(target.Eval("x.Last()"), Is.EqualTo(x.Last()));
 			Assert.That(target.Eval("x.Max()"), Is.EqualTo(x.Max()));
-			Assert.That(target.Eval<IEnumerable<int>>("x.Skip(2)").ToArray(), Is.EqualTo(x.Skip(2).ToArray()).AsCollection);
-			Assert.That(target.Eval<IEnumerable<int>>("x.Skip(2)").ToArray(), Is.EqualTo(x.Skip(2).ToArray()).AsCollection);
+			Assert.That(target.Eval<IEnumerable<int>>("x.Skip(2)"), Is.EqualTo(x.Skip(2)));
+			Assert.That(target.Eval<IEnumerable<int>>("x.Skip(2)"), Is.EqualTo(x.Skip(2)));
 		}
 	}
 }

--- a/test/DynamicExpresso.UnitTest/ExpressionTypeTest.cs
+++ b/test/DynamicExpresso.UnitTest/ExpressionTypeTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NUnit.Framework;
 
 namespace DynamicExpresso.UnitTest
@@ -11,10 +11,10 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(typeof(string), target.Parse("\"ciao\"").ReturnType);
-			Assert.AreEqual(typeof(int), target.Parse("45").ReturnType);
-			Assert.AreEqual(typeof(double), target.Parse("45.4").ReturnType);
-			Assert.AreEqual(typeof(object), target.Parse("null").ReturnType);
+			Assert.That(target.Parse("\"ciao\"").ReturnType, Is.EqualTo(typeof(string)));
+			Assert.That(target.Parse("45").ReturnType, Is.EqualTo(typeof(int)));
+			Assert.That(target.Parse("45.4").ReturnType, Is.EqualTo(typeof(double)));
+			Assert.That(target.Parse("null").ReturnType, Is.EqualTo(typeof(object)));
 		}
 
 		[Test]
@@ -25,8 +25,8 @@ namespace DynamicExpresso.UnitTest
 
 			var lambda = target.Parse("213", expressionType);
 
-			Assert.AreEqual(expressionType, lambda.ReturnType);
-			Assert.AreEqual((double)213, lambda.Invoke());
+			Assert.That(lambda.ReturnType, Is.EqualTo(expressionType));
+			Assert.That(lambda.Invoke(), Is.EqualTo((double)213));
 		}
 
 		[Test]
@@ -37,8 +37,8 @@ namespace DynamicExpresso.UnitTest
 
 			var lambda = target.Parse("213.46", expressionType);
 
-			Assert.AreEqual(expressionType, lambda.ReturnType);
-			Assert.AreEqual((int)213.46, lambda.Invoke());
+			Assert.That(lambda.ReturnType, Is.EqualTo(expressionType));
+			Assert.That(lambda.Invoke(), Is.EqualTo((int)213.46));
 		}
 
 		[Test]
@@ -47,12 +47,12 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter();
 
 			var lambda = target.Parse("null", typeof(string));
-			Assert.AreEqual(typeof(string), lambda.ReturnType);
-			Assert.IsNull(lambda.Invoke());
+			Assert.That(lambda.ReturnType, Is.EqualTo(typeof(string)));
+			Assert.That(lambda.Invoke(), Is.Null);
 
 			lambda = target.Parse("null", typeof(TestReferenceType));
-			Assert.AreEqual(typeof(TestReferenceType), lambda.ReturnType);
-			Assert.IsNull(lambda.Invoke());
+			Assert.That(lambda.ReturnType, Is.EqualTo(typeof(TestReferenceType)));
+			Assert.That(lambda.Invoke(), Is.Null);
 		}
 
 		[Test]
@@ -61,12 +61,12 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter();
 
 			var lambda = target.Parse("null", typeof(int?));
-			Assert.AreEqual(typeof(int?), lambda.ReturnType);
-			Assert.IsNull(lambda.Invoke());
+			Assert.That(lambda.ReturnType, Is.EqualTo(typeof(int?)));
+			Assert.That(lambda.Invoke(), Is.Null);
 
 			lambda = target.Parse("null", typeof(DateTime?));
-			Assert.AreEqual(typeof(DateTime?), lambda.ReturnType);
-			Assert.IsNull(lambda.Invoke());
+			Assert.That(lambda.ReturnType, Is.EqualTo(typeof(DateTime?)));
+			Assert.That(lambda.Invoke(), Is.Null);
 		}
 
 		[Test]
@@ -75,12 +75,12 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter();
 
 			var lambda = target.Parse("null", typeof(int?));
-			Assert.AreEqual(typeof(int?), lambda.ReturnType);
-			Assert.IsNull(lambda.Invoke());
+			Assert.That(lambda.ReturnType, Is.EqualTo(typeof(int?)));
+			Assert.That(lambda.Invoke(), Is.Null);
 
 			lambda = target.Parse("4651", typeof(int?));
-			Assert.AreEqual(typeof(int?), lambda.ReturnType);
-			Assert.AreEqual(4651, lambda.Invoke());
+			Assert.That(lambda.ReturnType, Is.EqualTo(typeof(int?)));
+			Assert.That(lambda.Invoke(), Is.EqualTo(4651));
 		}
 
 		[Test]
@@ -92,7 +92,7 @@ namespace DynamicExpresso.UnitTest
 													new Parameter("x", typeof(double), 10),
 													new Parameter("y", typeof(double), 2));
 
-			Assert.AreEqual(Math.Pow(10, 2) + 5, result);
+			Assert.That(result, Is.EqualTo(Math.Pow(10, 2) + 5));
 		}
 
 		private class TestReferenceType { };

--- a/test/DynamicExpresso.UnitTest/ExtensionsMethodsTest.cs
+++ b/test/DynamicExpresso.UnitTest/ExtensionsMethodsTest.cs
@@ -17,8 +17,8 @@ namespace DynamicExpresso.UnitTest
 									.Reference(typeof(TestExtensionsMethods))
 									.SetVariable("x", x);
 
-			Assert.AreEqual(x.HelloWorld(), target.Eval("x.HelloWorld()"));
-			Assert.AreEqual(x.HelloWorldWithParam(DateTime.Now), target.Eval("x.HelloWorldWithParam(DateTime.Now)"));
+			Assert.That(target.Eval("x.HelloWorld()"), Is.EqualTo(x.HelloWorld()));
+			Assert.That(target.Eval("x.HelloWorldWithParam(DateTime.Now)"), Is.EqualTo(x.HelloWorldWithParam(DateTime.Now)));
 		}
 
 		[Test]
@@ -30,7 +30,7 @@ namespace DynamicExpresso.UnitTest
 									.Reference(typeof(TestExtensionsMethods))
 									.SetVariable("x", x);
 
-			Assert.AreEqual(x.GenericHello(), target.Eval("x.GenericHello()"));
+			Assert.That(target.Eval("x.GenericHello()"), Is.EqualTo(x.GenericHello()));
 		}
 
 		[Test]
@@ -42,7 +42,7 @@ namespace DynamicExpresso.UnitTest
 									.Reference(typeof(TestExtensionsMethods))
 									.SetVariable("x", x);
 
-			Assert.AreEqual(x.GenericParamHello(), target.Eval("x.GenericParamHello()"));
+			Assert.That(target.Eval("x.GenericParamHello()"), Is.EqualTo(x.GenericParamHello()));
 		}
 
 		[Test]
@@ -55,7 +55,7 @@ namespace DynamicExpresso.UnitTest
 									.Reference(typeof(MyClass))
 									.SetVariable("x", x);
 
-			Assert.AreEqual(x.GenericWith2Params(new MyClass()), target.Eval("x.GenericWith2Params(new MyClass())"));
+			Assert.That(target.Eval("x.GenericWith2Params(new MyClass())"), Is.EqualTo(x.GenericWith2Params(new MyClass())));
 		}
 
 		[Test]
@@ -68,7 +68,7 @@ namespace DynamicExpresso.UnitTest
 									.Reference(typeof(TestExtensionsMethods))
 									.SetVariable("x", x);
 
-			Assert.AreEqual(x.GenericWith2Args(), target.Eval("x.GenericWith2Args()"));
+			Assert.That(target.Eval("x.GenericWith2Args()"), Is.EqualTo(x.GenericWith2Args()));
 		}
 
 		[Test]
@@ -80,7 +80,7 @@ namespace DynamicExpresso.UnitTest
 									.Reference(typeof(TestExtensionsMethods))
 									.SetVariable("x", x);
 
-			Assert.AreEqual(x.GenericMixedParamHello(), target.Eval("x.GenericMixedParamHello()"));
+			Assert.That(target.Eval("x.GenericMixedParamHello()"), Is.EqualTo(x.GenericMixedParamHello()));
 		}
 
 		public class MyClass

--- a/test/DynamicExpresso.UnitTest/FunctionTest.cs
+++ b/test/DynamicExpresso.UnitTest/FunctionTest.cs
@@ -13,7 +13,7 @@ namespace DynamicExpresso.UnitTest
 			Func<double, double, double> pow = (x, y) => Math.Pow(x, y);
 			target.SetFunction("pow", pow);
 
-			Assert.AreEqual(25, target.Eval("pow(5, 2)"));
+			Assert.That(target.Eval("pow(5, 2)"), Is.EqualTo(25));
 		}
 
 		[Test]
@@ -23,7 +23,7 @@ namespace DynamicExpresso.UnitTest
 			Func<double, double, double> pow = (x, y) => Math.Pow(x, y);
 			target.SetFunction("pow", pow);
 
-			Assert.AreEqual("25", target.Eval("pow(5, 2).ToString()"));
+			Assert.That(target.Eval("pow(5, 2).ToString()"), Is.EqualTo("25"));
 		}
     }
 }

--- a/test/DynamicExpresso.UnitTest/GenerateDelegatesTest.cs
+++ b/test/DynamicExpresso.UnitTest/GenerateDelegatesTest.cs
@@ -14,10 +14,10 @@ namespace DynamicExpresso.UnitTest
 
 			var func = target.ParseAsDelegate<Func<double, double, double>>("Math.Pow(x, y) + 5", "x", "y");
 
-			Assert.AreEqual(Math.Pow(10, 2) + 5, func(10, 2));
+			Assert.That(func(10, 2), Is.EqualTo(Math.Pow(10, 2) + 5));
 
             func = target.ParseAsDelegate<Func<double, double, double>>("Math.Pow(x, y) + .5", "x", "y");
-            Assert.AreEqual(Math.Pow(10, 2) + .5, func(10, 2));
+            Assert.That(func(10, 2), Is.EqualTo(Math.Pow(10, 2) + .5));
         }
 
 		[Test]
@@ -27,7 +27,7 @@ namespace DynamicExpresso.UnitTest
 
 			var func = target.ParseAsDelegate<Func<int>>("50");
 
-			Assert.AreEqual(50, func());
+			Assert.That(func(), Is.EqualTo(50));
 		}
 
 		[Test]
@@ -37,8 +37,8 @@ namespace DynamicExpresso.UnitTest
 
 			var func = target.ParseAsDelegate<Func<string, int>>("arg.Length");
 
-			Assert.AreEqual(4, func("ciao"));
-			Assert.AreEqual(9, func("123456879"));
+			Assert.That(func("ciao"), Is.EqualTo(4));
+			Assert.That(func("123456879"), Is.EqualTo(9));
 		}
 
 		[Test]
@@ -49,8 +49,8 @@ namespace DynamicExpresso.UnitTest
 			var argumentName = "val"; // if not specified the delegate parameter is used which is "arg"
 			var func = target.ParseAsDelegate<Func<string, int>>("val.Length", argumentName);
 
-			Assert.AreEqual(4, func("ciao"));
-			Assert.AreEqual(9, func("123456879"));
+			Assert.That(func("ciao"), Is.EqualTo(4));
+			Assert.That(func("123456879"), Is.EqualTo(9));
 		}
 
 		[Test]
@@ -60,8 +60,8 @@ namespace DynamicExpresso.UnitTest
 
 			var func = target.ParseAsDelegate<Func<double, double, double>>("arg1 * arg2");
 
-			Assert.AreEqual(6, func(3, 2));
-			Assert.AreEqual(50, func(5, 10));
+			Assert.That(func(3, 2), Is.EqualTo(6));
+			Assert.That(func(5, 10), Is.EqualTo(50));
 		}
 
 		[Test]
@@ -72,8 +72,8 @@ namespace DynamicExpresso.UnitTest
 			var argumentNames = new [] { "x", "y" };
 			var func = target.ParseAsDelegate<Func<double, double, double>>("x * y", argumentNames);
 
-			Assert.AreEqual(6, func(3, 2));
-			Assert.AreEqual(50, func(5, 10));
+			Assert.That(func(3, 2), Is.EqualTo(6));
+			Assert.That(func(5, 10), Is.EqualTo(50));
 		}
 
 		[Test]
@@ -83,8 +83,8 @@ namespace DynamicExpresso.UnitTest
 
 			var func = target.ParseAsDelegate<MyCustomDelegate>("x + y.Length");
 
-			Assert.AreEqual(7, func(3, "ciao"));
-			Assert.AreEqual(10, func(5, "mondo"));
+			Assert.That(func(3, "ciao"), Is.EqualTo(7));
+			Assert.That(func(5, "mondo"), Is.EqualTo(10));
 		}
 
 		private delegate int MyCustomDelegate(int x, string y);

--- a/test/DynamicExpresso.UnitTest/GenerateLambdaTest.cs
+++ b/test/DynamicExpresso.UnitTest/GenerateLambdaTest.cs
@@ -14,7 +14,7 @@ namespace DynamicExpresso.UnitTest
 
 			Expression<Func<double, double>> lambdaExpression = target.ParseAsExpression<Func<double, double>>("arg + 5");
 
-			Assert.AreEqual(15, lambdaExpression.Compile()(10));
+			Assert.That(lambdaExpression.Compile()(10), Is.EqualTo(15));
 		}
 
 		[Test]
@@ -24,10 +24,10 @@ namespace DynamicExpresso.UnitTest
 
 			Expression<Func<double, double>> lambdaExpression = target.ParseAsExpression<Func<double, double>>("arg + 5");
 
-			Assert.AreEqual(15, lambdaExpression.Compile()(10));
+			Assert.That(lambdaExpression.Compile()(10), Is.EqualTo(15));
 
 			lambdaExpression = target.ParseAsExpression<Func<double, double>>("arg + .5");
-			Assert.AreEqual(10.5, lambdaExpression.Compile()(10));
+			Assert.That(lambdaExpression.Compile()(10), Is.EqualTo(10.5));
 		}
 
 		[Test]
@@ -37,8 +37,8 @@ namespace DynamicExpresso.UnitTest
 
 			var lambdaExpression = target.ParseAsExpression<Func<double, double, double>>("arg1 * arg2");
 
-			Assert.AreEqual(6, lambdaExpression.Compile()(3, 2));
-			Assert.AreEqual(50, lambdaExpression.Compile()(5, 10));
+			Assert.That(lambdaExpression.Compile()(3, 2), Is.EqualTo(6));
+			Assert.That(lambdaExpression.Compile()(5, 10), Is.EqualTo(50));
 		}
 
 		[Test]
@@ -49,8 +49,8 @@ namespace DynamicExpresso.UnitTest
 			var argumentNames = new string[] { "x", "y" };
 			var lambdaExpression = target.ParseAsExpression<Func<double, double, double>>("x * y", argumentNames);
 
-			Assert.AreEqual(6, lambdaExpression.Compile()(3, 2));
-			Assert.AreEqual(50, lambdaExpression.Compile()(5, 10));
+			Assert.That(lambdaExpression.Compile()(3, 2), Is.EqualTo(6));
+			Assert.That(lambdaExpression.Compile()(5, 10), Is.EqualTo(50));
 		}
 
 		[Test]
@@ -65,7 +65,7 @@ namespace DynamicExpresso.UnitTest
 
 			Expression<Func<double, double, double>> lambdaExpression = lambda.LambdaExpression<Func<double, double, double>>();
 
-			Assert.AreEqual(Math.Pow(10, 2) + 5, lambdaExpression.Compile()(10, 2));
+			Assert.That(lambdaExpression.Compile()(10, 2), Is.EqualTo(Math.Pow(10, 2) + 5));
 		}
 
 		[Test]

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -53,7 +53,7 @@ namespace DynamicExpresso.UnitTest
 		public void GitHub_Issue_64()
 		{
 			var interpreter = new Interpreter();
-			Assert.That(interpreter.Eval("null ?? null"), Is.EqualTo(null));
+			Assert.That(interpreter.Eval("null ?? null"), Is.Null);
 			Assert.That(interpreter.Eval("\"hallo\" ?? null"), Is.EqualTo("hallo"));
 			Assert.That(interpreter.Eval("null ?? \"hallo\""), Is.EqualTo("hallo"));
 		}
@@ -71,7 +71,7 @@ namespace DynamicExpresso.UnitTest
 
 			interpreter.SetVariable("x", x);
 			Assert.That(interpreter.Eval("x.var1?.ToString()"), Is.EqualTo("hallo"));
-			Assert.That(interpreter.Eval("x.var2?.ToString()"), Is.EqualTo(null));
+			Assert.That(interpreter.Eval("x.var2?.ToString()"), Is.Null);
 			Assert.That(interpreter.Eval("x.var1?.Substring(1)"), Is.EqualTo("allo"));
 		}
 

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -20,10 +20,10 @@ namespace DynamicExpresso.UnitTest
 		{
 			var interpreter = new Interpreter();
 
-			Assert.AreEqual(5.0.ToString(), interpreter.Eval("5.0.ToString()"));
-			Assert.AreEqual((5).ToString(), interpreter.Eval("(5).ToString()"));
-			Assert.AreEqual((5.0).ToString(), interpreter.Eval("(5.0).ToString()"));
-			Assert.AreEqual(5.ToString(), interpreter.Eval("5.ToString()"));
+			Assert.That(interpreter.Eval("5.0.ToString()"), Is.EqualTo(5.0.ToString()));
+			Assert.That(interpreter.Eval("(5).ToString()"), Is.EqualTo((5).ToString()));
+			Assert.That(interpreter.Eval("(5.0).ToString()"), Is.EqualTo((5.0).ToString()));
+			Assert.That(interpreter.Eval("5.ToString()"), Is.EqualTo(5.ToString()));
 		}
 
 		[Test]
@@ -31,9 +31,9 @@ namespace DynamicExpresso.UnitTest
 		{
 			var interpreter = new Interpreter();
 
-			Assert.AreEqual((-.5).ToString(), interpreter.Eval("-.5.ToString()"));
-			Assert.AreEqual((.1).ToString(), interpreter.Eval(".1.ToString()"));
-			Assert.AreEqual((-1 - .1 - 0.1).ToString(), interpreter.Eval("(-1-.1-0.1).ToString()"));
+			Assert.That(interpreter.Eval("-.5.ToString()"), Is.EqualTo((-.5).ToString()));
+			Assert.That(interpreter.Eval(".1.ToString()"), Is.EqualTo((.1).ToString()));
+			Assert.That(interpreter.Eval("(-1-.1-0.1).ToString()"), Is.EqualTo((-1 - .1 - 0.1).ToString()));
 		}
 
 		[Test]
@@ -45,17 +45,17 @@ namespace DynamicExpresso.UnitTest
 
 			interpreter.SetVariable("array", array);
 
-			Assert.AreEqual(array.Contains(5), interpreter.Eval("array.Contains(5)"));
-			Assert.AreEqual(array.Contains(3), interpreter.Eval("array.Contains(3)"));
+			Assert.That(interpreter.Eval("array.Contains(5)"), Is.EqualTo(array.Contains(5)));
+			Assert.That(interpreter.Eval("array.Contains(3)"), Is.EqualTo(array.Contains(3)));
 		}
 
 		[Test]
 		public void GitHub_Issue_64()
 		{
 			var interpreter = new Interpreter();
-			Assert.AreEqual(null, interpreter.Eval("null ?? null"));
-			Assert.AreEqual("hallo", interpreter.Eval("\"hallo\" ?? null"));
-			Assert.AreEqual("hallo", interpreter.Eval("null ?? \"hallo\""));
+			Assert.That(interpreter.Eval("null ?? null"), Is.EqualTo(null));
+			Assert.That(interpreter.Eval("\"hallo\" ?? null"), Is.EqualTo("hallo"));
+			Assert.That(interpreter.Eval("null ?? \"hallo\""), Is.EqualTo("hallo"));
 		}
 
 		[Test]
@@ -70,9 +70,9 @@ namespace DynamicExpresso.UnitTest
 			};
 
 			interpreter.SetVariable("x", x);
-			Assert.AreEqual("hallo", interpreter.Eval("x.var1?.ToString()"));
-			Assert.AreEqual(null, interpreter.Eval("x.var2?.ToString()"));
-			Assert.AreEqual("allo", interpreter.Eval("x.var1?.Substring(1)"));
+			Assert.That(interpreter.Eval("x.var1?.ToString()"), Is.EqualTo("hallo"));
+			Assert.That(interpreter.Eval("x.var2?.ToString()"), Is.EqualTo(null));
+			Assert.That(interpreter.Eval("x.var1?.Substring(1)"), Is.EqualTo("allo"));
 		}
 
 		[Test]
@@ -87,10 +87,10 @@ namespace DynamicExpresso.UnitTest
 			};
 
 			interpreter.SetVariable("x", x);
-			Assert.AreEqual(x.var1?[2], interpreter.Eval("x.var1?[2]"));
-			Assert.AreEqual(x.var2?[2], interpreter.Eval("x.var2?[2]"));
-			Assert.AreEqual(x.var1?[2] == 'l', interpreter.Eval("x.var1?[2] == 'l'"));
-			Assert.AreEqual(x.var2?[2] == null, interpreter.Eval("x.var2?[2] == null"));
+			Assert.That(interpreter.Eval("x.var1?[2]"), Is.EqualTo(x.var1?[2]));
+			Assert.That(interpreter.Eval("x.var2?[2]"), Is.EqualTo(x.var2?[2]));
+			Assert.That(interpreter.Eval("x.var1?[2] == 'l'"), Is.EqualTo(x.var1?[2] == 'l'));
+			Assert.That(interpreter.Eval("x.var2?[2] == null"), Is.EqualTo(x.var2?[2] == null));
 		}
 
 		[Test]
@@ -102,7 +102,7 @@ namespace DynamicExpresso.UnitTest
 			interpreter.SetVariable("b", 1.2, typeof(double?));
 			var result = interpreter.Eval("a + b");
 
-			Assert.AreEqual(result, 2.2);
+			Assert.That(result, Is.EqualTo(2.2));
 		}
 
 		[Test]
@@ -119,20 +119,20 @@ namespace DynamicExpresso.UnitTest
 		{
 			var interpreter = new Interpreter();
 
-			Assert.AreEqual(10000000001, interpreter.Eval("1+1e10"));
-			Assert.AreEqual(10000000001, interpreter.Eval("1+1e+10"));
-			Assert.AreEqual(1.0000000001, interpreter.Eval("1+1e-10"));
-			Assert.AreEqual(-20199999999, interpreter.Eval("1 - 2.02e10"));
-			Assert.AreEqual(-20199999999, interpreter.Eval("1 - 2.02e+10"));
-			Assert.AreEqual(0.999999999798, interpreter.Eval("1 - 2.02e-10"));
-			Assert.AreEqual(1e-10, interpreter.Eval("1/1e+10"));
+			Assert.That(interpreter.Eval("1+1e10"), Is.EqualTo(10000000001));
+			Assert.That(interpreter.Eval("1+1e+10"), Is.EqualTo(10000000001));
+			Assert.That(interpreter.Eval("1+1e-10"), Is.EqualTo(1.0000000001));
+			Assert.That(interpreter.Eval("1 - 2.02e10"), Is.EqualTo(-20199999999));
+			Assert.That(interpreter.Eval("1 - 2.02e+10"), Is.EqualTo(-20199999999));
+			Assert.That(interpreter.Eval("1 - 2.02e-10"), Is.EqualTo(0.999999999798));
+			Assert.That(interpreter.Eval("1/1e+10"), Is.EqualTo(1e-10));
 
 			interpreter.SetVariable("@Var1", 1);
 			interpreter.SetVariable("@Var2", 1e+10);
-			Assert.AreEqual(10000000001, interpreter.Eval("@Var1+@Var2"));
+			Assert.That(interpreter.Eval("@Var1+@Var2"), Is.EqualTo(10000000001));
 
 			interpreter.SetVariable("e", 2);
-			Assert.AreEqual(10000000003, interpreter.Eval("@Var1+@Var2+e"));
+			Assert.That(interpreter.Eval("@Var1+@Var2+e"), Is.EqualTo(10000000003));
 		}
 
 		private delegate bool GFunction(string arg = null);
@@ -148,18 +148,18 @@ namespace DynamicExpresso.UnitTest
 			// GetGFunction1 is defined outside the test function
 			GFunction gFunc1 = GetGFunction1;
 
-			Assert.True(gFunc1.Method.GetParameters()[0].HasDefaultValue);
+			Assert.That(gFunc1.Method.GetParameters()[0].HasDefaultValue, Is.True);
 
 			var flags = BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.Instance;
 			var invokeMethod1 = (MethodInfo)gFunc1.GetType().FindMembers(MemberTypes.Method, flags, Type.FilterName, "Invoke")[0];
-			Assert.True(invokeMethod1.GetParameters()[0].HasDefaultValue);
+			Assert.That(invokeMethod1.GetParameters()[0].HasDefaultValue, Is.True);
 
 			var interpreter = new Interpreter();
 			interpreter.SetFunction("GFunction", gFunc1);
 			interpreter.SetVariable("arg", "arg");
 
-			Assert.True((bool)interpreter.Eval("GFunction(arg)"));
-			Assert.False((bool)interpreter.Eval("GFunction()"));
+			Assert.That((bool)interpreter.Eval("GFunction(arg)"), Is.True);
+			Assert.That((bool)interpreter.Eval("GFunction()"), Is.False);
 		}
 
 		[Test]
@@ -172,7 +172,7 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("arr1", new object[] { 1d, 2d, 3d });
 			target.SetFunction("SubArray", subArray);
 
-			Assert.AreEqual(2, target.Eval("SubArray(arr1, 1, 1).First()"));
+			Assert.That(target.Eval("SubArray(arr1, 1, 1).First()"), Is.EqualTo(2));
 		}
 
 		[Test]
@@ -188,7 +188,7 @@ namespace DynamicExpresso.UnitTest
 			// we should properly throw an ambiguous invocation exception (multiple matching overloads found)
 			// and not an Argument list incompatible with delegate expression (no matching overload found)
 			var exc = Assert.Throws<ParseException>(() => interpreter.Eval("f(null)"));
-			StringAssert.StartsWith("Ambiguous invocation of delegate (multiple overloads found)", exc.Message);
+			Assert.That(exc.Message, Does.StartWith("Ambiguous invocation of delegate (multiple overloads found)"));
 		}
 
 
@@ -200,7 +200,7 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter();
 			interpreter.SetFunction("f", f1);
 
-			Assert.AreEqual(1, interpreter.Eval("f()"));
+			Assert.That(interpreter.Eval("f()"), Is.EqualTo(1));
 
 			// calls to f should lead to an unknown identifier exception
 			interpreter.UnsetFunction("f");
@@ -223,14 +223,14 @@ namespace DynamicExpresso.UnitTest
 
 			var flags = BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.Instance;
 			var invokeMethod2 = (MethodInfo)gFunc2.GetType().FindMembers(MemberTypes.Method, flags, Type.FilterName, "Invoke")[0];
-			Assert.True(invokeMethod2.GetParameters()[0].HasDefaultValue);
+			Assert.That(invokeMethod2.GetParameters()[0].HasDefaultValue, Is.True);
 
 			var interpreter = new Interpreter();
 			interpreter.SetFunction("GFunction", gFunc2);
 			interpreter.SetVariable("arg", "arg");
 
-			Assert.True((bool)interpreter.Eval("GFunction(arg)"));
-			Assert.False((bool)interpreter.Eval("GFunction()"));
+			Assert.That((bool)interpreter.Eval("GFunction(arg)"), Is.True);
+			Assert.That((bool)interpreter.Eval("GFunction()"), Is.False);
 		}
 
 		[Test]
@@ -256,7 +256,7 @@ namespace DynamicExpresso.UnitTest
 			// GFunction1 is used
 			// because gFunc1.Method.GetParameters()[0].HasDefaultValue == true
 			// and     gFunc2.Method.GetParameters()[0].HasDefaultValue == false
-			Assert.False((bool)interpreter.Eval("GFunction()"));
+			Assert.That((bool)interpreter.Eval("GFunction()"), Is.False);
 		}
 
 #endif
@@ -269,13 +269,13 @@ namespace DynamicExpresso.UnitTest
 			var str = "str";
 
 			interpreter.SetVariable("str", str);
-			Assert.AreEqual(str?.Length, interpreter.Eval("str?.Length"));
-			Assert.AreEqual(str?.Length == 3, interpreter.Eval<bool>("str?.Length == 3"));
+			Assert.That(interpreter.Eval("str?.Length"), Is.EqualTo(str?.Length));
+			Assert.That(interpreter.Eval<bool>("str?.Length == 3"), Is.EqualTo(str?.Length == 3));
 
 			str = null;
 			interpreter.SetVariable("str", str);
-			Assert.AreEqual(str?.Length, interpreter.Eval("str?.Length"));
-			Assert.AreEqual(str?.Length == 0, interpreter.Eval<bool>("str?.Length == 0"));
+			Assert.That(interpreter.Eval("str?.Length"), Is.EqualTo(str?.Length));
+			Assert.That(interpreter.Eval<bool>("str?.Length == 0"), Is.EqualTo(str?.Length == 0));
 		}
 
 		[Test]
@@ -286,14 +286,14 @@ namespace DynamicExpresso.UnitTest
 			var lambda = interpreter.Parse("Scope?.ValueInt", new Parameter("Scope", typeof(Scope)));
 
 			var result = lambda.Invoke((Scope)null);
-			Assert.IsNull(result);
+			Assert.That(result, Is.Null);
 
 			result = lambda.Invoke(new Scope { ValueInt = 5 });
-			Assert.AreEqual(5, result);
+			Assert.That(result, Is.EqualTo(5));
 
 			var scope = new Scope { Value = 5 };
 			interpreter.SetVariable("scope", scope);
-			Assert.AreEqual(scope?.Value.HasValue, interpreter.Eval<bool>("scope?.Value.HasValue"));
+			Assert.That(interpreter.Eval<bool>("scope?.Value.HasValue"), Is.EqualTo(scope?.Value.HasValue));
 
 			// must throw, because scope.ValueInt is not a nullable type
 			Assert.Throws<ParseException>(() => interpreter.Eval<bool>("scope.ValueInt.HasValue"));
@@ -316,16 +316,16 @@ namespace DynamicExpresso.UnitTest
 			var lambda = interpreter.Parse("Scope?.Value", new Parameter("Scope", typeof(Scope)));
 
 			var result = lambda.Invoke((Scope)null);
-			Assert.IsNull(result);
+			Assert.That(result, Is.Null);
 
 			result = lambda.Invoke(new Scope());
-			Assert.IsNull(result);
+			Assert.That(result, Is.Null);
 
 			result = lambda.Invoke(new Scope { Value = null });
-			Assert.IsNull(result);
+			Assert.That(result, Is.Null);
 
 			result = lambda.Invoke(new Scope { Value = 5 });
-			Assert.AreEqual(5, result);
+			Assert.That(result, Is.EqualTo(5));
 		}
 
 		[Test]
@@ -336,13 +336,13 @@ namespace DynamicExpresso.UnitTest
 			var lambda = interpreter.Parse("Scope?.Arr?[0]", new Parameter("Scope", typeof(Scope)));
 
 			var result = lambda.Invoke(new Scope());
-			Assert.IsNull(result);
+			Assert.That(result, Is.Null);
 
 			result = lambda.Invoke(new Scope { Arr = null });
-			Assert.IsNull(result);
+			Assert.That(result, Is.Null);
 
 			result = lambda.Invoke(new Scope { Arr = new int?[] { 5 } });
-			Assert.AreEqual(5, result);
+			Assert.That(result, Is.EqualTo(5));
 		}
 
 		[Test]
@@ -353,14 +353,14 @@ namespace DynamicExpresso.UnitTest
 			var lambda = interpreter.Parse("Scope?.ArrInt?[0]", new Parameter("Scope", typeof(Scope)));
 
 			var result = lambda.Invoke(new Scope());
-			Assert.IsNull(result);
+			Assert.That(result, Is.Null);
 
 			result = lambda.Invoke(new Scope { ArrInt = new int[] { 5 } });
-			Assert.AreEqual(5, result);
+			Assert.That(result, Is.EqualTo(5));
 
 			interpreter.SetVariable("scope", new Scope { ArrInt = new int[] { 5 } });
 			var resultNullableBool = interpreter.Eval<bool>("scope?.ArrInt?[0].HasValue");
-			Assert.IsTrue(resultNullableBool);
+			Assert.That(resultNullableBool, Is.True);
 
 			// must throw, because scope.ValueInt is not a nullable type
 			Assert.Throws<ParseException>(() => interpreter.Eval<bool>("scope.ArrInt[0].HasValue"));
@@ -373,11 +373,11 @@ namespace DynamicExpresso.UnitTest
 
 			interpreter.SetVariable("x", (int?)null);
 			var result = interpreter.Eval<string>("x?.ToString()");
-			Assert.IsNull(result);
+			Assert.That(result, Is.Null);
 
 			interpreter.SetVariable("x", (int?)56);
 			result = interpreter.Eval<string>("x?.ToString()");
-			Assert.AreEqual("56", result);
+			Assert.That(result, Is.EqualTo("56"));
 		}
 
 		[Test]
@@ -394,10 +394,10 @@ namespace DynamicExpresso.UnitTest
 			};
 
 			var expressionWithoutLambdas = interpreterWithoutLambdas.Parse(stringExpression, typeof(void), parameters.ToArray());
-			Assert.AreEqual("E33", expressionWithoutLambdas.Invoke(parameters.ToArray()));
+			Assert.That(expressionWithoutLambdas.Invoke(parameters.ToArray()), Is.EqualTo("E33"));
 
 			var expressionWithLambdas = interpreterWithLambdas.Parse(stringExpression, typeof(void), parameters.ToArray());
-			Assert.AreEqual("E33", expressionWithLambdas.Invoke(parameters.ToArray()));
+			Assert.That(expressionWithLambdas.Invoke(parameters.ToArray()), Is.EqualTo("E33"));
 		}
 
 		[Test]
@@ -409,7 +409,7 @@ namespace DynamicExpresso.UnitTest
 			// (ie a conversion expression should be emitted from long to object)
 			var del = interpreter.ParseAsDelegate<Func<object>>("a*2");
 			var result = del();
-			Assert.AreEqual(246, result);
+			Assert.That(result, Is.EqualTo(246));
 		}
 
 		[Test]
@@ -418,7 +418,7 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter().SetVariable("a", 123L);
 			var del = interpreter.ParseAsDelegate<Func<dynamic>>("a*2");
 			var result = del();
-			Assert.AreEqual(246, result);
+			Assert.That(result, Is.EqualTo(246));
 		}
 
 		[Test]
@@ -428,7 +428,7 @@ namespace DynamicExpresso.UnitTest
 			interpreter.Reference(typeof(Utils));
 
 			var result = interpreter.Eval<object>("Utils.Select(Utils.Array(\"a\", \"b\"), \"x+x\")");
-			Assert.IsNotNull(result);
+			Assert.That(result, Is.Not.Null);
 		}
 
 		[Test]
@@ -440,7 +440,7 @@ namespace DynamicExpresso.UnitTest
 			var list = new[] { 1, 2, 3 };
 
 			var listInt = target.Eval<List<int>>("Utils.Array(list)", new Parameter("list", list));
-			Assert.AreEqual(Utils.Array(list), listInt);
+			Assert.That(listInt, Is.EqualTo(Utils.Array(list)));
 		}
 
 		[Test]
@@ -451,14 +451,14 @@ namespace DynamicExpresso.UnitTest
 			DateTime? date = DateTime.UtcNow;
 			interpreter.SetVariable("date", date);
 
-			Assert.AreEqual(date?.Day, interpreter.Eval("date?.Day"));
-			Assert.AreEqual(date?.IsDaylightSavingTime(), interpreter.Eval("date?.IsDaylightSavingTime()"));
+			Assert.That(interpreter.Eval("date?.Day"), Is.EqualTo(date?.Day));
+			Assert.That(interpreter.Eval("date?.IsDaylightSavingTime()"), Is.EqualTo(date?.IsDaylightSavingTime()));
 
 			date = null;
 			interpreter.SetVariable("date", date);
 
-			Assert.AreEqual(date?.Day, interpreter.Eval("date?.Day"));
-			Assert.AreEqual(date?.IsDaylightSavingTime(), interpreter.Eval("date?.IsDaylightSavingTime()"));
+			Assert.That(interpreter.Eval("date?.Day"), Is.EqualTo(date?.Day));
+			Assert.That(interpreter.Eval("date?.IsDaylightSavingTime()"), Is.EqualTo(date?.IsDaylightSavingTime()));
 		}
 
 		[Test]
@@ -472,11 +472,11 @@ namespace DynamicExpresso.UnitTest
 			interpreter.SetVariable("date1", date1);
 			interpreter.SetVariable("date2", date2);
 
-			Assert.IsNull(interpreter.Eval("(date1 - date2)?.Days"));
+			Assert.That(interpreter.Eval("(date1 - date2)?.Days"), Is.Null);
 
 			date2 = date1.AddDays(1);
 			interpreter.SetVariable("date2", date2);
-			Assert.AreEqual(-1, interpreter.Eval("(date1 - date2)?.Days"));
+			Assert.That(interpreter.Eval("(date1 - date2)?.Days"), Is.EqualTo(-1));
 		}
 
 		[Test]
@@ -486,12 +486,12 @@ namespace DynamicExpresso.UnitTest
 			target.Reference(typeof(Utils));
 			target.Reference(typeof(IEnumerable<>));
 
-			Assert.AreEqual(1, Utils.Any((IEnumerable<object>)null));
-			Assert.AreEqual(2, Utils.Any((IEnumerable)null));
-			Assert.AreEqual(2, Utils.Any(null));
-			Assert.AreEqual(1, target.Eval("Utils.Any(list)", new Parameter("list", typeof(IEnumerable<object>), null)));
-			Assert.AreEqual(2, target.Eval("Utils.Any(list)", new Parameter("list", typeof(IEnumerable), null)));
-			Assert.AreEqual(2, target.Eval("Utils.Any(null)"));
+			Assert.That(Utils.Any((IEnumerable<object>)null), Is.EqualTo(1));
+			Assert.That(Utils.Any((IEnumerable)null), Is.EqualTo(2));
+			Assert.That(Utils.Any(null), Is.EqualTo(2));
+			Assert.That(target.Eval("Utils.Any(list)", new Parameter("list", typeof(IEnumerable<object>), null)), Is.EqualTo(1));
+			Assert.That(target.Eval("Utils.Any(list)", new Parameter("list", typeof(IEnumerable), null)), Is.EqualTo(2));
+			Assert.That(target.Eval("Utils.Any(null)"), Is.EqualTo(2));
 		}
 
 		[Test]
@@ -505,19 +505,19 @@ namespace DynamicExpresso.UnitTest
 				.SetVariable("DateInThePast", DateTimeOffset.UtcNow.AddDays(-5));
 
 			// actual case
-			Assert.IsTrue(interpreter.Eval<bool>("List.Any(x => x > Now())"));
-			Assert.IsTrue(interpreter.Eval<bool>("List.Any(x => x is DateTimeOffset)"));
-			Assert.IsFalse(interpreter.Eval<bool>("DateInThePast.IsInFuture()"));
+			Assert.That(interpreter.Eval<bool>("List.Any(x => x > Now())"), Is.True);
+			Assert.That(interpreter.Eval<bool>("List.Any(x => x is DateTimeOffset)"), Is.True);
+			Assert.That(interpreter.Eval<bool>("DateInThePast.IsInFuture()"), Is.False);
 
 			// case insensivity outside lambda expressions
-			Assert.IsFalse(interpreter.Eval<bool>("dateinthepast > now()")); // identifier
-			Assert.IsTrue(interpreter.Eval<bool>("dateinthepast is datetimeoffset")); // known type
-			Assert.IsFalse(interpreter.Eval<bool>("dateinthepast.isinfuture()")); // extension method
+			Assert.That(interpreter.Eval<bool>("dateinthepast > now()"), Is.False); // identifier
+			Assert.That(interpreter.Eval<bool>("dateinthepast is datetimeoffset"), Is.True); // known type
+			Assert.That(interpreter.Eval<bool>("dateinthepast.isinfuture()"), Is.False); // extension method
 
 			// ensure the case insensitivity option is also used in the lambda expression
-			Assert.IsTrue(interpreter.Eval<bool>("list.Any(x => x > now())")); // identifier
-			Assert.IsTrue(interpreter.Eval<bool>("list.Any(x => x is datetimeoffset)")); // known type
-			Assert.IsTrue(interpreter.Eval<bool>("list.Any(x => x.isinfuture())")); // extension method
+			Assert.That(interpreter.Eval<bool>("list.Any(x => x > now())"), Is.True); // identifier
+			Assert.That(interpreter.Eval<bool>("list.Any(x => x is datetimeoffset)"), Is.True); // known type
+			Assert.That(interpreter.Eval<bool>("list.Any(x => x.isinfuture())"), Is.True); // extension method
 		}
 
 		[Test]
@@ -549,12 +549,12 @@ namespace DynamicExpresso.UnitTest
 			target.Reference(typeof(DateTimeKind));
 
 			var result = target.Eval<RegexOptions>("RegexOptions.Compiled | RegexOptions.Singleline");
-			Assert.True(result.HasFlag(RegexOptions.Compiled));
-			Assert.True(result.HasFlag(RegexOptions.Singleline));
+			Assert.That(result.HasFlag(RegexOptions.Compiled), Is.True);
+			Assert.That(result.HasFlag(RegexOptions.Singleline), Is.True);
 
 			// DateTimeKind doesn't have the Flags attribute: the bitwise operation returns an integer
 			var result2 = target.Eval<DateTimeKind>("DateTimeKind.Local | DateTimeKind.Utc");
-			Assert.AreEqual((DateTimeKind)3, result2);
+			Assert.That(result2, Is.EqualTo((DateTimeKind)3));
 		}
 
 		[Test]
@@ -567,7 +567,7 @@ namespace DynamicExpresso.UnitTest
 			var expression = "list.Where(x => x > value)";
 			var lambda = target.Parse(expression, list, value1);
 			var result = lambda.Invoke(list, value2);
-			Assert.AreEqual(new[] { 3 }, result);
+			Assert.That(result, Is.EqualTo(new[] { 3 }));
 		}
 
 		[Test]
@@ -580,7 +580,7 @@ namespace DynamicExpresso.UnitTest
 			var expression = "list.Where(x => x > value)";
 			var lambda = target.Parse(expression, (new[] { list, value1 }).Select(p => new Parameter(p.Name, p.Type)).ToArray());
 			var result = lambda.Invoke(list, value1);
-			Assert.AreEqual(new[] { 2, 3 }, result);
+			Assert.That(result, Is.EqualTo(new[] { 2, 3 }));
 		}
 
 		[Test]
@@ -592,7 +592,7 @@ namespace DynamicExpresso.UnitTest
 
 			// the str parameter is captured, and can be used in the nested lambda
 			var results = target.Eval("myList.Select(str => str.Select(c => str.Length))");
-			Assert.AreEqual(new[] { new[] { 2, 2 }, new[] { 3, 3, 3 } }, results);
+			Assert.That(results, Is.EqualTo(new[] { new[] { 2, 2 }, new[] { 3, 3, 3 } }));
 		}
 
 		[Test]
@@ -626,7 +626,7 @@ namespace DynamicExpresso.UnitTest
 			var totalBonus = employees.Sum(x => x.Salary * (annualBonus.SingleOrDefault(y => y.Grade == x.Grade).BonusFactor)); //total = 357875
 
 			var evalSum = interpreter.Eval("employees.Sum(x => x.Salary * (annualBonus.SingleOrDefault(y => y.Grade == x.Grade).BonusFactor))");
-			Assert.AreEqual(totalBonus, evalSum);
+			Assert.That(evalSum, Is.EqualTo(totalBonus));
 		}
 
 		public class Employee
@@ -652,11 +652,11 @@ namespace DynamicExpresso.UnitTest
 			interpreter.Reference(typeof(PageType));
 
 			var results = interpreter.Eval<IEnumerable<PageType>>(@"courseList.Select(x => new PageType() { PageName = x.PageName, VisualCount = 5 })");
-			Assert.AreEqual(1, results.Count());
+			Assert.That(results.Count(), Is.EqualTo(1));
 
 			var result = results.Single();
-			Assert.AreEqual("Test", result.PageName);
-			Assert.AreEqual(5, result.VisualCount);
+			Assert.That(result.PageName, Is.EqualTo("Test"));
+			Assert.That(result.VisualCount, Is.EqualTo(5));
 		}
 
 		public class PageType
@@ -673,11 +673,11 @@ namespace DynamicExpresso.UnitTest
 			target.Reference(typeof(DateTimeKind));
 
 			var result = target.Eval<RegexOptions>("~RegexOptions.None");
-			Assert.AreEqual(~RegexOptions.None, result);
+			Assert.That(result, Is.EqualTo(~RegexOptions.None));
 
 			// DateTimeKind doesn't have the Flags attribute: the bitwise operation returns an integer
 			var result2 = target.Eval<DateTimeKind>("~DateTimeKind.Local");
-			Assert.AreEqual((DateTimeKind)(-3), result2);
+			Assert.That(result2, Is.EqualTo((DateTimeKind)(-3)));
 		}
 
 		[Test]
@@ -691,11 +691,11 @@ namespace DynamicExpresso.UnitTest
 			interpreter.SetVariable("list", list);
 
 			var results = interpreter.Eval<List<int>>(@"b.Add(list, (int t) => t + 10)");
-			Assert.AreEqual(new List<int> { 20, 40, 14 }, results);
+			Assert.That(results, Is.EqualTo(new List<int> { 20, 40, 14 }));
 
 			// ensure that list, t are not parsed as two arguments of a lambda expression
 			results = interpreter.Eval<List<int>>(@"b.Add(list, t => t + 10)");
-			Assert.AreEqual(new List<int> { 20, 40, 14 }, results);
+			Assert.That(results, Is.EqualTo(new List<int> { 20, 40, 14 }));
 		}
 
 		public class Functions
@@ -718,7 +718,7 @@ namespace DynamicExpresso.UnitTest
 			Assert.Throws<NullReferenceException>(() => interpreter.Eval<int>("Utils.ParamArrayObjects(null)"));
 
 			var result = interpreter.Eval<int>($"Utils.ParamArrayObjects({paramsArguments})");
-			Assert.AreEqual(4, result);
+			Assert.That(result, Is.EqualTo(4));
 		}
 
 		[Test]
@@ -727,7 +727,7 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter();
 
 			var result = interpreter.Eval<bool>("((int?)5)>((double?)4)");
-			Assert.IsTrue(result);
+			Assert.That(result, Is.True);
 		}
 
 		[Test]
@@ -739,16 +739,16 @@ namespace DynamicExpresso.UnitTest
 			object str = "test";
 			interpreter.SetVariable("str", str, typeof(object));
 
-			Assert.AreEqual(string.IsNullOrEmpty(str as string), interpreter.Eval("string.IsNullOrEmpty(str as string)"));
-			Assert.AreEqual(str is string, interpreter.Eval("str is string"));
-			Assert.AreEqual(str is int?, interpreter.Eval("str is int?"));
-			Assert.AreEqual(str is int[], interpreter.Eval("(str is int[])"));
-			Assert.AreEqual(str is int?[], interpreter.Eval("(str is int?[])"));
-			Assert.AreEqual(str is int?[][], interpreter.Eval("(str is int?[][])"));
-			Assert.AreEqual(str is IEnumerable<int>[][], interpreter.Eval("(str is IEnumerable<int>[][])"));
-			Assert.AreEqual(str is IEnumerable<int?>[][], interpreter.Eval("(str is IEnumerable<int?>[][])"));
-			Assert.AreEqual(str is IEnumerable<int[]>[][], interpreter.Eval("(str is IEnumerable<int[]>[][])"));
-			Assert.AreEqual(str is IEnumerable<int?[][]>[][], interpreter.Eval("(str is IEnumerable<int?[][]>[][])"));
+			Assert.That(interpreter.Eval("string.IsNullOrEmpty(str as string)"), Is.EqualTo(string.IsNullOrEmpty(str as string)));
+			Assert.That(interpreter.Eval("str is string"), Is.EqualTo(str is string));
+			Assert.That(interpreter.Eval("str is int?"), Is.EqualTo(str is int?));
+			Assert.That(interpreter.Eval("(str is int[])"), Is.EqualTo(str is int[]));
+			Assert.That(interpreter.Eval("(str is int?[])"), Is.EqualTo(str is int?[]));
+			Assert.That(interpreter.Eval("(str is int?[][])"), Is.EqualTo(str is int?[][]));
+			Assert.That(interpreter.Eval("(str is IEnumerable<int>[][])"), Is.EqualTo(str is IEnumerable<int>[][]));
+			Assert.That(interpreter.Eval("(str is IEnumerable<int?>[][])"), Is.EqualTo(str is IEnumerable<int?>[][]));
+			Assert.That(interpreter.Eval("(str is IEnumerable<int[]>[][])"), Is.EqualTo(str is IEnumerable<int[]>[][]));
+			Assert.That(interpreter.Eval("(str is IEnumerable<int?[][]>[][])"), Is.EqualTo(str is IEnumerable<int?[][]>[][]));
 		}
 
 		private class Npc
@@ -771,7 +771,7 @@ namespace DynamicExpresso.UnitTest
 			var func = interpreter.ParseAsDelegate<Action>("NearNpcs.ActionToAll(n => n.money = 10)");
 			func.Invoke();
 
-			Assert.IsTrue(testnpcs.All(n => n.money == 10));
+			Assert.That(testnpcs.All(n => n.money == 10), Is.True);
 		}
 
 		[Test]
@@ -817,7 +817,7 @@ namespace DynamicExpresso.UnitTest
 			var lambda = interpreter.Parse("this[0]", new Parameter("this", b));
 			var res = lambda.Invoke(b);
 
-			Assert.AreEqual(25, res);
+			Assert.That(res, Is.EqualTo(25));
 		}
 
 		#endregion
@@ -829,14 +829,14 @@ namespace DynamicExpresso.UnitTest
 
 			var interpreter1 = new Interpreter();
 			interpreter1.SetVariable("a", a);
-			Assert.AreEqual("AA", interpreter1.Eval("a.Substring(0, 2)"));
+			Assert.That(interpreter1.Eval("a.Substring(0, 2)"), Is.EqualTo("AA"));
 
 			var interpreter2 = new Interpreter().SetDefaultNumberType(DefaultNumberType.Decimal);
 			interpreter2.SetVariable("a", a);
 			// expected to throw because Substring is not defined for decimal
 			Assert.Throws<NoApplicableMethodException>(() => interpreter2.Eval("a.Substring(0, 2)"));
 			// It works if we cast to int
-			Assert.AreEqual("AA", interpreter2.Eval("a.Substring((int)0, (int)2)"));
+			Assert.That(interpreter2.Eval("a.Substring((int)0, (int)2)"), Is.EqualTo("AA"));
 		}
 
 		[Test]
@@ -845,10 +845,10 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter();
 
 			var exception1 = Assert.Throws<UnknownIdentifierException>(() => interpreter.Eval("b < 1"));
-			Assert.AreEqual("b", exception1.Identifier);
+			Assert.That(exception1.Identifier, Is.EqualTo("b"));
 
 			var exception2 = Assert.Throws<UnknownIdentifierException>(() => interpreter.Eval("b > 1"));
-			Assert.AreEqual("b", exception2.Identifier);
+			Assert.That(exception2.Identifier, Is.EqualTo("b"));
 		}
 
 		[Test]
@@ -863,7 +863,7 @@ namespace DynamicExpresso.UnitTest
 			};
 
 			var expressionDelegate = interpreter.ParseAsDelegate<Func<object, bool>>($"input.Prop1 == null", "input");
-			Assert.IsFalse(expressionDelegate(input));
+			Assert.That(expressionDelegate(input), Is.False);
 		}
 
 		[Test]
@@ -874,7 +874,7 @@ namespace DynamicExpresso.UnitTest
 			var x = 1L;
 			interpreter.SetVariable("x", x);
 
-			Assert.AreEqual((int)x == 1, interpreter.Eval<bool>("(int)x == 1"));
+			Assert.That(interpreter.Eval<bool>("(int)x == 1"), Is.EqualTo((int)x == 1));
 		}
 	}
 

--- a/test/DynamicExpresso.UnitTest/IdentifiersTest.cs
+++ b/test/DynamicExpresso.UnitTest/IdentifiersTest.cs
@@ -21,9 +21,9 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.IsTrue(target.Identifiers.Any(p => p.Name == "true"));
-			Assert.IsTrue(target.Identifiers.Any(p => p.Name == "false"));
-			Assert.IsTrue(target.Identifiers.Any(p => p.Name == "null"));
+			Assert.That(target.Identifiers.Any(p => p.Name == "true"), Is.True);
+			Assert.That(target.Identifiers.Any(p => p.Name == "false"), Is.True);
+			Assert.That(target.Identifiers.Any(p => p.Name == "null"), Is.True);
 		}
 
 		[Test]
@@ -33,7 +33,7 @@ namespace DynamicExpresso.UnitTest
 
 			target.SetVariable("x", null);
 
-			Assert.IsTrue(target.Identifiers.Any(p => p.Name == "x"));
+			Assert.That(target.Identifiers.Any(p => p.Name == "x"), Is.True);
 		}
 
 		[Test]
@@ -44,9 +44,9 @@ namespace DynamicExpresso.UnitTest
 
 			var lambda = target.Parse("x > a || true == b", new Parameter("a", 1), new Parameter("b", false));
 
-			Assert.AreEqual(2, lambda.Identifiers.Count());
-			Assert.AreEqual("x", lambda.Identifiers.ElementAt(0).Name);
-			Assert.AreEqual("true", lambda.Identifiers.ElementAt(1).Name);
+			Assert.That(lambda.Identifiers.Count(), Is.EqualTo(2));
+			Assert.That(lambda.Identifiers.ElementAt(0).Name, Is.EqualTo("x"));
+			Assert.That(lambda.Identifiers.ElementAt(1).Name, Is.EqualTo("true"));
 		}
 
 		[Test]
@@ -58,11 +58,11 @@ namespace DynamicExpresso.UnitTest
 
 			interpreter.SetVariable("this", new Customer {Name = Name});
 
-			Assert.AreEqual(Name, interpreter.Eval("this.Name"));
-			Assert.AreEqual(Name, interpreter.Eval("this.GetName()"));
+			Assert.That(interpreter.Eval("this.Name"), Is.EqualTo(Name));
+			Assert.That(interpreter.Eval("this.GetName()"), Is.EqualTo(Name));
 
-			Assert.AreEqual(Name, interpreter.Eval("Name"));
-			Assert.AreEqual(Name, interpreter.Eval("GetName()"));
+			Assert.That(interpreter.Eval("Name"), Is.EqualTo(Name));
+			Assert.That(interpreter.Eval("GetName()"), Is.EqualTo(Name));
 		}
 
 		[Test]
@@ -74,11 +74,11 @@ namespace DynamicExpresso.UnitTest
 			var parameter = new Parameter("this", context.GetType());
 			var interpreter = new Interpreter();
 
-			Assert.AreEqual(Name, interpreter.Parse("this.Name", parameter).Invoke(context));
-			Assert.AreEqual(Name, interpreter.Parse("this.GetName()", parameter).Invoke(context));
+			Assert.That(interpreter.Parse("this.Name", parameter).Invoke(context), Is.EqualTo(Name));
+			Assert.That(interpreter.Parse("this.GetName()", parameter).Invoke(context), Is.EqualTo(Name));
 
-			Assert.AreEqual(Name, interpreter.Parse("Name", parameter).Invoke(context));
-			Assert.AreEqual(Name, interpreter.Parse("GetName()", parameter).Invoke(context));
+			Assert.That(interpreter.Parse("Name", parameter).Invoke(context), Is.EqualTo(Name));
+			Assert.That(interpreter.Parse("GetName()", parameter).Invoke(context), Is.EqualTo(Name));
 		}
 	}
 }

--- a/test/DynamicExpresso.UnitTest/InvalidExpressionTest.cs
+++ b/test/DynamicExpresso.UnitTest/InvalidExpressionTest.cs
@@ -71,9 +71,9 @@ namespace DynamicExpresso.UnitTest
 
 			var ex = Assert.Throws<UnknownIdentifierException>(() => target.Parse("x + y * Math.Pow(x, 2)", typeof(void)));
 
-			Assert.AreEqual("Unknown identifier 'x' (at index 0).", ex.Message);
-			Assert.AreEqual("x", ex.Identifier);
-			Assert.AreEqual(0, ex.Position);
+			Assert.That(ex.Message, Is.EqualTo("Unknown identifier 'x' (at index 0)."));
+			Assert.That(ex.Identifier, Is.EqualTo("x"));
+			Assert.That(ex.Position, Is.EqualTo(0));
 		}
 
 		[Test]
@@ -84,8 +84,8 @@ namespace DynamicExpresso.UnitTest
 
 			var ex = Assert.Throws<UnknownIdentifierException>(() => target.Parse("x + y * Math.Pow(x, 2)", typeof(void)));
 
-			Assert.AreEqual("y", ex.Identifier);
-			Assert.AreEqual(4, ex.Position);
+			Assert.That(ex.Identifier, Is.EqualTo("y"));
+			Assert.That(ex.Position, Is.EqualTo(4));
 		}
 
 		[Test]
@@ -96,9 +96,9 @@ namespace DynamicExpresso.UnitTest
 
 			var ex = Assert.Throws<NoApplicableMethodException>(() => target.Parse("Math.NotExistingMethod(x, 2)", typeof(void)));
 
-			Assert.AreEqual("NotExistingMethod", ex.MethodName);
-			Assert.AreEqual("Math", ex.MethodTypeName);
-			Assert.AreEqual(5, ex.Position);
+			Assert.That(ex.MethodName, Is.EqualTo("NotExistingMethod"));
+			Assert.That(ex.MethodTypeName, Is.EqualTo("Math"));
+			Assert.That(ex.Position, Is.EqualTo(5));
 		}
 
 		[Test]

--- a/test/DynamicExpresso.UnitTest/LambdaExpressionTest.cs
+++ b/test/DynamicExpresso.UnitTest/LambdaExpressionTest.cs
@@ -30,7 +30,7 @@ namespace DynamicExpresso.UnitTest
 
 			var lambda = target.Parse("list.Select(str => str.Length)");
 
-			Assert.AreEqual(typeof(IEnumerable<int>), lambda.ReturnType);
+			Assert.That(lambda.ReturnType, Is.EqualTo(typeof(IEnumerable<int>)));
 		}
 
 		[Test]
@@ -42,8 +42,8 @@ namespace DynamicExpresso.UnitTest
 
 			var results = target.Eval<IEnumerable<int>>("myList.Where(x => x >= 19)");
 
-			Assert.AreEqual(2, results.Count());
-			Assert.AreEqual(new[] { 19, 21 }, results);
+			Assert.That(results.Count(), Is.EqualTo(2));
+			Assert.That(results, Is.EqualTo(new[] { 19, 21 }));
 		}
 
 		[Test]
@@ -55,8 +55,8 @@ namespace DynamicExpresso.UnitTest
 
 			var results = target.Eval<IEnumerable<int>>("myList.Where((int x) => x >= 19)");
 
-			Assert.AreEqual(2, results.Count());
-			Assert.AreEqual(new[] { 19, 21 }, results);
+			Assert.That(results.Count(), Is.EqualTo(2));
+			Assert.That(results, Is.EqualTo(new[] { 19, 21 }));
 		}
 
 		[Test]
@@ -68,8 +68,8 @@ namespace DynamicExpresso.UnitTest
 
 			var results = target.Eval<IEnumerable<char>>("myList.Select(i => i.ToString()).Select(str => str[0])");
 
-			Assert.AreEqual(4, results.Count());
-			Assert.AreEqual(new[] { '1', '1', '1', '2' }, results);
+			Assert.That(results.Count(), Is.EqualTo(4));
+			Assert.That(results, Is.EqualTo(new[] { '1', '1', '1', '2' }));
 		}
 
 		[Test]
@@ -81,8 +81,8 @@ namespace DynamicExpresso.UnitTest
 
 			var results = target.Eval<IEnumerable<string>>("myList.Where(str => str.Length > 5).Select(str => str.ToUpper())");
 
-			Assert.AreEqual(1, results.Count());
-			Assert.AreEqual(new[] { "AWESOME" }, results);
+			Assert.That(results.Count(), Is.EqualTo(1));
+			Assert.That(results, Is.EqualTo(new[] { "AWESOME" }));
 		}
 
 		[Test]
@@ -90,7 +90,7 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter(_options);
 			var lambda = target.Eval<Func<string, string>>("str => str.ToUpper()");
-			Assert.AreEqual("TEST", lambda.Invoke("test"));
+			Assert.That(lambda.Invoke("test"), Is.EqualTo("TEST"));
 		}
 
 		[Test]
@@ -98,7 +98,7 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter(_options);
 			var lambda = target.Eval<Func<int>>("() => 5 + 6");
-			Assert.AreEqual(11, lambda.Invoke());
+			Assert.That(lambda.Invoke(), Is.EqualTo(11));
 		}
 
 		[Test]
@@ -107,7 +107,7 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter(_options);
 			target.SetVariable("increment", 3);
 			var lambda = target.Eval<Func<int, string, string>>("(i, str) => str.ToUpper() + (i + increment)");
-			Assert.AreEqual("TEST8", lambda.Invoke(5, "test"));
+			Assert.That(lambda.Invoke(5, "test"), Is.EqualTo("TEST8"));
 		}
 
 		[Test]
@@ -119,8 +119,8 @@ namespace DynamicExpresso.UnitTest
 
 			var results = target.Eval<IEnumerable<char>>("myList.SelectMany(str => str)");
 
-			Assert.AreEqual(4, results.Count());
-			Assert.AreEqual(new[] { 'a', 'b', 'c', 'd' }, results);
+			Assert.That(results.Count(), Is.EqualTo(4));
+			Assert.That(results, Is.EqualTo(new[] { 'a', 'b', 'c', 'd' }));
 		}
 
 		[Test]
@@ -136,8 +136,8 @@ namespace DynamicExpresso.UnitTest
 
 			var results = target.Eval<IEnumerable<string>>("myList.SelectMany(obj => obj.Strings)");
 
-			Assert.AreEqual(4, results.Count());
-			Assert.AreEqual(new[] { "ab", "cd", "ef", "gh" }, results);
+			Assert.That(results.Count(), Is.EqualTo(4));
+			Assert.That(results, Is.EqualTo(new[] { "ab", "cd", "ef", "gh" }));
 		}
 
 		[Test]
@@ -149,8 +149,8 @@ namespace DynamicExpresso.UnitTest
 
 			var results = target.Eval<IEnumerable<char>>("myList.Select(str => str.SingleOrDefault(c => c == 'd')).Where(c => c != '\0')");
 
-			Assert.AreEqual(1, results.Count());
-			Assert.AreEqual(new[] { 'd' }, results);
+			Assert.That(results.Count(), Is.EqualTo(1));
+			Assert.That(results, Is.EqualTo(new[] { 'd' }));
 		}
 
 		[Test]
@@ -161,7 +161,7 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("str", str);
 
 			var result = target.Eval<char>("str.MySingleOrDefault(c => c == 'd')");
-			Assert.AreEqual(str.SingleOrDefault(c => c == 'd'), result);
+			Assert.That(result, Is.EqualTo(str.SingleOrDefault(c => c == 'd')));
 		}
 
 		[Test]
@@ -172,13 +172,13 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("str", str);
 
 			var result = target.Eval<char>("str.WithSeveralParams((c) => c == 'd')");
-			Assert.AreEqual('d', result);
+			Assert.That(result, Is.EqualTo('d'));
 
 			result = target.Eval<char>("str.WithSeveralParams((c, i) => c == 'd')");
-			Assert.AreEqual('d', result);
+			Assert.That(result, Is.EqualTo('d'));
 
 			result = target.Eval<char>("str.WithSeveralParams((c, i, str2) => c == 'd')");
-			Assert.AreEqual('d', result);
+			Assert.That(result, Is.EqualTo('d'));
 		}
 
 		[Test]
@@ -190,7 +190,7 @@ namespace DynamicExpresso.UnitTest
 
 			var results = target.Eval<int>("myList.Sum()");
 
-			Assert.AreEqual(6, results);
+			Assert.That(results, Is.EqualTo(6));
 		}
 
 		[Test]
@@ -202,7 +202,7 @@ namespace DynamicExpresso.UnitTest
 
 			var results = target.Eval<int>("myList.Max()");
 
-			Assert.AreEqual(3, results);
+			Assert.That(results, Is.EqualTo(3));
 		}
 
 		[Test]
@@ -214,7 +214,7 @@ namespace DynamicExpresso.UnitTest
 
 			var results = target.Eval<int>("myList.Sum(str => str.Length)");
 
-			Assert.AreEqual(10, results);
+			Assert.That(results, Is.EqualTo(10));
 		}
 
 		[Test]
@@ -227,8 +227,8 @@ namespace DynamicExpresso.UnitTest
 
 			var results = target.Eval<IEnumerable<int>>("myList.Select(i => i + increment)");
 
-			Assert.AreEqual(3, results.Count());
-			Assert.AreEqual(new[] { 4, 5, 6 }, results);
+			Assert.That(results.Count(), Is.EqualTo(3));
+			Assert.That(results, Is.EqualTo(new[] { 4, 5, 6 }));
 		}
 
 		[Test]
@@ -240,8 +240,8 @@ namespace DynamicExpresso.UnitTest
 
 			var results = target.Eval<IEnumerable<string>>("myList.TakeWhile((item, idx) => idx <= 2 && item.Length >= 3)");
 
-			Assert.AreEqual(3, results.Count());
-			Assert.AreEqual(new[] { "aaaaa", "bbbb", "ccc" }, results);
+			Assert.That(results.Count(), Is.EqualTo(3));
+			Assert.That(results, Is.EqualTo(new[] { "aaaaa", "bbbb", "ccc" }));
 		}
 
 		[Test]
@@ -254,8 +254,8 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("myList", list);
 			var results = target.Eval<Dictionary<string, int>>("myList.ToDictionary(str => new WithProp { MyStr = str }.MyStr, str => str.Length)");
 
-			Assert.AreEqual(4, results.Count);
-			Assert.AreEqual(list.ToDictionary(str => new WithProp { MyStr = str }.MyStr, str => str.Length), results);
+			Assert.That(results.Count, Is.EqualTo(4));
+			Assert.That(results, Is.EqualTo(list.ToDictionary(str => new WithProp { MyStr = str }.MyStr, str => str.Length)));
 		}
 
 		private class WithProp
@@ -273,8 +273,8 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("intList", intList);
 			var results = target.Eval<IEnumerable<string>>("strList.Zip(intList, (str, i) => str + i)");
 
-			Assert.AreEqual(3, results.Count());
-			Assert.AreEqual(strList.Zip(intList, (str, i) => str + i), results);
+			Assert.That(results.Count(), Is.EqualTo(3));
+			Assert.That(results, Is.EqualTo(strList.Zip(intList, (str, i) => str + i)));
 		}
 
 		[Test]
@@ -282,11 +282,11 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
 			var listInt = target.Eval<IEnumerable<int>>("list.Where(n => n > x)", new Parameter("list", new[] { 1, 2, 3 }), new Parameter("x", 1));
-			Assert.AreEqual(new[] { 2, 3 }, listInt);
+			Assert.That(listInt, Is.EqualTo(new[] { 2, 3 }));
 
 			// ensure the parameters can be reused with different values
 			listInt = target.Eval<IEnumerable<int>>("list.Where(n => n > x)", new Parameter("list", new[] { 2, 4, 5 }), new Parameter("x", 2));
-			Assert.AreEqual(new[] { 4, 5 }, listInt);
+			Assert.That(listInt, Is.EqualTo(new[] { 4, 5 }));
 		}
 
 		[Test]
@@ -297,14 +297,14 @@ namespace DynamicExpresso.UnitTest
 			var list = new Parameter("list", new[] { 1, 2, 3 });
 			var listLamba = target.Parse("list.Where(n => n > x)", list, parm).Compile<Func<int[], int, IEnumerable<int>>>();
 			var result = listLamba(list.Value as int[], 2);
-			Assert.AreEqual(new[] { 3 }, result);
+			Assert.That(result, Is.EqualTo(new[] { 3 }));
 
 			var listInt = listLamba(list.Value as int[], 1);
-			Assert.AreEqual(new[] { 2, 3 }, listInt);
+			Assert.That(listInt, Is.EqualTo(new[] { 2, 3 }));
 
 			// ensure the parameters can be reused with different values
 			listInt = target.Eval<IEnumerable<int>>("list.Where(n => n > x)", new Parameter("list", new[] { 2, 4, 5 }), new Parameter("x", 2));
-			Assert.AreEqual(new[] { 4, 5 }, listInt);
+			Assert.That(listInt, Is.EqualTo(new[] { 4, 5 }));
 		}
 
 		[Test]
@@ -312,7 +312,7 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LambdaExpressions);
 			var listInt = target.Eval<IEnumerable<int>>("list.Select(n => n - 1).Where(n => n > x).Select(n => n + x)", new Parameter("list", new[] { 1, 2, 3 }), new Parameter("x", 1));
-			Assert.AreEqual(new[] { 3 }, listInt);
+			Assert.That(listInt, Is.EqualTo(new[] { 3 }));
 		}
 
 		[Test]
@@ -323,7 +323,7 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("x", 1);
 
 			var listInt = target.Eval<IEnumerable<int>>("list.Where(n => n > x)");
-			Assert.AreEqual(new[] { 2, 3 }, listInt);
+			Assert.That(listInt, Is.EqualTo(new[] { 2, 3 }));
 		}
 
 		public class NestedLambdaTestClass
@@ -379,7 +379,7 @@ namespace DynamicExpresso.UnitTest
 						l3 => l3.Name + l2.Name + l3.GetChildrenIdentifiers(
 							l4 => l4.Name + l2.Name + l3.Name + l1.Name + root.Name)
 							)))", new Parameter(nameof(root), root));
-			Assert.AreEqual(expectedResult, evalResult);
+			Assert.That(evalResult, Is.EqualTo(expectedResult));
 		}
 
 		[Test]
@@ -405,7 +405,7 @@ namespace DynamicExpresso.UnitTest
 						l3 => l3.Name + l2.Name + l3.GetChildrenIdentifiers(
 							l4 => l4.Name + l2.Name + l3.Name + l1.Name + root.Name)
 							)))", new Parameter(nameof(root), root));
-			Assert.AreEqual(expectedResult, evalResult);
+			Assert.That(evalResult, Is.EqualTo(expectedResult));
 		}
 
 		[Test]
@@ -438,8 +438,8 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("list", list);
 
 			var result = target.Eval(@"list.ForEach(n => n.Money = 5)");
-			Assert.IsNull(result);
-			Assert.AreEqual(5, list[0].Money);
+			Assert.That(result, Is.Null);
+			Assert.That(list[0].Money, Is.EqualTo(5));
 		}
 
 		[Test]
@@ -451,8 +451,8 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("npc", npc);
 
 			var result = target.Eval(@"npc.AddMoney((n, i, str) => n.Money = i + str.Length)");
-			Assert.IsNull(result);
-			Assert.AreEqual(14, npc.Money);
+			Assert.That(result, Is.Null);
+			Assert.That(npc.Money, Is.EqualTo(14));
 		}
 
 		private static NestedLambdaTestClass BuildNestedTestClassHierarchy()

--- a/test/DynamicExpresso.UnitTest/LiteralsTest.cs
+++ b/test/DynamicExpresso.UnitTest/LiteralsTest.cs
@@ -1,7 +1,8 @@
-using NUnit.Framework;
-using System.Threading;
+using System;
 using System.Globalization;
+using System.Threading;
 using DynamicExpresso.Exceptions;
+using NUnit.Framework;
 
 namespace DynamicExpresso.UnitTest
 {
@@ -13,8 +14,8 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual("ciao", target.Eval("\"ciao\""));
-			Assert.AreEqual('c', target.Eval("'c'"));
+			Assert.That(target.Eval("\"ciao\""), Is.EqualTo("ciao"));
+			Assert.That(target.Eval("'c'"), Is.EqualTo('c'));
 		}
 
 		[Test]
@@ -22,8 +23,8 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.IsTrue((bool)target.Eval("true"));
-			Assert.IsFalse((bool)target.Eval("false"));
+			Assert.That((bool)target.Eval("true"), Is.True);
+			Assert.That((bool)target.Eval("false"), Is.False);
 		}
 
 		[Test]
@@ -31,50 +32,50 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(0, target.Eval("0"));
-			Assert.AreEqual(0.0, target.Eval("0.0"));
-			Assert.AreEqual(45, target.Eval("45"));
-			Assert.AreEqual(45, target.Eval("45u"));
-			Assert.AreEqual(-45u, target.Eval("-45u"));
-			Assert.AreEqual(-565, target.Eval("-565"));
-			Assert.AreEqual(23423423423434, target.Eval("23423423423434"));
-			Assert.AreEqual(45.5, target.Eval("45.5"));
-			Assert.AreEqual(-0.5, target.Eval("-0.5"));
-			Assert.AreEqual(.2, target.Eval(".2"));
-			Assert.AreEqual(-.2, target.Eval("-.2"));
-			Assert.AreEqual(+.2, target.Eval("+.2"));
-			Assert.AreEqual(.02, target.Eval(".02"));
-			Assert.AreEqual(-.02, target.Eval("-.02"));
-			Assert.AreEqual(+.02, target.Eval("+.02"));
-			Assert.AreEqual(.20, target.Eval(".20"));
-			Assert.AreEqual(-.20, target.Eval("-.20"));
-			Assert.AreEqual(+.20, target.Eval("+.20"));
-			Assert.AreEqual(.201, target.Eval(".201"));
-			Assert.AreEqual(-.201, target.Eval("-.201"));
-			Assert.AreEqual(+.201, target.Eval("+.201"));
-			Assert.AreEqual(2e+201, target.Eval("2e+201"));
-			Assert.AreEqual(2e+20, target.Eval("2e+20"));
+			Assert.That(target.Eval("0"), Is.EqualTo(0));
+			Assert.That(target.Eval("0.0"), Is.EqualTo(0.0));
+			Assert.That(target.Eval("45"), Is.EqualTo(45));
+			Assert.That(target.Eval("45u"), Is.EqualTo(45));
+			Assert.That(target.Eval("-45u"), Is.EqualTo(-45u));
+			Assert.That(target.Eval("-565"), Is.EqualTo(-565));
+			Assert.That(target.Eval("23423423423434"), Is.EqualTo(23423423423434));
+			Assert.That(target.Eval("45.5"), Is.EqualTo(45.5));
+			Assert.That(target.Eval("-0.5"), Is.EqualTo(-0.5));
+			Assert.That(target.Eval(".2"), Is.EqualTo(.2));
+			Assert.That(target.Eval("-.2"), Is.EqualTo(-.2));
+			Assert.That(target.Eval("+.2"), Is.EqualTo(+.2));
+			Assert.That(target.Eval(".02"), Is.EqualTo(.02));
+			Assert.That(target.Eval("-.02"), Is.EqualTo(-.02));
+			Assert.That(target.Eval("+.02"), Is.EqualTo(+.02));
+			Assert.That(target.Eval(".20"), Is.EqualTo(.20));
+			Assert.That(target.Eval("-.20"), Is.EqualTo(-.20));
+			Assert.That(target.Eval("+.20"), Is.EqualTo(+.20));
+			Assert.That(target.Eval(".201"), Is.EqualTo(.201));
+			Assert.That(target.Eval("-.201"), Is.EqualTo(-.201));
+			Assert.That(target.Eval("+.201"), Is.EqualTo(+.201));
+			Assert.That(target.Eval("2e+201"), Is.EqualTo(2e+201));
+			Assert.That(target.Eval("2e+20"), Is.EqualTo(2e+20));
 
 			// f suffix (single)
-			Assert.AreEqual(4f, target.Eval("4f"));
-			Assert.AreEqual(45F, target.Eval("45F"));
-			Assert.AreEqual(45.8f, target.Eval("45.8f"));
-			Assert.AreEqual(45.8F, target.Eval("45.8F"));
-			Assert.AreEqual(45.8F, target.Eval(" 45.8F "));
-			Assert.AreEqual(.2f, target.Eval(".2f"));
-			Assert.AreEqual(.2F, target.Eval(".2F"));
-			Assert.AreEqual(-.2f, target.Eval("-.2f"));
-			Assert.AreEqual(-.2F, target.Eval("-.2F"));
+			Assert.That(target.Eval("4f"), Is.EqualTo(4f));
+			Assert.That(target.Eval("45F"), Is.EqualTo(45F));
+			Assert.That(target.Eval("45.8f"), Is.EqualTo(45.8f));
+			Assert.That(target.Eval("45.8F"), Is.EqualTo(45.8F));
+			Assert.That(target.Eval(" 45.8F "), Is.EqualTo(45.8F));
+			Assert.That(target.Eval(".2f"), Is.EqualTo(.2f));
+			Assert.That(target.Eval(".2F"), Is.EqualTo(.2F));
+			Assert.That(target.Eval("-.2f"), Is.EqualTo(-.2f));
+			Assert.That(target.Eval("-.2F"), Is.EqualTo(-.2F));
 
 			// m suffix (decimal)
-			Assert.AreEqual(5M, target.Eval("5M"));
-			Assert.AreEqual(254m, target.Eval("254m"));
-			Assert.AreEqual(45.232M, target.Eval("45.232M"));
-			Assert.AreEqual(45.232m, target.Eval("45.232m"));
-			Assert.AreEqual(.022M, target.Eval(".022M"));
-			Assert.AreEqual(.022m, target.Eval(".022m"));
-			Assert.AreEqual(-.022m, target.Eval("-.022m"));
-			Assert.AreEqual(-.022M, target.Eval("-.022M"));
+			Assert.That(target.Eval("5M"), Is.EqualTo(5M));
+			Assert.That(target.Eval("254m"), Is.EqualTo(254m));
+			Assert.That(target.Eval("45.232M"), Is.EqualTo(45.232M));
+			Assert.That(target.Eval("45.232m"), Is.EqualTo(45.232m));
+			Assert.That(target.Eval(".022M"), Is.EqualTo(.022M));
+			Assert.That(target.Eval(".022m"), Is.EqualTo(.022m));
+			Assert.That(target.Eval("-.022m"), Is.EqualTo(-.022m));
+			Assert.That(target.Eval("-.022M"), Is.EqualTo(-.022M));
 		}
 
 		[Test]
@@ -82,63 +83,63 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.IsInstanceOf(typeof(System.Int32), target.Eval("81"));
-			Assert.IsInstanceOf(typeof(System.Double), target.Eval("81.5"));
-			Assert.IsInstanceOf(typeof(System.Int64), target.Eval("23423423423434"));
+			Assert.That(target.Eval("81"), Is.InstanceOf<int>());
+			Assert.That(target.Eval("81.5"), Is.InstanceOf<double>());
+			Assert.That(target.Eval("23423423423434"), Is.InstanceOf<long>());
 		}
 
 		[Test]
 		public void Numeric_Literals_DefaultLong()
 		{
 			var target = new Interpreter();
-			
+
 			target.SetDefaultNumberType(DefaultNumberType.Long);
 
-			Assert.IsInstanceOf(typeof(System.Int64), target.Eval("45"));
+			Assert.That(target.Eval("45"), Is.InstanceOf<long>());
 
-			Assert.AreEqual(0L, target.Eval("0"));
-			Assert.AreEqual(0.0, target.Eval("0.0"));
-			Assert.AreEqual(45L, target.Eval("45"));
-			Assert.AreEqual(45L, target.Eval("45u"));
-			Assert.AreEqual(-45L, target.Eval("-45u"));
-			Assert.AreEqual(23423423423434L, target.Eval("23423423423434"));
-			Assert.AreEqual(45.5, target.Eval("45.5"));
-			Assert.AreEqual(-0.5, target.Eval("-0.5"));
-			Assert.AreEqual(.2, target.Eval(".2"));
-			Assert.AreEqual(-.2, target.Eval("-.2"));
-			Assert.AreEqual(+.2, target.Eval("+.2"));
-			Assert.AreEqual(.02, target.Eval(".02"));
-			Assert.AreEqual(-.02, target.Eval("-.02"));
-			Assert.AreEqual(+.02, target.Eval("+.02"));
-			Assert.AreEqual(.20, target.Eval(".20"));
-			Assert.AreEqual(-.20, target.Eval("-.20"));
-			Assert.AreEqual(+.20, target.Eval("+.20"));
-			Assert.AreEqual(.201, target.Eval(".201"));
-			Assert.AreEqual(-.201, target.Eval("-.201"));
-			Assert.AreEqual(+.201, target.Eval("+.201"));
-			Assert.AreEqual(2e+201, target.Eval("2e+201"));
-			Assert.AreEqual(2e+20, target.Eval("2e+20"));
+			Assert.That(target.Eval("0"), Is.EqualTo(0L));
+			Assert.That(target.Eval("0.0"), Is.EqualTo(0.0));
+			Assert.That(target.Eval("45"), Is.EqualTo(45L));
+			Assert.That(target.Eval("45u"), Is.EqualTo(45L));
+			Assert.That(target.Eval("-45u"), Is.EqualTo(-45L));
+			Assert.That(target.Eval("23423423423434"), Is.EqualTo(23423423423434L));
+			Assert.That(target.Eval("45.5"), Is.EqualTo(45.5));
+			Assert.That(target.Eval("-0.5"), Is.EqualTo(-0.5));
+			Assert.That(target.Eval(".2"), Is.EqualTo(.2));
+			Assert.That(target.Eval("-.2"), Is.EqualTo(-.2));
+			Assert.That(target.Eval("+.2"), Is.EqualTo(+.2));
+			Assert.That(target.Eval(".02"), Is.EqualTo(.02));
+			Assert.That(target.Eval("-.02"), Is.EqualTo(-.02));
+			Assert.That(target.Eval("+.02"), Is.EqualTo(+.02));
+			Assert.That(target.Eval(".20"), Is.EqualTo(.20));
+			Assert.That(target.Eval("-.20"), Is.EqualTo(-.20));
+			Assert.That(target.Eval("+.20"), Is.EqualTo(+.20));
+			Assert.That(target.Eval(".201"), Is.EqualTo(.201));
+			Assert.That(target.Eval("-.201"), Is.EqualTo(-.201));
+			Assert.That(target.Eval("+.201"), Is.EqualTo(+.201));
+			Assert.That(target.Eval("2e+201"), Is.EqualTo(2e+201));
+			Assert.That(target.Eval("2e+20"), Is.EqualTo(2e+20));
 
 			// f suffix (single)
-			Assert.AreEqual(4f, target.Eval("4f"));
-			Assert.AreEqual(45F, target.Eval("45F"));
-			Assert.AreEqual(45.8f, target.Eval("45.8f"));
-			Assert.AreEqual(45.8F, target.Eval("45.8F"));
-			Assert.AreEqual(45.8F, target.Eval(" 45.8F "));
-			Assert.AreEqual(.2f, target.Eval(".2f"));
-			Assert.AreEqual(.2F, target.Eval(".2F"));
-			Assert.AreEqual(-.2f, target.Eval("-.2f"));
-			Assert.AreEqual(-.2F, target.Eval("-.2F"));
+			Assert.That(target.Eval("4f"), Is.EqualTo(4f));
+			Assert.That(target.Eval("45F"), Is.EqualTo(45F));
+			Assert.That(target.Eval("45.8f"), Is.EqualTo(45.8f));
+			Assert.That(target.Eval("45.8F"), Is.EqualTo(45.8F));
+			Assert.That(target.Eval(" 45.8F "), Is.EqualTo(45.8F));
+			Assert.That(target.Eval(".2f"), Is.EqualTo(.2f));
+			Assert.That(target.Eval(".2F"), Is.EqualTo(.2F));
+			Assert.That(target.Eval("-.2f"), Is.EqualTo(-.2f));
+			Assert.That(target.Eval("-.2F"), Is.EqualTo(-.2F));
 
 			// m suffix (decimal)
-			Assert.AreEqual(5M, target.Eval("5M"));
-			Assert.AreEqual(254m, target.Eval("254m"));
-			Assert.AreEqual(45.232M, target.Eval("45.232M"));
-			Assert.AreEqual(45.232m, target.Eval("45.232m"));
-			Assert.AreEqual(.022M, target.Eval(".022M"));
-			Assert.AreEqual(.022m, target.Eval(".022m"));
-			Assert.AreEqual(-.022m, target.Eval("-.022m"));
-			Assert.AreEqual(-.022M, target.Eval("-.022M"));
+			Assert.That(target.Eval("5M"), Is.EqualTo(5M));
+			Assert.That(target.Eval("254m"), Is.EqualTo(254m));
+			Assert.That(target.Eval("45.232M"), Is.EqualTo(45.232M));
+			Assert.That(target.Eval("45.232m"), Is.EqualTo(45.232m));
+			Assert.That(target.Eval(".022M"), Is.EqualTo(.022M));
+			Assert.That(target.Eval(".022m"), Is.EqualTo(.022m));
+			Assert.That(target.Eval("-.022m"), Is.EqualTo(-.022m));
+			Assert.That(target.Eval("-.022M"), Is.EqualTo(-.022M));
 		}
 
 		[Test]
@@ -148,49 +149,49 @@ namespace DynamicExpresso.UnitTest
 
 			target.SetDefaultNumberType(DefaultNumberType.Single);
 
-			Assert.IsInstanceOf(typeof(System.Single), target.Eval("45"));
-			Assert.AreEqual(10F / 3f, target.Eval("10/3"));
+			Assert.That(target.Eval("45"), Is.InstanceOf<Single>());
+			Assert.That(target.Eval("10/3"), Is.EqualTo(10F / 3f));
 
-			Assert.AreEqual(0F, target.Eval("0"));
-			Assert.AreEqual(0.0F, target.Eval("0.0"));
-			Assert.AreEqual(45F, target.Eval("45"));
-			Assert.AreEqual(-565F, target.Eval("-565"));
-			Assert.AreEqual(23423423423434F, target.Eval("23423423423434"));
-			Assert.AreEqual(45.5F, target.Eval("45.5"));
-			Assert.AreEqual(-0.5F, target.Eval("-0.5"));
-			Assert.AreEqual(.2F, target.Eval(".2"));
-			Assert.AreEqual(-.2F, target.Eval("-.2"));
-			Assert.AreEqual(+.2F, target.Eval("+.2"));
-			Assert.AreEqual(.02F, target.Eval(".02"));
-			Assert.AreEqual(-.02F, target.Eval("-.02"));
-			Assert.AreEqual(+.02F, target.Eval("+.02"));
-			Assert.AreEqual(.20F, target.Eval(".20"));
-			Assert.AreEqual(-.20F, target.Eval("-.20"));
-			Assert.AreEqual(+.20F, target.Eval("+.20"));
-			Assert.AreEqual(.201F, target.Eval(".201"));
-			Assert.AreEqual(-.201F, target.Eval("-.201"));
-			Assert.AreEqual(+.201F, target.Eval("+.201"));
+			Assert.That(target.Eval("0"), Is.EqualTo(0F));
+			Assert.That(target.Eval("0.0"), Is.EqualTo(0.0F));
+			Assert.That(target.Eval("45"), Is.EqualTo(45F));
+			Assert.That(target.Eval("-565"), Is.EqualTo(-565F));
+			Assert.That(target.Eval("23423423423434"), Is.EqualTo(23423423423434F));
+			Assert.That(target.Eval("45.5"), Is.EqualTo(45.5F));
+			Assert.That(target.Eval("-0.5"), Is.EqualTo(-0.5F));
+			Assert.That(target.Eval(".2"), Is.EqualTo(.2F));
+			Assert.That(target.Eval("-.2"), Is.EqualTo(-.2F));
+			Assert.That(target.Eval("+.2"), Is.EqualTo(+.2F));
+			Assert.That(target.Eval(".02"), Is.EqualTo(.02F));
+			Assert.That(target.Eval("-.02"), Is.EqualTo(-.02F));
+			Assert.That(target.Eval("+.02"), Is.EqualTo(+.02F));
+			Assert.That(target.Eval(".20"), Is.EqualTo(.20F));
+			Assert.That(target.Eval("-.20"), Is.EqualTo(-.20F));
+			Assert.That(target.Eval("+.20"), Is.EqualTo(+.20F));
+			Assert.That(target.Eval(".201"), Is.EqualTo(.201F));
+			Assert.That(target.Eval("-.201"), Is.EqualTo(-.201F));
+			Assert.That(target.Eval("+.201"), Is.EqualTo(+.201F));
 
 			// f suffix (single)
-			Assert.AreEqual(4f, target.Eval("4f"));
-			Assert.AreEqual(45F, target.Eval("45F"));
-			Assert.AreEqual(45.8f, target.Eval("45.8f"));
-			Assert.AreEqual(45.8F, target.Eval("45.8F"));
-			Assert.AreEqual(45.8F, target.Eval(" 45.8F "));
-			Assert.AreEqual(.2f, target.Eval(".2f"));
-			Assert.AreEqual(.2F, target.Eval(".2F"));
-			Assert.AreEqual(-.2f, target.Eval("-.2f"));
-			Assert.AreEqual(-.2F, target.Eval("-.2F"));
+			Assert.That(target.Eval("4f"), Is.EqualTo(4f));
+			Assert.That(target.Eval("45F"), Is.EqualTo(45F));
+			Assert.That(target.Eval("45.8f"), Is.EqualTo(45.8f));
+			Assert.That(target.Eval("45.8F"), Is.EqualTo(45.8F));
+			Assert.That(target.Eval(" 45.8F "), Is.EqualTo(45.8F));
+			Assert.That(target.Eval(".2f"), Is.EqualTo(.2f));
+			Assert.That(target.Eval(".2F"), Is.EqualTo(.2F));
+			Assert.That(target.Eval("-.2f"), Is.EqualTo(-.2f));
+			Assert.That(target.Eval("-.2F"), Is.EqualTo(-.2F));
 
 			// m suffix (decimal)
-			Assert.AreEqual(5M, target.Eval("5M"));
-			Assert.AreEqual(254m, target.Eval("254m"));
-			Assert.AreEqual(45.232M, target.Eval("45.232M"));
-			Assert.AreEqual(45.232m, target.Eval("45.232m"));
-			Assert.AreEqual(.022M, target.Eval(".022M"));
-			Assert.AreEqual(.022m, target.Eval(".022m"));
-			Assert.AreEqual(-.022m, target.Eval("-.022m"));
-			Assert.AreEqual(-.022M, target.Eval("-.022M"));
+			Assert.That(target.Eval("5M"), Is.EqualTo(5M));
+			Assert.That(target.Eval("254m"), Is.EqualTo(254m));
+			Assert.That(target.Eval("45.232M"), Is.EqualTo(45.232M));
+			Assert.That(target.Eval("45.232m"), Is.EqualTo(45.232m));
+			Assert.That(target.Eval(".022M"), Is.EqualTo(.022M));
+			Assert.That(target.Eval(".022m"), Is.EqualTo(.022m));
+			Assert.That(target.Eval("-.022m"), Is.EqualTo(-.022m));
+			Assert.That(target.Eval("-.022M"), Is.EqualTo(-.022M));
 		}
 
 		[Test]
@@ -200,51 +201,51 @@ namespace DynamicExpresso.UnitTest
 
 			target.SetDefaultNumberType(DefaultNumberType.Double);
 
-			Assert.IsInstanceOf(typeof(System.Double), target.Eval("45"));
-			Assert.AreEqual(10D / 3D, target.Eval("10/3"));
+			Assert.That(target.Eval("45"), Is.InstanceOf<double>());
+			Assert.That(target.Eval("10/3"), Is.EqualTo(10D / 3D));
 
-			Assert.AreEqual(0D, target.Eval("0"));
-			Assert.AreEqual(0.0D, target.Eval("0.0"));
-			Assert.AreEqual(45D, target.Eval("45"));
-			Assert.AreEqual(-565D, target.Eval("-565"));
-			Assert.AreEqual(23423423423434D, target.Eval("23423423423434"));
-			Assert.AreEqual(45.5D, target.Eval("45.5"));
-			Assert.AreEqual(-0.5D, target.Eval("-0.5"));
-			Assert.AreEqual(.2D, target.Eval(".2"));
-			Assert.AreEqual(-.2D, target.Eval("-.2"));
-			Assert.AreEqual(+.2D, target.Eval("+.2"));
-			Assert.AreEqual(.02D, target.Eval(".02"));
-			Assert.AreEqual(-.02D, target.Eval("-.02"));
-			Assert.AreEqual(+.02D, target.Eval("+.02"));
-			Assert.AreEqual(.20D, target.Eval(".20"));
-			Assert.AreEqual(-.20D, target.Eval("-.20"));
-			Assert.AreEqual(+.20D, target.Eval("+.20"));
-			Assert.AreEqual(.201D, target.Eval(".201"));
-			Assert.AreEqual(-.201D, target.Eval("-.201"));
-			Assert.AreEqual(+.201D, target.Eval("+.201"));
-			Assert.AreEqual(2e+201, target.Eval("2e+201"));
-			Assert.AreEqual(2e+20, target.Eval("2e+20"));
+			Assert.That(target.Eval("0"), Is.EqualTo(0D));
+			Assert.That(target.Eval("0.0"), Is.EqualTo(0.0D));
+			Assert.That(target.Eval("45"), Is.EqualTo(45D));
+			Assert.That(target.Eval("-565"), Is.EqualTo(-565D));
+			Assert.That(target.Eval("23423423423434"), Is.EqualTo(23423423423434D));
+			Assert.That(target.Eval("45.5"), Is.EqualTo(45.5D));
+			Assert.That(target.Eval("-0.5"), Is.EqualTo(-0.5D));
+			Assert.That(target.Eval(".2"), Is.EqualTo(.2D));
+			Assert.That(target.Eval("-.2"), Is.EqualTo(-.2D));
+			Assert.That(target.Eval("+.2"), Is.EqualTo(+.2D));
+			Assert.That(target.Eval(".02"), Is.EqualTo(.02D));
+			Assert.That(target.Eval("-.02"), Is.EqualTo(-.02D));
+			Assert.That(target.Eval("+.02"), Is.EqualTo(+.02D));
+			Assert.That(target.Eval(".20"), Is.EqualTo(.20D));
+			Assert.That(target.Eval("-.20"), Is.EqualTo(-.20D));
+			Assert.That(target.Eval("+.20"), Is.EqualTo(+.20D));
+			Assert.That(target.Eval(".201"), Is.EqualTo(.201D));
+			Assert.That(target.Eval("-.201"), Is.EqualTo(-.201D));
+			Assert.That(target.Eval("+.201"), Is.EqualTo(+.201D));
+			Assert.That(target.Eval("2e+201"), Is.EqualTo(2e+201));
+			Assert.That(target.Eval("2e+20"), Is.EqualTo(2e+20));
 
 			// f suffix (single)
-			Assert.AreEqual(4f, target.Eval("4f"));
-			Assert.AreEqual(45F, target.Eval("45F"));
-			Assert.AreEqual(45.8f, target.Eval("45.8f"));
-			Assert.AreEqual(45.8F, target.Eval("45.8F"));
-			Assert.AreEqual(45.8F, target.Eval(" 45.8F "));
-			Assert.AreEqual(.2f, target.Eval(".2f"));
-			Assert.AreEqual(.2F, target.Eval(".2F"));
-			Assert.AreEqual(-.2f, target.Eval("-.2f"));
-			Assert.AreEqual(-.2F, target.Eval("-.2F"));
+			Assert.That(target.Eval("4f"), Is.EqualTo(4f));
+			Assert.That(target.Eval("45F"), Is.EqualTo(45F));
+			Assert.That(target.Eval("45.8f"), Is.EqualTo(45.8f));
+			Assert.That(target.Eval("45.8F"), Is.EqualTo(45.8F));
+			Assert.That(target.Eval(" 45.8F "), Is.EqualTo(45.8F));
+			Assert.That(target.Eval(".2f"), Is.EqualTo(.2f));
+			Assert.That(target.Eval(".2F"), Is.EqualTo(.2F));
+			Assert.That(target.Eval("-.2f"), Is.EqualTo(-.2f));
+			Assert.That(target.Eval("-.2F"), Is.EqualTo(-.2F));
 
 			// m suffix (decimal)
-			Assert.AreEqual(5M, target.Eval("5M"));
-			Assert.AreEqual(254m, target.Eval("254m"));
-			Assert.AreEqual(45.232M, target.Eval("45.232M"));
-			Assert.AreEqual(45.232m, target.Eval("45.232m"));
-			Assert.AreEqual(.022M, target.Eval(".022M"));
-			Assert.AreEqual(.022m, target.Eval(".022m"));
-			Assert.AreEqual(-.022m, target.Eval("-.022m"));
-			Assert.AreEqual(-.022M, target.Eval("-.022M"));
+			Assert.That(target.Eval("5M"), Is.EqualTo(5M));
+			Assert.That(target.Eval("254m"), Is.EqualTo(254m));
+			Assert.That(target.Eval("45.232M"), Is.EqualTo(45.232M));
+			Assert.That(target.Eval("45.232m"), Is.EqualTo(45.232m));
+			Assert.That(target.Eval(".022M"), Is.EqualTo(.022M));
+			Assert.That(target.Eval(".022m"), Is.EqualTo(.022m));
+			Assert.That(target.Eval("-.022m"), Is.EqualTo(-.022m));
+			Assert.That(target.Eval("-.022M"), Is.EqualTo(-.022M));
 		}
 
 		[Test]
@@ -254,50 +255,49 @@ namespace DynamicExpresso.UnitTest
 
 			target.SetDefaultNumberType(DefaultNumberType.Decimal);
 
-			Assert.IsInstanceOf(typeof(System.Decimal), target.Eval("45"));
-			Assert.AreEqual(10M/3M, target.Eval("10/3"));
+			Assert.That(target.Eval("45"), Is.InstanceOf<Decimal>());
+			Assert.That(target.Eval("10/3"), Is.EqualTo(10M / 3M));
 
-			Assert.AreEqual(0M, target.Eval("0"));
-			Assert.AreEqual(0.0M, target.Eval("0.0"));
-			Assert.AreEqual(45M, target.Eval("45"));
-			Assert.AreEqual(-565M, target.Eval("-565"));
-			Assert.AreEqual(23423423423434M, target.Eval("23423423423434"));
-			Assert.AreEqual(45.5M, target.Eval("45.5"));
-			Assert.AreEqual(-0.5M, target.Eval("-0.5"));
-			Assert.AreEqual(.2M, target.Eval(".2"));
-			Assert.AreEqual(-.2M, target.Eval("-.2"));
-			Assert.AreEqual(+.2M, target.Eval("+.2"));
-			Assert.AreEqual(.02M, target.Eval(".02"));
-			Assert.AreEqual(-.02M, target.Eval("-.02"));
-			Assert.AreEqual(+.02M, target.Eval("+.02"));
-			Assert.AreEqual(.20M, target.Eval(".20"));
-			Assert.AreEqual(-.20M, target.Eval("-.20"));
-			Assert.AreEqual(+.20M, target.Eval("+.20"));
-			Assert.AreEqual(.201M, target.Eval(".201"));
-			Assert.AreEqual(-.201M, target.Eval("-.201"));
-			Assert.AreEqual(+.201M, target.Eval("+.201"));
-			
+			Assert.That(target.Eval("0"), Is.EqualTo(0M));
+			Assert.That(target.Eval("0.0"), Is.EqualTo(0.0M));
+			Assert.That(target.Eval("45"), Is.EqualTo(45M));
+			Assert.That(target.Eval("-565"), Is.EqualTo(-565M));
+			Assert.That(target.Eval("23423423423434"), Is.EqualTo(23423423423434M));
+			Assert.That(target.Eval("45.5"), Is.EqualTo(45.5M));
+			Assert.That(target.Eval("-0.5"), Is.EqualTo(-0.5M));
+			Assert.That(target.Eval(".2"), Is.EqualTo(.2M));
+			Assert.That(target.Eval("-.2"), Is.EqualTo(-.2M));
+			Assert.That(target.Eval("+.2"), Is.EqualTo(+.2M));
+			Assert.That(target.Eval(".02"), Is.EqualTo(.02M));
+			Assert.That(target.Eval("-.02"), Is.EqualTo(-.02M));
+			Assert.That(target.Eval("+.02"), Is.EqualTo(+.02M));
+			Assert.That(target.Eval(".20"), Is.EqualTo(.20M));
+			Assert.That(target.Eval("-.20"), Is.EqualTo(-.20M));
+			Assert.That(target.Eval("+.20"), Is.EqualTo(+.20M));
+			Assert.That(target.Eval(".201"), Is.EqualTo(.201M));
+			Assert.That(target.Eval("-.201"), Is.EqualTo(-.201M));
+			Assert.That(target.Eval("+.201"), Is.EqualTo(+.201M));
 
 			// f suffix (single)
-			Assert.AreEqual(4f, target.Eval("4f"));
-			Assert.AreEqual(45F, target.Eval("45F"));
-			Assert.AreEqual(45.8f, target.Eval("45.8f"));
-			Assert.AreEqual(45.8F, target.Eval("45.8F"));
-			Assert.AreEqual(45.8F, target.Eval(" 45.8F "));
-			Assert.AreEqual(.2f, target.Eval(".2f"));
-			Assert.AreEqual(.2F, target.Eval(".2F"));
-			Assert.AreEqual(-.2f, target.Eval("-.2f"));
-			Assert.AreEqual(-.2F, target.Eval("-.2F"));
+			Assert.That(target.Eval("4f"), Is.EqualTo(4f));
+			Assert.That(target.Eval("45F"), Is.EqualTo(45F));
+			Assert.That(target.Eval("45.8f"), Is.EqualTo(45.8f));
+			Assert.That(target.Eval("45.8F"), Is.EqualTo(45.8F));
+			Assert.That(target.Eval(" 45.8F "), Is.EqualTo(45.8F));
+			Assert.That(target.Eval(".2f"), Is.EqualTo(.2f));
+			Assert.That(target.Eval(".2F"), Is.EqualTo(.2F));
+			Assert.That(target.Eval("-.2f"), Is.EqualTo(-.2f));
+			Assert.That(target.Eval("-.2F"), Is.EqualTo(-.2F));
 
 			// m suffix (decimal)
-			Assert.AreEqual(5M, target.Eval("5M"));
-			Assert.AreEqual(254m, target.Eval("254m"));
-			Assert.AreEqual(45.232M, target.Eval("45.232M"));
-			Assert.AreEqual(45.232m, target.Eval("45.232m"));
-			Assert.AreEqual(.022M, target.Eval(".022M"));
-			Assert.AreEqual(.022m, target.Eval(".022m"));
-			Assert.AreEqual(-.022m, target.Eval("-.022m"));
-			Assert.AreEqual(-.022M, target.Eval("-.022M"));
+			Assert.That(target.Eval("5M"), Is.EqualTo(5M));
+			Assert.That(target.Eval("254m"), Is.EqualTo(254m));
+			Assert.That(target.Eval("45.232M"), Is.EqualTo(45.232M));
+			Assert.That(target.Eval("45.232m"), Is.EqualTo(45.232m));
+			Assert.That(target.Eval(".022M"), Is.EqualTo(.022M));
+			Assert.That(target.Eval(".022m"), Is.EqualTo(.022m));
+			Assert.That(target.Eval("-.022m"), Is.EqualTo(-.022m));
+			Assert.That(target.Eval("-.022M"), Is.EqualTo(-.022M));
 		}
 
 		[Test]
@@ -358,9 +358,9 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(0b101ul, target.Eval("0b101ul"));
-			Assert.AreEqual(0B1111L, target.Eval("0B1111l"));
-			Assert.AreEqual(8, target.Eval("4+0b10+2"));
+			Assert.That(target.Eval("0b101ul"), Is.EqualTo(0b101ul));
+			Assert.That(target.Eval("0B1111l"), Is.EqualTo(0B1111L));
+			Assert.That(target.Eval("4+0b10+2"), Is.EqualTo(8));
 
 			Assert.Throws<ParseException>(() => target.Eval("0b"));
 			Assert.Throws<ParseException>(() => target.Eval("0b12"));
@@ -374,10 +374,10 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(0x012EFul, target.Eval("0x012EFul"));
-			Assert.AreEqual(0XAAe2L, target.Eval("0XAAe2l"));
-			Assert.AreEqual(170, target.Eval("4+0xA1+5"));
-			Assert.AreEqual(170, target.Eval("4+(0xA1)+5"));
+			Assert.That(target.Eval("0x012EFul"), Is.EqualTo(0x012EFul));
+			Assert.That(target.Eval("0XAAe2l"), Is.EqualTo(0XAAe2L));
+			Assert.That(target.Eval("4+0xA1+5"), Is.EqualTo(170));
+			Assert.That(target.Eval("4+(0xA1)+5"), Is.EqualTo(170));
 
 			Assert.Throws<ParseException>(() => target.Eval("0x"));
 			Assert.Throws<ParseException>(() => target.Eval("0x1Gl"));
@@ -389,59 +389,58 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual("ciao".GetType(), target.Eval("\"ciao\".GetType()"));
-			Assert.AreEqual('c'.GetType(), target.Eval("'c'.GetType()"));
-			Assert.AreEqual(true.GetType(), target.Eval("true.GetType()"));
-			Assert.AreEqual(false.GetType(), target.Eval("false.GetType()"));
+			Assert.That(target.Eval("\"ciao\".GetType()"), Is.EqualTo("ciao".GetType()));
+			Assert.That(target.Eval("'c'.GetType()"), Is.EqualTo('c'.GetType()));
+			Assert.That(target.Eval("true.GetType()"), Is.EqualTo(true.GetType()));
+			Assert.That(target.Eval("false.GetType()"), Is.EqualTo(false.GetType()));
 
-			Assert.AreEqual(45.GetType(), target.Eval("45.GetType()"));
-			Assert.AreEqual(23423423423434.GetType(), target.Eval("23423423423434.GetType()"));
-			Assert.AreEqual(45.5.GetType(), target.Eval("45.5.GetType()"));
-			Assert.AreEqual(45.8f.GetType(), target.Eval("45.8f.GetType()"));
-			Assert.AreEqual(45.232M.GetType(), target.Eval("45.232M.GetType()"));
+			Assert.That(target.Eval("45.GetType()"), Is.EqualTo(45.GetType()));
+			Assert.That(target.Eval("23423423423434.GetType()"), Is.EqualTo(23423423423434.GetType()));
+			Assert.That(target.Eval("45.5.GetType()"), Is.EqualTo(45.5.GetType()));
+			Assert.That(target.Eval("45.8f.GetType()"), Is.EqualTo(45.8f.GetType()));
+			Assert.That(target.Eval("45.232M.GetType()"), Is.EqualTo(45.232M.GetType()));
 
 			// Note: in C# I cannot compile "-565.GetType()" , I need to add parentheses
-			Assert.AreEqual((-565).GetType(), target.Eval("-565.GetType()"));
-			Assert.AreEqual((-0.5).GetType(), target.Eval("-0.5.GetType()"));
+			Assert.That(target.Eval("-565.GetType()"), Is.EqualTo((-565).GetType()));
+			Assert.That(target.Eval("-0.5.GetType()"), Is.EqualTo((-0.5).GetType()));
 
-			Assert.AreEqual((-.5).GetType(), target.Eval("-.5.GetType()"));
-			Assert.AreEqual((-.5f).GetType(), target.Eval("-.5f.GetType()"));
+			Assert.That(target.Eval("-.5.GetType()"), Is.EqualTo((-.5).GetType()));
+			Assert.That(target.Eval("-.5f.GetType()"), Is.EqualTo((-.5f).GetType()));
 
-			Assert.AreEqual((+.5).GetType(), target.Eval("+.5.GetType()"));
-			Assert.AreEqual((+.5f).GetType(), target.Eval("+.5f.GetType()"));
+			Assert.That(target.Eval("+.5.GetType()"), Is.EqualTo((+.5).GetType()));
+			Assert.That(target.Eval("+.5f.GetType()"), Is.EqualTo((+.5f).GetType()));
 		}
 
 		[Test]
 		public void Long_strings()
 		{
 			var target = new Interpreter();
-			Assert.AreEqual(
-				"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
-				target.Eval("\"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\""));
+			Assert.That(
+				target.Eval("\"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\""), Is.EqualTo("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."));
 		}
 
 		[Test]
 		public void Null_Keyword()
 		{
 			var target = new Interpreter();
-			Assert.IsNull(target.Eval("null"));
+			Assert.That(target.Eval("null"), Is.Null);
 		}
 
 		[Test]
 		public void Empty_String()
 		{
 			var target = new Interpreter();
-			Assert.AreEqual(string.Empty, target.Eval("\"\""));
+			Assert.That(target.Eval("\"\""), Is.EqualTo(string.Empty));
 		}
 
 		[Test]
 		public void Whitespace_String()
 		{
 			var target = new Interpreter();
-			Assert.AreEqual(" ", target.Eval("\" \""));
-			Assert.AreEqual(" \t ", target.Eval("\" \t \""));
-			Assert.AreEqual("   ", target.Eval("\"   \""));
-			Assert.AreEqual(" \r\n", target.Eval("\" \r\n\""));
+			Assert.That(target.Eval("\" \""), Is.EqualTo(" "));
+			Assert.That(target.Eval("\" \t \""), Is.EqualTo(" \t "));
+			Assert.That(target.Eval("\"   \""), Is.EqualTo("   "));
+			Assert.That(target.Eval("\" \r\n\""), Is.EqualTo(" \r\n"));
 		}
 
 		[Test]
@@ -449,7 +448,7 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual("l'aquila", target.Eval("\"l'aquila\""));
+			Assert.That(target.Eval("\"l'aquila\""), Is.EqualTo("l'aquila"));
 		}
 
 		[Test]
@@ -457,15 +456,15 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual("汉语/漢語", target.Eval("\"汉语/漢語\""));
-			Assert.AreEqual('汉', target.Eval("'汉'"));
+			Assert.That(target.Eval("\"汉语/漢語\""), Is.EqualTo("汉语/漢語"));
+			Assert.That(target.Eval("'汉'"), Is.EqualTo('汉'));
 
 			for (char c = char.MinValue; c < char.MaxValue; c++)
 			{
 				if (c != '\"' && c != '\\')
-					Assert.AreEqual(new string(c, 1), target.Eval(string.Format("\"{0}\"", c)), string.Format("Failed to parse string literals \"{0}\".", c));
+					Assert.That(target.Eval(string.Format("\"{0}\"", c)), Is.EqualTo(new string(c, 1)), string.Format("Failed to parse string literals \"{0}\".", c));
 				if (c != '\'' && c != '\\')
-					Assert.AreEqual(c, target.Eval(string.Format("'{0}'", c)), string.Format("Failed to parse char literals '{0}'.", c));
+					Assert.That(target.Eval(string.Format("'{0}'", c)), Is.EqualTo(c), string.Format("Failed to parse char literals '{0}'.", c));
 			}
 		}
 
@@ -474,17 +473,17 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual('\'', target.Eval("'\\''"));
-			Assert.AreEqual('\"', target.Eval("'\\\"'"));
-			Assert.AreEqual('\\', target.Eval("'\\\\'"));
-			Assert.AreEqual('\0', target.Eval("'\\0'"));
-			Assert.AreEqual('\a', target.Eval("'\\a'"));
-			Assert.AreEqual('\b', target.Eval("'\\b'"));
-			Assert.AreEqual('\f', target.Eval("'\\f'"));
-			Assert.AreEqual('\n', target.Eval("'\\n'"));
-			Assert.AreEqual('\r', target.Eval("'\\r'"));
-			Assert.AreEqual('\t', target.Eval("'\\t'"));
-			Assert.AreEqual('\v', target.Eval("'\\v'"));
+			Assert.That(target.Eval("'\\''"), Is.EqualTo('\''));
+			Assert.That(target.Eval("'\\\"'"), Is.EqualTo('\"'));
+			Assert.That(target.Eval("'\\\\'"), Is.EqualTo('\\'));
+			Assert.That(target.Eval("'\\0'"), Is.EqualTo('\0'));
+			Assert.That(target.Eval("'\\a'"), Is.EqualTo('\a'));
+			Assert.That(target.Eval("'\\b'"), Is.EqualTo('\b'));
+			Assert.That(target.Eval("'\\f'"), Is.EqualTo('\f'));
+			Assert.That(target.Eval("'\\n'"), Is.EqualTo('\n'));
+			Assert.That(target.Eval("'\\r'"), Is.EqualTo('\r'));
+			Assert.That(target.Eval("'\\t'"), Is.EqualTo('\t'));
+			Assert.That(target.Eval("'\\v'"), Is.EqualTo('\v'));
 		}
 
 		[Test]
@@ -492,19 +491,19 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual("\'", target.Eval("\"\\'\""));
-			Assert.AreEqual("\"", target.Eval("\"\\\"\""));
-			Assert.AreEqual("\\", target.Eval("\"\\\\\""));
-			Assert.AreEqual("\0", target.Eval("\"\\0\""));
-			Assert.AreEqual("\a", target.Eval("\"\\a\""));
-			Assert.AreEqual("\b", target.Eval("\"\\b\""));
-			Assert.AreEqual("\f", target.Eval("\"\\f\""));
-			Assert.AreEqual("\n", target.Eval("\"\\n\""));
-			Assert.AreEqual("\r", target.Eval("\"\\r\""));
-			Assert.AreEqual("\t", target.Eval("\"\\t\""));
-			Assert.AreEqual("\v", target.Eval("\"\\v\""));
+			Assert.That(target.Eval("\"\\'\""), Is.EqualTo("\'"));
+			Assert.That(target.Eval("\"\\\"\""), Is.EqualTo("\""));
+			Assert.That(target.Eval("\"\\\\\""), Is.EqualTo("\\"));
+			Assert.That(target.Eval("\"\\0\""), Is.EqualTo("\0"));
+			Assert.That(target.Eval("\"\\a\""), Is.EqualTo("\a"));
+			Assert.That(target.Eval("\"\\b\""), Is.EqualTo("\b"));
+			Assert.That(target.Eval("\"\\f\""), Is.EqualTo("\f"));
+			Assert.That(target.Eval("\"\\n\""), Is.EqualTo("\n"));
+			Assert.That(target.Eval("\"\\r\""), Is.EqualTo("\r"));
+			Assert.That(target.Eval("\"\\t\""), Is.EqualTo("\t"));
+			Assert.That(target.Eval("\"\\v\""), Is.EqualTo("\v"));
 
-			Assert.AreEqual("L\'aquila\r\n\tè\tbella.", target.Eval("\"L\\'aquila\\r\\n\\tè\\tbella.\""));
+			Assert.That(target.Eval("\"L\\'aquila\\r\\n\\tè\\tbella.\""), Is.EqualTo("L\'aquila\r\n\tè\tbella."));
 		}
 
 		[Test]
@@ -560,42 +559,42 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(typeof(string), target.Parse("\"some string\"").ReturnType);
-			Assert.AreEqual(typeof(string), target.Parse("\"\"").ReturnType);
-			Assert.AreEqual(typeof(int), target.Parse("234").ReturnType);
-			Assert.AreEqual(typeof(int), target.Parse("-234").ReturnType);
-			Assert.AreEqual(typeof(uint), target.Parse("123u").ReturnType);
-			Assert.AreEqual(typeof(uint), target.Parse("123U").ReturnType);
-			Assert.AreEqual(typeof(long), target.Parse("-123l").ReturnType);
-			Assert.AreEqual(typeof(long), target.Parse("123l").ReturnType);
-			Assert.AreEqual(typeof(long), target.Parse("123L").ReturnType);
-			Assert.AreEqual(typeof(ulong), target.Parse("123UL").ReturnType);
-			Assert.AreEqual(typeof(ulong), target.Parse("123Ul").ReturnType);
-			Assert.AreEqual(typeof(ulong), target.Parse("123uL").ReturnType);
-			Assert.AreEqual(typeof(ulong), target.Parse("123ul").ReturnType);
-			Assert.AreEqual(typeof(ulong), target.Parse("123LU").ReturnType);
-			Assert.AreEqual(typeof(ulong), target.Parse("123Lu").ReturnType);
-			Assert.AreEqual(typeof(ulong), target.Parse("123lU").ReturnType);
-			Assert.AreEqual(typeof(ulong), target.Parse("123lu").ReturnType);
-			Assert.AreEqual(typeof(double), target.Parse("234.54").ReturnType);
-			Assert.AreEqual(typeof(double), target.Parse(".9").ReturnType);
-			Assert.AreEqual(typeof(double), target.Parse("-.9").ReturnType);
-			Assert.AreEqual(typeof(double), target.Parse("234d").ReturnType);
-			Assert.AreEqual(typeof(double), target.Parse("234D").ReturnType);
-			Assert.AreEqual(typeof(float), target.Parse("4.5f").ReturnType);
-			Assert.AreEqual(typeof(float), target.Parse("4.5F").ReturnType);
-			Assert.AreEqual(typeof(float), target.Parse(".5f").ReturnType);
-			Assert.AreEqual(typeof(float), target.Parse(".5F").ReturnType);
-			Assert.AreEqual(typeof(decimal), target.Parse("234.48m").ReturnType);
-			Assert.AreEqual(typeof(decimal), target.Parse("234.48M").ReturnType);
-			Assert.AreEqual(typeof(decimal), target.Parse(".48m").ReturnType);
-			Assert.AreEqual(typeof(decimal), target.Parse(".48M").ReturnType);
-			Assert.AreEqual(typeof(object), target.Parse("null").ReturnType);
+			Assert.That(target.Parse("\"some string\"").ReturnType, Is.EqualTo(typeof(string)));
+			Assert.That(target.Parse("\"\"").ReturnType, Is.EqualTo(typeof(string)));
+			Assert.That(target.Parse("234").ReturnType, Is.EqualTo(typeof(int)));
+			Assert.That(target.Parse("-234").ReturnType, Is.EqualTo(typeof(int)));
+			Assert.That(target.Parse("123u").ReturnType, Is.EqualTo(typeof(uint)));
+			Assert.That(target.Parse("123U").ReturnType, Is.EqualTo(typeof(uint)));
+			Assert.That(target.Parse("-123l").ReturnType, Is.EqualTo(typeof(long)));
+			Assert.That(target.Parse("123l").ReturnType, Is.EqualTo(typeof(long)));
+			Assert.That(target.Parse("123L").ReturnType, Is.EqualTo(typeof(long)));
+			Assert.That(target.Parse("123UL").ReturnType, Is.EqualTo(typeof(ulong)));
+			Assert.That(target.Parse("123Ul").ReturnType, Is.EqualTo(typeof(ulong)));
+			Assert.That(target.Parse("123uL").ReturnType, Is.EqualTo(typeof(ulong)));
+			Assert.That(target.Parse("123ul").ReturnType, Is.EqualTo(typeof(ulong)));
+			Assert.That(target.Parse("123LU").ReturnType, Is.EqualTo(typeof(ulong)));
+			Assert.That(target.Parse("123Lu").ReturnType, Is.EqualTo(typeof(ulong)));
+			Assert.That(target.Parse("123lU").ReturnType, Is.EqualTo(typeof(ulong)));
+			Assert.That(target.Parse("123lu").ReturnType, Is.EqualTo(typeof(ulong)));
+			Assert.That(target.Parse("234.54").ReturnType, Is.EqualTo(typeof(double)));
+			Assert.That(target.Parse(".9").ReturnType, Is.EqualTo(typeof(double)));
+			Assert.That(target.Parse("-.9").ReturnType, Is.EqualTo(typeof(double)));
+			Assert.That(target.Parse("234d").ReturnType, Is.EqualTo(typeof(double)));
+			Assert.That(target.Parse("234D").ReturnType, Is.EqualTo(typeof(double)));
+			Assert.That(target.Parse("4.5f").ReturnType, Is.EqualTo(typeof(float)));
+			Assert.That(target.Parse("4.5F").ReturnType, Is.EqualTo(typeof(float)));
+			Assert.That(target.Parse(".5f").ReturnType, Is.EqualTo(typeof(float)));
+			Assert.That(target.Parse(".5F").ReturnType, Is.EqualTo(typeof(float)));
+			Assert.That(target.Parse("234.48m").ReturnType, Is.EqualTo(typeof(decimal)));
+			Assert.That(target.Parse("234.48M").ReturnType, Is.EqualTo(typeof(decimal)));
+			Assert.That(target.Parse(".48m").ReturnType, Is.EqualTo(typeof(decimal)));
+			Assert.That(target.Parse(".48M").ReturnType, Is.EqualTo(typeof(decimal)));
+			Assert.That(target.Parse("null").ReturnType, Is.EqualTo(typeof(object)));
 
-			Assert.AreEqual((45.5).GetType(), target.Eval("45.5").GetType());
-			Assert.AreEqual((45.8f).GetType(), target.Eval("45.8f").GetType());
-			Assert.AreEqual((45.232M).GetType(), target.Eval("45.232M").GetType());
-			Assert.AreEqual((2e+201).GetType(), target.Eval("2e+201").GetType());
+			Assert.That(target.Eval("45.5").GetType(), Is.EqualTo((45.5).GetType()));
+			Assert.That(target.Eval("45.8f").GetType(), Is.EqualTo((45.8f).GetType()));
+			Assert.That(target.Eval("45.232M").GetType(), Is.EqualTo((45.232M).GetType()));
+			Assert.That(target.Eval("2e+201").GetType(), Is.EqualTo((2e+201).GetType()));
 		}
 
 		[Test]
@@ -604,7 +603,7 @@ namespace DynamicExpresso.UnitTest
 			var originalCulture = Thread.CurrentThread.CurrentCulture;
 			Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
 			var target = new Interpreter();
-			Assert.AreEqual(45.5, target.Eval("45.5"));
+			Assert.That(target.Eval("45.5"), Is.EqualTo(45.5));
 			Thread.CurrentThread.CurrentCulture = originalCulture;
 		}
 
@@ -614,7 +613,7 @@ namespace DynamicExpresso.UnitTest
 			var originalCulture = Thread.CurrentThread.CurrentCulture;
 			Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("it-IT");
 			var target = new Interpreter();
-			Assert.AreEqual(45.5, target.Eval("45.5"));
+			Assert.That(target.Eval("45.5"), Is.EqualTo(45.5));
 			Thread.CurrentThread.CurrentCulture = originalCulture;
 		}
 

--- a/test/DynamicExpresso.UnitTest/MemberInvocationTest.cs
+++ b/test/DynamicExpresso.UnitTest/MemberInvocationTest.cs
@@ -16,9 +16,9 @@ namespace DynamicExpresso.UnitTest
 
 			var target = new Interpreter().SetVariable("x", x);
 
-			Assert.AreEqual(x.HelloWorld(), target.Eval("x.HelloWorld()"));
-			Assert.AreEqual(x.AProperty, target.Eval("x.AProperty"));
-			Assert.AreEqual(x.AField, target.Eval("x.AField"));
+			Assert.That(target.Eval("x.HelloWorld()"), Is.EqualTo(x.HelloWorld()));
+			Assert.That(target.Eval("x.AProperty"), Is.EqualTo(x.AProperty));
+			Assert.That(target.Eval("x.AField"), Is.EqualTo(x.AField));
 		}
 
 		[Ignore("See issue 65")]
@@ -26,7 +26,7 @@ namespace DynamicExpresso.UnitTest
 		public void Null_conditional_property()
 		{
 			var target = new Interpreter().SetVariable("x", null, typeof(MyTestService));
-			Assert.IsNull(target.Eval("x?.AProperty"));
+			Assert.That(target.Eval("x?.AProperty"), Is.Null);
 		}
 
 		[Test]
@@ -38,14 +38,14 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("x", x);
 			var y = new MyTestService();
 			target.SetVariable("y", y);
-			var z = new[] {7, 8, 9, 10};
+			var z = new[] { 7, 8, 9, 10 };
 			target.SetVariable("z", z);
 
-			Assert.AreEqual(x[2], target.Eval("x[2]"));
-			Assert.AreEqual(y[2], target.Eval("y[2]"));
-			Assert.AreEqual(y[2].ToString(), target.Eval("y[2].ToString()"));
-			Assert.AreEqual(y[(short)2], target.Eval("y[(Int16)2]"));
-			Assert.AreEqual(z[2], target.Eval("z[2]"));
+			Assert.That(target.Eval("x[2]"), Is.EqualTo(x[2]));
+			Assert.That(target.Eval("y[2]"), Is.EqualTo(y[2]));
+			Assert.That(target.Eval("y[2].ToString()"), Is.EqualTo(y[2].ToString()));
+			Assert.That(target.Eval("y[(Int16)2]"), Is.EqualTo(y[(short)2]));
+			Assert.That(target.Eval("z[2]"), Is.EqualTo(z[2]));
 		}
 
 		[Test]
@@ -61,13 +61,13 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("z", z);
 
 			target.Eval("x[2] = 'r'");
-			Assert.AreEqual(x.ToString(), "tire");
+			Assert.That(x.ToString(), Is.EqualTo("tire"));
 			target.Eval("y[(Int16)9] = y.Today");
-			Assert.AreEqual(y.AField, y.Today.AddYears(9));
+			Assert.That(y.Today.AddYears(9), Is.EqualTo(y.AField));
 			target.Eval("y[(Int64)7] = y.Today");
-			Assert.AreEqual(y.AField, y.Today.AddSeconds(7));
+			Assert.That(y.Today.AddSeconds(7), Is.EqualTo(y.AField));
 			target.Eval("z[2] = 4");
-			Assert.AreEqual(z, new[] { 7, 8, 4, 10 });
+			Assert.That(z, Is.EqualTo(new[] { 7, 8, 4, 10 }));
 		}
 
 		[Test]
@@ -90,13 +90,13 @@ namespace DynamicExpresso.UnitTest
 			var y = new Dictionary<string, int> { { "first", 1 }, { "second", 2 }, { "third", 3 } };
 			target.SetVariable("y", y);
 
-			Assert.AreEqual(x[2], target.Eval("x[2]"));
-			Assert.AreEqual(y["second"], target.Eval("y[\"second\"]"));
+			Assert.That(target.Eval("x[2]"), Is.EqualTo(x[2]));
+			Assert.That(target.Eval("y[\"second\"]"), Is.EqualTo(y["second"]));
 
 			target.Eval("x[2] = 1");
-			Assert.AreEqual(x, new List<int> { 3, 4, 1, 6 });
+			Assert.That(new List<int> { 3, 4, 1, 6 }, Is.EqualTo(x));
 			target.Eval("y[\"second\"] = 2000");
-			Assert.AreEqual(y, new Dictionary<string, int> { { "first", 1 }, { "second", 2000 }, { "third", 3 } });
+			Assert.That(new Dictionary<string, int> { { "first", 1 }, { "second", 2000 }, { "third", 3 } }, Is.EqualTo(y));
 		}
 
 		[Test]
@@ -109,9 +109,9 @@ namespace DynamicExpresso.UnitTest
 			var y = new MyTestService();
 			target.SetVariable("y", y);
 
-			Assert.AreEqual(x[1, 2], target.Eval("x[1, 2]"));
-			Assert.AreEqual(y[y.Today, 2], target.Eval("y[y.Today, 2]"));
-			Assert.AreEqual(y[y.Today], target.Eval("y[y.Today]"));
+			Assert.That(target.Eval("x[1, 2]"), Is.EqualTo(x[1, 2]));
+			Assert.That(target.Eval("y[y.Today, 2]"), Is.EqualTo(y[y.Today, 2]));
+			Assert.That(target.Eval("y[y.Today]"), Is.EqualTo(y[y.Today]));
 		}
 
 		[Test]
@@ -128,11 +128,11 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("span", span);
 
 			target.Eval("x[1, 2] = 7");
-			Assert.AreEqual(x, new[,] { { 11, 12, 13, 14 }, { 21, 22, 7, 24 }, { 31, 32, 33, 34 } });
+			Assert.That(new[,] { { 11, 12, 13, 14 }, { 21, 22, 7, 24 }, { 31, 32, 33, 34 } }, Is.EqualTo(x));
 			target.Eval("y[y.Today, 2] = span");
-			Assert.AreEqual(y.AField, y.Today.AddDays(2).Add(span));
+			Assert.That(y.Today.AddDays(2).Add(span), Is.EqualTo(y.AField));
 			target.Eval("y[y.Today] = span");
-			Assert.AreEqual(y.AField, y.Today.AddDays(3).Add(span));
+			Assert.That(y.Today.AddDays(3).Add(span), Is.EqualTo(y.AField));
 		}
 
 		[Test]
@@ -140,8 +140,7 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(string.Format("ciao {0}, today is {1}", "mondo", DateTime.Today),
-											target.Eval("string.Format(\"ciao {0}, today is {1}\", \"mondo\", DateTime.Today.ToString())"));
+			Assert.That(target.Eval("string.Format(\"ciao {0}, today is {1}\", \"mondo\", DateTime.Today.ToString())"), Is.EqualTo(string.Format("ciao {0}, today is {1}", "mondo", DateTime.Today)));
 		}
 
 		[Test]
@@ -149,8 +148,7 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(string.Format("ciao {0}, today is {1}", "mondo", DateTime.Today),
-											target.Eval("string.Format(\"ciao {0}, today is {1}\", \"mondo\", DateTime.Today)"));
+			Assert.That(target.Eval("string.Format(\"ciao {0}, today is {1}\", \"mondo\", DateTime.Today)"), Is.EqualTo(string.Format("ciao {0}, today is {1}", "mondo", DateTime.Today)));
 		}
 
 		[Test]
@@ -158,8 +156,7 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(string.Format("ciao {0}", ""),
-											target.Eval("string.Format(\"ciao {0}\", \"\")"));
+			Assert.That(target.Eval("string.Format(\"ciao {0}\", \"\")"), Is.EqualTo(string.Format("ciao {0}", "")));
 		}
 
 		[Test]
@@ -167,8 +164,7 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(string.Format("ciao mondo, today is {0}", DateTime.Today),
-											target.Eval("string.Format(\"ciao {0}, today is {1}\", \"mondo\", DateTime.Today)"));
+			Assert.That(target.Eval("string.Format(\"ciao {0}, today is {1}\", \"mondo\", DateTime.Today)"), Is.EqualTo(string.Format("ciao mondo, today is {0}", DateTime.Today)));
 		}
 
 		[Test]
@@ -178,15 +174,15 @@ namespace DynamicExpresso.UnitTest
 
 			var x = new MyTestService();
 			var parameters = new[] {
-                            new Parameter("x", x.GetType(), x)
-                            };
+							new Parameter("x", x.GetType(), x)
+							};
 
-			Assert.AreEqual(x.HelloWorld(), target.Eval("x.HelloWorld()", parameters));
-			Assert.AreEqual(x.HELLOWORLD(), target.Eval("x.HELLOWORLD()", parameters));
-			Assert.AreEqual(x.AProperty, target.Eval("x.AProperty", parameters));
-			Assert.AreEqual(x.APROPERTY, target.Eval("x.APROPERTY", parameters));
-			Assert.AreEqual(x.AField, target.Eval("x.AField", parameters));
-			Assert.AreEqual(x.AFIELD, target.Eval("x.AFIELD", parameters));
+			Assert.That(target.Eval("x.HelloWorld()", parameters), Is.EqualTo(x.HelloWorld()));
+			Assert.That(target.Eval("x.HELLOWORLD()", parameters), Is.EqualTo(x.HELLOWORLD()));
+			Assert.That(target.Eval("x.AProperty", parameters), Is.EqualTo(x.AProperty));
+			Assert.That(target.Eval("x.APROPERTY", parameters), Is.EqualTo(x.APROPERTY));
+			Assert.That(target.Eval("x.AField", parameters), Is.EqualTo(x.AField));
+			Assert.That(target.Eval("x.AFIELD", parameters), Is.EqualTo(x.AFIELD));
 		}
 
 		[Test]
@@ -196,15 +192,15 @@ namespace DynamicExpresso.UnitTest
 
 			var x = new MyTestServiceCaseInsensitive();
 			var parameters = new[] {
-                            new Parameter("x", x.GetType(), x)
-                            };
+							new Parameter("x", x.GetType(), x)
+							};
 
-			Assert.AreEqual(x.AMethod(), target.Eval("x.AMethod()", parameters));
-			Assert.AreEqual(x.AMethod(), target.Eval("x.AMETHOD()", parameters));
-			Assert.AreEqual(x.AProperty, target.Eval("x.AProperty", parameters));
-			Assert.AreEqual(x.AProperty, target.Eval("x.APROPERTY", parameters));
-			Assert.AreEqual(x.AField, target.Eval("x.AField", parameters));
-			Assert.AreEqual(x.AField, target.Eval("x.AFIELD", parameters));
+			Assert.That(target.Eval("x.AMethod()", parameters), Is.EqualTo(x.AMethod()));
+			Assert.That(target.Eval("x.AMETHOD()", parameters), Is.EqualTo(x.AMethod()));
+			Assert.That(target.Eval("x.AProperty", parameters), Is.EqualTo(x.AProperty));
+			Assert.That(target.Eval("x.APROPERTY", parameters), Is.EqualTo(x.AProperty));
+			Assert.That(target.Eval("x.AField", parameters), Is.EqualTo(x.AField));
+			Assert.That(target.Eval("x.AFIELD", parameters), Is.EqualTo(x.AField));
 		}
 
 		[Test]
@@ -214,11 +210,11 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 											.SetVariable("service", service);
 
-			Assert.AreEqual(0, service.VoidMethodCalls);
+			Assert.That(service.VoidMethodCalls, Is.EqualTo(0));
 			target.Eval("service.VoidMethod()");
-			Assert.AreEqual(1, service.VoidMethodCalls);
+			Assert.That(service.VoidMethodCalls, Is.EqualTo(1));
 
-			Assert.AreEqual(typeof(void), target.Parse("service.VoidMethod()").ReturnType);
+			Assert.That(target.Parse("service.VoidMethod()").ReturnType, Is.EqualTo(typeof(void)));
 		}
 
 		[Test]
@@ -228,7 +224,7 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 											.SetVariable("service", service);
 
-			Assert.AreEqual("DynamicExpresso.UnitTest.MemberInvocationTest+MyTestService", target.Eval("service.ToString()"));
+			Assert.That(target.Eval("service.ToString()"), Is.EqualTo("DynamicExpresso.UnitTest.MemberInvocationTest+MyTestService"));
 		}
 
 		[Test]
@@ -238,14 +234,14 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 											.SetVariable("service", service, typeof(MyTestInterface));
 
-			Assert.AreEqual("DynamicExpresso.UnitTest.MemberInvocationTest+MyTestInterfaceImp", target.Eval("service.ToString()"));
+			Assert.That(target.Eval("service.ToString()"), Is.EqualTo("DynamicExpresso.UnitTest.MemberInvocationTest+MyTestInterfaceImp"));
 		}
 
 		[Test]
 		public void ToString_Method_on_a_primitive_type()
 		{
 			var target = new Interpreter();
-			Assert.AreEqual("3", target.Eval("(3).ToString()"));
+			Assert.That(target.Eval("(3).ToString()"), Is.EqualTo("3"));
 		}
 
 		[Test]
@@ -255,7 +251,7 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 											.SetVariable("service", service);
 
-			Assert.AreEqual(typeof(MyTestService), target.Eval("service.GetType()"));
+			Assert.That(target.Eval("service.GetType()"), Is.EqualTo(typeof(MyTestService)));
 		}
 
 		[Test]
@@ -265,14 +261,14 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 											.SetVariable("service", service, typeof(MyTestInterface));
 
-			Assert.AreEqual(typeof(MyTestInterfaceImp), target.Eval("service.GetType()"));
+			Assert.That(target.Eval("service.GetType()"), Is.EqualTo(typeof(MyTestInterfaceImp)));
 		}
 
 		[Test]
 		public void GetType_Method_on_a_primitive_type()
 		{
 			var target = new Interpreter();
-			Assert.AreEqual((3).GetType(), target.Eval("(3).GetType()"));
+			Assert.That(target.Eval("(3).GetType()"), Is.EqualTo((3).GetType()));
 		}
 
 		[Test]
@@ -285,16 +281,16 @@ namespace DynamicExpresso.UnitTest
 			var z = 5;
 			int? w = null;
 			var parameters = new[] {
-                            new Parameter("x", x.GetType(), x),
-                            new Parameter("y", y.GetType(), y),
-                            new Parameter("z", z.GetType(), z),
-                            new Parameter("w", typeof(int?), w)
-                            };
+							new Parameter("x", x.GetType(), x),
+							new Parameter("y", y.GetType(), y),
+							new Parameter("z", z.GetType(), z),
+							new Parameter("w", typeof(int?), w)
+							};
 
-			Assert.AreEqual(x.MethodWithNullableParam(y, z), target.Eval("x.MethodWithNullableParam(y, z)", parameters));
-			Assert.AreEqual(x.MethodWithNullableParam(y, w), target.Eval("x.MethodWithNullableParam(y, w)", parameters));
-			Assert.AreEqual(x.MethodWithNullableParam(y, 30), target.Eval("x.MethodWithNullableParam(y, 30)", parameters));
-			Assert.AreEqual(x.MethodWithNullableParam(y, null), target.Eval("x.MethodWithNullableParam(y, null)", parameters));
+			Assert.That(target.Eval("x.MethodWithNullableParam(y, z)", parameters), Is.EqualTo(x.MethodWithNullableParam(y, z)));
+			Assert.That(target.Eval("x.MethodWithNullableParam(y, w)", parameters), Is.EqualTo(x.MethodWithNullableParam(y, w)));
+			Assert.That(target.Eval("x.MethodWithNullableParam(y, 30)", parameters), Is.EqualTo(x.MethodWithNullableParam(y, 30)));
+			Assert.That(target.Eval("x.MethodWithNullableParam(y, null)", parameters), Is.EqualTo(x.MethodWithNullableParam(y, null)));
 		}
 
 		[Test]
@@ -307,27 +303,27 @@ namespace DynamicExpresso.UnitTest
 			double z = 5;
 			int? w = null;
 			var parameters = new[] {
-                            new Parameter("x", x.GetType(), x),
-                            new Parameter("y", y.GetType(), y),
-                            new Parameter("z", z.GetType(), z),
-                            new Parameter("w", typeof(int?), w)
-                            };
+							new Parameter("x", x.GetType(), x),
+							new Parameter("y", y.GetType(), y),
+							new Parameter("z", z.GetType(), z),
+							new Parameter("w", typeof(int?), w)
+							};
 
-			Assert.AreEqual(x.MethodWithGenericParam(x), target.Eval("x.MethodWithGenericParam(x)", parameters));
-			Assert.AreEqual(x.MethodWithGenericParam(y), target.Eval("x.MethodWithGenericParam(y)", parameters));
-			Assert.AreEqual(x.MethodWithGenericParam(z), target.Eval("x.MethodWithGenericParam(z)", parameters));
-			Assert.AreEqual(x.MethodWithGenericParam(w), target.Eval("x.MethodWithGenericParam(w)", parameters));
+			Assert.That(target.Eval("x.MethodWithGenericParam(x)", parameters), Is.EqualTo(x.MethodWithGenericParam(x)));
+			Assert.That(target.Eval("x.MethodWithGenericParam(y)", parameters), Is.EqualTo(x.MethodWithGenericParam(y)));
+			Assert.That(target.Eval("x.MethodWithGenericParam(z)", parameters), Is.EqualTo(x.MethodWithGenericParam(z)));
+			Assert.That(target.Eval("x.MethodWithGenericParam(w)", parameters), Is.EqualTo(x.MethodWithGenericParam(w)));
 
-			Assert.AreEqual(x.MethodWithGenericParam(y, x), target.Eval("x.MethodWithGenericParam(y, x)", parameters));
-			Assert.AreEqual(x.MethodWithGenericParam(y, y), target.Eval("x.MethodWithGenericParam(y, y)", parameters));
-			Assert.AreEqual(x.MethodWithGenericParam(y, z), target.Eval("x.MethodWithGenericParam(y, z)", parameters));
-			Assert.AreEqual(x.MethodWithGenericParam(y, w), target.Eval("x.MethodWithGenericParam(y, w)", parameters));
+			Assert.That(target.Eval("x.MethodWithGenericParam(y, x)", parameters), Is.EqualTo(x.MethodWithGenericParam(y, x)));
+			Assert.That(target.Eval("x.MethodWithGenericParam(y, y)", parameters), Is.EqualTo(x.MethodWithGenericParam(y, y)));
+			Assert.That(target.Eval("x.MethodWithGenericParam(y, z)", parameters), Is.EqualTo(x.MethodWithGenericParam(y, z)));
+			Assert.That(target.Eval("x.MethodWithGenericParam(y, w)", parameters), Is.EqualTo(x.MethodWithGenericParam(y, w)));
 
-			Assert.AreEqual(x.MethodWithGenericParamAndDefault(y,y), target.Eval("x.MethodWithGenericParamAndDefault(y,y)", parameters));
-			Assert.AreEqual(x.MethodWithGenericParamAndDefault(y), target.Eval("x.MethodWithGenericParamAndDefault(y)", parameters));
-			Assert.AreEqual(x.MethodWithGenericParamAndDefault1Levels(y), target.Eval("x.MethodWithGenericParamAndDefault1Levels(y)", parameters));
-			Assert.AreEqual(x.MethodWithGenericParamAndDefault2Levels(y), target.Eval("x.MethodWithGenericParamAndDefault2Levels(y)", parameters));
-			Assert.AreEqual(x.MethodWithGenericParamAndDefault2Levels(y, w), target.Eval("x.MethodWithGenericParamAndDefault2Levels(y, w)", parameters));
+			Assert.That(target.Eval("x.MethodWithGenericParamAndDefault(y,y)", parameters), Is.EqualTo(x.MethodWithGenericParamAndDefault(y, y)));
+			Assert.That(target.Eval("x.MethodWithGenericParamAndDefault(y)", parameters), Is.EqualTo(x.MethodWithGenericParamAndDefault(y)));
+			Assert.That(target.Eval("x.MethodWithGenericParamAndDefault1Levels(y)", parameters), Is.EqualTo(x.MethodWithGenericParamAndDefault1Levels(y)));
+			Assert.That(target.Eval("x.MethodWithGenericParamAndDefault2Levels(y)", parameters), Is.EqualTo(x.MethodWithGenericParamAndDefault2Levels(y)));
+			Assert.That(target.Eval("x.MethodWithGenericParamAndDefault2Levels(y, w)", parameters), Is.EqualTo(x.MethodWithGenericParamAndDefault2Levels(y, w)));
 		}
 
 		[Test]
@@ -338,7 +334,7 @@ namespace DynamicExpresso.UnitTest
 			var x = new MyTestService();
 			target.SetVariable("x", x);
 
-			Assert.AreEqual("works", target.Eval("x.GenericMethodWithConstraint(\"works\")"));
+			Assert.That(target.Eval("x.GenericMethodWithConstraint(\"works\")"), Is.EqualTo("works"));
 			Assert.Throws<NoApplicableMethodException>(() => target.Eval("x.GenericMethodWithConstraint(5)"), "This shouldn't throw a System.ArgumentException \"Violates the constraint of type 'T'\"");
 		}
 
@@ -351,16 +347,16 @@ namespace DynamicExpresso.UnitTest
 
 			target.SetVariable("x", x);
 
-			Assert.AreEqual(0, x.MethodWithParamsArrayCalls);
+			Assert.That(x.MethodWithParamsArrayCalls, Is.EqualTo(0));
 
-			Assert.AreEqual(x.MethodWithParamsArray(DateTime.Now, 2, 1, 34), target.Eval("x.MethodWithParamsArray(DateTime.Now, 2, 1, 34)"));
-			Assert.AreEqual(2, x.MethodWithParamsArrayCalls);
+			Assert.That(target.Eval("x.MethodWithParamsArray(DateTime.Now, 2, 1, 34)"), Is.EqualTo(x.MethodWithParamsArray(DateTime.Now, 2, 1, 34)));
+			Assert.That(x.MethodWithParamsArrayCalls, Is.EqualTo(2));
 
 			var myParamArray = new int[] { 2, 1, 34 };
 			target.SetVariable("myParamArray", myParamArray);
 
-			Assert.AreEqual(x.MethodWithParamsArray(DateTime.Now, myParamArray), target.Eval("x.MethodWithParamsArray(DateTime.Now, myParamArray)"));
-			Assert.AreEqual(4, x.MethodWithParamsArrayCalls);
+			Assert.That(target.Eval("x.MethodWithParamsArray(DateTime.Now, myParamArray)"), Is.EqualTo(x.MethodWithParamsArray(DateTime.Now, myParamArray)));
+			Assert.That(x.MethodWithParamsArrayCalls, Is.EqualTo(4));
 		}
 
 		[Test]
@@ -373,12 +369,12 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("x", x);
 
 			target.Eval("x.AmbiguousMethod(DateTime.Now, 2, 3)");
-			Assert.AreEqual(1, x.AmbiguousMethod_NormalCalls);
-			Assert.AreEqual(0, x.AmbiguousMethod_ParamsArrayCalls);
+			Assert.That(x.AmbiguousMethod_NormalCalls, Is.EqualTo(1));
+			Assert.That(x.AmbiguousMethod_ParamsArrayCalls, Is.EqualTo(0));
 
 			target.Eval("x.AmbiguousMethod(DateTime.Now, 2, 3, 4)");
-			Assert.AreEqual(1, x.AmbiguousMethod_NormalCalls);
-			Assert.AreEqual(1, x.AmbiguousMethod_ParamsArrayCalls);
+			Assert.That(x.AmbiguousMethod_NormalCalls, Is.EqualTo(1));
+			Assert.That(x.AmbiguousMethod_ParamsArrayCalls, Is.EqualTo(1));
 		}
 
 		[Test]
@@ -387,7 +383,7 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter();
 			var x = new MyTestService();
 			target.SetVariable("x", x);
-			Assert.AreEqual(3, target.Eval("x.OverloadMethodWithParamsArray(2, 3, 1)"));
+			Assert.That(target.Eval("x.OverloadMethodWithParamsArray(2, 3, 1)"), Is.EqualTo(3));
 		}
 
 
@@ -398,7 +394,7 @@ namespace DynamicExpresso.UnitTest
 			target.Reference(typeof(Utils));
 
 			var listInt = target.Eval<List<int>>("Utils.Array(1, 2, 3)");
-			Assert.AreEqual(new[] { 1, 2, 3 }, listInt);
+			Assert.That(listInt, Is.EqualTo(new[] { 1, 2, 3 }));
 
 			// type parameter can't be inferred from usage
 			Assert.Throws<ParseException>(() => target.Eval<List<int>>("Utils.Array(1,\"str\", 3)"));
@@ -420,11 +416,11 @@ namespace DynamicExpresso.UnitTest
 				new Parameter("w", w.GetType(), w)
 			};
 
-			Assert.AreEqual(x.MethodWithOptionalParam(y), target.Eval("x.MethodWithOptionalParam(y)", parameters));
-			Assert.AreEqual(x.MethodWithOptionalParam(y, z), target.Eval("x.MethodWithOptionalParam(y, z)", parameters));
-			Assert.AreEqual(x.MethodWithOptionalParam(z, y), target.Eval("x.MethodWithOptionalParam(z, y)", parameters));
-			Assert.AreEqual(x.MethodWithOptionalParam(y, z, w), target.Eval("x.MethodWithOptionalParam(y, z, w)", parameters));
-			Assert.AreEqual(x.MethodWithOptionalParam(w, y, z), target.Eval("x.MethodWithOptionalParam(w, y, z)", parameters));
+			Assert.That(target.Eval("x.MethodWithOptionalParam(y)", parameters), Is.EqualTo(x.MethodWithOptionalParam(y)));
+			Assert.That(target.Eval("x.MethodWithOptionalParam(y, z)", parameters), Is.EqualTo(x.MethodWithOptionalParam(y, z)));
+			Assert.That(target.Eval("x.MethodWithOptionalParam(z, y)", parameters), Is.EqualTo(x.MethodWithOptionalParam(z, y)));
+			Assert.That(target.Eval("x.MethodWithOptionalParam(y, z, w)", parameters), Is.EqualTo(x.MethodWithOptionalParam(y, z, w)));
+			Assert.That(target.Eval("x.MethodWithOptionalParam(w, y, z)", parameters), Is.EqualTo(x.MethodWithOptionalParam(w, y, z)));
 		}
 
 		[Test]
@@ -441,8 +437,8 @@ namespace DynamicExpresso.UnitTest
 				new Parameter("z", z.GetType(), z),
 			};
 
-			Assert.AreEqual(x.MethodWithOptionalNullParam(y), target.Eval("x.MethodWithOptionalNullParam(y)", parameters));
-			Assert.AreEqual(x.MethodWithOptionalNullParam(y, z), target.Eval("x.MethodWithOptionalNullParam(y, z)", parameters));
+			Assert.That(target.Eval("x.MethodWithOptionalNullParam(y)", parameters), Is.EqualTo(x.MethodWithOptionalNullParam(y)));
+			Assert.That(target.Eval("x.MethodWithOptionalNullParam(y, z)", parameters), Is.EqualTo(x.MethodWithOptionalNullParam(y, z)));
 		}
 
 		[Test]
@@ -453,7 +449,7 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter();
 			target.SetVariable("x", x);
 
-			Assert.AreEqual(x.HelloWorld().ToUpper(), target.Eval("x.HelloWorld().ToUpper()"));
+			Assert.That(target.Eval("x.HelloWorld().ToUpper()"), Is.EqualTo(x.HelloWorld().ToUpper()));
 		}
 
 		internal static class Utils
@@ -482,8 +478,8 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter();
 			target.Reference(typeof(Utils));
 
-			Assert.AreEqual(1, target.Eval("Utils.GenericVsNonGeneric(12345)"));
-			Assert.AreEqual(2, target.Eval("Utils.GenericVsNonGeneric('a')"));
+			Assert.That(target.Eval("Utils.GenericVsNonGeneric(12345)"), Is.EqualTo(1));
+			Assert.That(target.Eval("Utils.GenericVsNonGeneric('a')"), Is.EqualTo(2));
 		}
 
 		[Test]
@@ -495,12 +491,12 @@ namespace DynamicExpresso.UnitTest
 			var arr = new int[] { 2 };
 			target.SetVariable("arr", arr);
 
-			Assert.AreEqual(3, target.Eval("Utils.WithParamsArray(arr)"));
-			Assert.AreEqual(4, target.Eval("Utils.WithParamsArray(1)"));
-			Assert.AreEqual(4, target.Eval("Utils.WithParamsArray(1, arr)"));
-			Assert.AreEqual(5, target.Eval("Utils.WithParamsArray(1, 2)"));
-			Assert.AreEqual(4, target.Eval("Utils.WithParamsArray(1, 2, 3)"));
-			Assert.AreEqual(4, target.Eval("Utils.WithParamsArray(1, 2, 3, 4)"));
+			Assert.That(target.Eval("Utils.WithParamsArray(arr)"), Is.EqualTo(3));
+			Assert.That(target.Eval("Utils.WithParamsArray(1)"), Is.EqualTo(4));
+			Assert.That(target.Eval("Utils.WithParamsArray(1, arr)"), Is.EqualTo(4));
+			Assert.That(target.Eval("Utils.WithParamsArray(1, 2)"), Is.EqualTo(5));
+			Assert.That(target.Eval("Utils.WithParamsArray(1, 2, 3)"), Is.EqualTo(4));
+			Assert.That(target.Eval("Utils.WithParamsArray(1, 2, 3, 4)"), Is.EqualTo(4));
 		}
 
 		[Test]
@@ -515,9 +511,9 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("str", str);
 			target.SetVariable("e", e);
 			target.SetVariable("intg", intg);
-			Assert.AreEqual(6, target.Eval("Utils.WithParamsArray2(str, e)"));
-			Assert.AreEqual(7, target.Eval("Utils.WithParamsArray2(str, e, str, str)"));
-			Assert.AreEqual(8, target.Eval("Utils.WithParamsArray2(str, e, intg, intg)"));
+			Assert.That(target.Eval("Utils.WithParamsArray2(str, e)"), Is.EqualTo(6));
+			Assert.That(target.Eval("Utils.WithParamsArray2(str, e, str, str)"), Is.EqualTo(7));
+			Assert.That(target.Eval("Utils.WithParamsArray2(str, e, intg, intg)"), Is.EqualTo(8));
 		}
 
 		private interface MyTestInterface

--- a/test/DynamicExpresso.UnitTest/NullableTest.cs
+++ b/test/DynamicExpresso.UnitTest/NullableTest.cs
@@ -26,26 +26,26 @@ namespace DynamicExpresso.UnitTest
 			// Addition
 			var expected = a + b;
 			var lambda = interpreter.Parse("a + b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			// Subtraction
 			expected = a - b;
 			lambda = interpreter.Parse("a - b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			// Division
 			expected = a / b;
 			lambda = interpreter.Parse("a / b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			// Multiplication
 			expected = a * b;
 			lambda = interpreter.Parse("a * b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 		}
 
 		[Test]
@@ -62,26 +62,26 @@ namespace DynamicExpresso.UnitTest
 			// Addition
 			var expected = a + b;
 			var lambda = interpreter.Parse("a + b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			// Subtraction
 			expected = a - b;
 			lambda = interpreter.Parse("a - b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			// Division
 			expected = a / b;
 			lambda = interpreter.Parse("a / b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			// Multiplication
 			expected = a * b;
 			lambda = interpreter.Parse("a * b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 		}
 
 		[Test]
@@ -98,26 +98,26 @@ namespace DynamicExpresso.UnitTest
 			// Addition
 			var expected = a + b;
 			var lambda = interpreter.Parse("a + b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			// Subtraction
 			expected = a - b;
 			lambda = interpreter.Parse("a - b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			// Division
 			expected = a / b;
 			lambda = interpreter.Parse("a / b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			// Multiplication
 			expected = a * b;
 			lambda = interpreter.Parse("a * b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 		}
 
 		[Test]
@@ -134,26 +134,26 @@ namespace DynamicExpresso.UnitTest
 			// Addition
 			var expected = a + b;
 			var lambda = interpreter.Parse("a + b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			// Subtraction
 			expected = a - b;
 			lambda = interpreter.Parse("a - b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			// Division
 			expected = a / b;
 			lambda = interpreter.Parse("a / b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			// Multiplication
 			expected = a * b;
 			lambda = interpreter.Parse("a * b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 		}
 
 		[Test]
@@ -170,26 +170,26 @@ namespace DynamicExpresso.UnitTest
 			// Addition
 			var expected = a + b;
 			var lambda = interpreter.Parse("a + b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			// Subtraction
 			expected = a - b;
 			lambda = interpreter.Parse("a - b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			// Division
 			expected = a / b;
 			lambda = interpreter.Parse("a / b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			// Multiplication
 			expected = a * b;
 			lambda = interpreter.Parse("a * b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 		}
 
 		[Test]
@@ -206,26 +206,26 @@ namespace DynamicExpresso.UnitTest
 			// Addition
 			var expected = a + b;
 			var lambda = interpreter.Parse("a + b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			// Subtraction
 			expected = a - b;
 			lambda = interpreter.Parse("a - b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			// Division
 			expected = a / b;
 			lambda = interpreter.Parse("a / b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			// Multiplication
 			expected = a * b;
 			lambda = interpreter.Parse("a * b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 		}
 
 		[Test]
@@ -243,43 +243,43 @@ namespace DynamicExpresso.UnitTest
 
 			var expected = a < b;
 			var lambda = interpreter.Parse("a < b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			expected = a > b;
 			lambda = interpreter.Parse("a > b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			expected = a == b;
 			lambda = interpreter.Parse("a == b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			expected = a != b;
 			lambda = interpreter.Parse("a != b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			expected = b == c;
 			lambda = interpreter.Parse("b == b");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			expected = b != c;
 			lambda = interpreter.Parse("b != c");
-			Assert.AreEqual(expected, lambda.Invoke());
-			Assert.AreEqual(expectedReturnType, lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(expected));
+			Assert.That(lambda.ReturnType, Is.EqualTo(expectedReturnType));
 
 			lambda = interpreter.Parse("a - b");
-			Assert.AreEqual(a - b, lambda.Invoke());
-			Assert.AreEqual(typeof(TimeSpan?), lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(a - b));
+			Assert.That(lambda.ReturnType, Is.EqualTo(typeof(TimeSpan?)));
 
 			b = null;
 			interpreter.SetVariable("b", b, typeof(DateTimeOffset?));
 			lambda = interpreter.Parse("a - b");
-			Assert.AreEqual(a - b, lambda.Invoke());
-			Assert.AreEqual(typeof(TimeSpan?), lambda.ReturnType);
+			Assert.That(lambda.Invoke(), Is.EqualTo(a - b));
+			Assert.That(lambda.ReturnType, Is.EqualTo(typeof(TimeSpan?)));
 		}
 	}
 }

--- a/test/DynamicExpresso.UnitTest/OperatorsTest.cs
+++ b/test/DynamicExpresso.UnitTest/OperatorsTest.cs
@@ -15,9 +15,9 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(2 * 4, target.Eval("2 * 4"));
-			Assert.AreEqual(8 / 2, target.Eval("8 / 2"));
-			Assert.AreEqual(7 % 3, target.Eval("7 % 3"));
+			Assert.That(target.Eval("2 * 4"), Is.EqualTo(2 * 4));
+			Assert.That(target.Eval("8 / 2"), Is.EqualTo(8 / 2));
+			Assert.That(target.Eval("7 % 3"), Is.EqualTo(7 % 3));
 		}
 
 		[Test]
@@ -25,9 +25,9 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(45 + 5, target.Eval("45 + 5"));
-			Assert.AreEqual(45 - 5, target.Eval("45 - 5"));
-			Assert.AreEqual(1.0 - 0.5, target.Eval("1.0 - 0.5"));
+			Assert.That(target.Eval("45 + 5"), Is.EqualTo(45 + 5));
+			Assert.That(target.Eval("45 - 5"), Is.EqualTo(45 - 5));
+			Assert.That(target.Eval("1.0 - 0.5"), Is.EqualTo(1.0 - 0.5));
 		}
 
 		[Test]
@@ -35,12 +35,12 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(-45, target.Eval("-45"));
-			Assert.AreEqual(5, target.Eval("+5"));
-			Assert.AreEqual(false, target.Eval("!true"));
+			Assert.That(target.Eval("-45"), Is.EqualTo(-45));
+			Assert.That(target.Eval("+5"), Is.EqualTo(5));
+			Assert.That(target.Eval("!true"), Is.EqualTo(false));
 
-			Assert.AreEqual(~2, target.Eval("~2"));
-			Assert.AreEqual(~2ul, target.Eval("~2ul"));
+			Assert.That(target.Eval("~2"), Is.EqualTo(~2));
+			Assert.That(target.Eval("~2ul"), Is.EqualTo(~2ul));
 		}
 
 		[Test]
@@ -50,16 +50,16 @@ namespace DynamicExpresso.UnitTest
 			var x = 0b_1100_1001_0000_0000_0000_0000_0001_0001;
 			target.SetVariable("x", x);
 
-			Assert.AreEqual(x >> 4, target.Eval("x >> 4"));
-			Assert.AreEqual(x << 4, target.Eval("x << 4"));
+			Assert.That(target.Eval("x >> 4"), Is.EqualTo(x >> 4));
+			Assert.That(target.Eval("x << 4"), Is.EqualTo(x << 4));
 
 			// ensure they can be chained
-			Assert.AreEqual(x >> 1 >> 1 >> 1, target.Eval("x >> 1 >> 1 >> 1"));
-			Assert.AreEqual(x << 1 << 1 << 1, target.Eval("x << 1 << 1 << 1"));
+			Assert.That(target.Eval("x >> 1 >> 1 >> 1"), Is.EqualTo(x >> 1 >> 1 >> 1));
+			Assert.That(target.Eval("x << 1 << 1 << 1"), Is.EqualTo(x << 1 << 1 << 1));
 
 			// ensure priority
-			Assert.IsFalse(target.Eval<bool>("1 << 4 < 16"));
-			Assert.IsTrue(target.Eval<bool>("1 << 4 < 17"));
+			Assert.That(target.Eval<bool>("1 << 4 < 16"), Is.False);
+			Assert.That(target.Eval<bool>("1 << 4 < 17"), Is.True);
 		}
 
 		[Test]
@@ -73,7 +73,7 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("a", a);
 			target.SetVariable("b", b);
 
-			Assert.AreEqual(a & b, target.Eval("a & b"));
+			Assert.That(target.Eval("a & b"), Is.EqualTo(a & b));
 		}
 
 		[Test]
@@ -87,7 +87,7 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("a", a);
 			target.SetVariable("b", b);
 
-			Assert.AreEqual(a | b, target.Eval("a | b"));
+			Assert.That(target.Eval("a | b"), Is.EqualTo(a | b));
 		}
 
 		[Test]
@@ -101,7 +101,7 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("a", a);
 			target.SetVariable("b", b);
 
-			Assert.AreEqual(a ^ b, target.Eval("a ^ b"));
+			Assert.That(target.Eval("a ^ b"), Is.EqualTo(a ^ b));
 		}
 
 		[Test, Ignore("Current operator resolution doesn't lift int to uint")]
@@ -113,13 +113,13 @@ namespace DynamicExpresso.UnitTest
 			var x = 0b_1111_1000u;
 			target.SetVariable("x", x);
 
-			Assert.AreEqual(~x, target.Eval<uint>("~x"));
-			Assert.AreEqual(x >> 4, target.Eval<uint>("x >> 4"));
-			Assert.AreEqual(x << 4, target.Eval<uint>("x << 4"));
+			Assert.That(target.Eval<uint>("~x"), Is.EqualTo(~x));
+			Assert.That(target.Eval<uint>("x >> 4"), Is.EqualTo(x >> 4));
+			Assert.That(target.Eval<uint>("x << 4"), Is.EqualTo(x << 4));
 
-			Assert.AreEqual(x & 4, target.Eval<uint>("x & 4"));
-			Assert.AreEqual(x | 4, target.Eval<uint>("x | 4"));
-			Assert.AreEqual(x ^ 4, target.Eval<uint>("x ^ 4"));
+			Assert.That(target.Eval<uint>("x & 4"), Is.EqualTo(x & 4));
+			Assert.That(target.Eval<uint>("x | 4"), Is.EqualTo(x | 4));
+			Assert.That(target.Eval<uint>("x ^ 4"), Is.EqualTo(x ^ 4));
 		}
 
 		[Test]
@@ -130,10 +130,10 @@ namespace DynamicExpresso.UnitTest
 			var x = 51.5;
 			target.SetVariable("x", x);
 
-			Assert.AreEqual((int)x, target.Eval("(int)x"));
-			Assert.AreEqual(typeof(int), target.Parse("(int)x").ReturnType);
-			Assert.AreEqual(typeof(object), target.Parse("(object)x").ReturnType);
-			Assert.AreEqual((double)84 + 9 * 8, target.Eval("(double)84 + 9 *8"));
+			Assert.That(target.Eval("(int)x"), Is.EqualTo((int)x));
+			Assert.That(target.Parse("(int)x").ReturnType, Is.EqualTo(typeof(int)));
+			Assert.That(target.Parse("(object)x").ReturnType, Is.EqualTo(typeof(object)));
+			Assert.That(target.Eval("(double)84 + 9 *8"), Is.EqualTo((double)84 + 9 * 8));
 		}
 
 		[Test]
@@ -141,8 +141,8 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(8 / 2 + 2, target.Eval("8 / 2 + 2"));
-			Assert.AreEqual(8 + 2 / 2, target.Eval("8 + 2 / 2"));
+			Assert.That(target.Eval("8 / 2 + 2"), Is.EqualTo(8 / 2 + 2));
+			Assert.That(target.Eval("8 + 2 / 2"), Is.EqualTo(8 + 2 / 2));
 		}
 
 		[Test]
@@ -153,9 +153,9 @@ namespace DynamicExpresso.UnitTest
 			Assert.Throws<ParseException>(() => target.Eval("typeof(int??)"));
 			Assert.Throws<ParseException>(() => target.Eval("typeof(string?)"));
 
-			Assert.AreEqual(typeof(string), target.Eval("typeof(string)"));
-			Assert.AreEqual(typeof(int), target.Eval("typeof(int)"));
-			Assert.AreEqual(typeof(int?), target.Eval("typeof(int?)"));
+			Assert.That(target.Eval("typeof(string)"), Is.EqualTo(typeof(string)));
+			Assert.That(target.Eval("typeof(int)"), Is.EqualTo(typeof(int)));
+			Assert.That(target.Eval("typeof(int?)"), Is.EqualTo(typeof(int?)));
 		}
 
 		[Test]
@@ -163,9 +163,9 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(typeof(int[]), target.Eval("typeof(int[])"));
-			Assert.AreEqual(typeof(int?[]), target.Eval("typeof(int?[])"));
-			Assert.AreEqual(typeof(int?[,,][][,]), target.Eval("typeof(int?[,,][][,])"));
+			Assert.That(target.Eval("typeof(int[])"), Is.EqualTo(typeof(int[])));
+			Assert.That(target.Eval("typeof(int?[])"), Is.EqualTo(typeof(int?[])));
+			Assert.That(target.Eval("typeof(int?[,,][][,])"), Is.EqualTo(typeof(int?[,,][][,])));
 		}
 
 		[Test]
@@ -175,13 +175,13 @@ namespace DynamicExpresso.UnitTest
 			target.Reference(typeof(IEnumerable<>), "IEnumerable");
 			target.Reference(typeof(Dictionary<,>), "Dictionary");
 
-			Assert.AreEqual(typeof(IEnumerable<int>), target.Eval("typeof(IEnumerable<int>)"));
-			Assert.AreEqual(typeof(IEnumerable<IEnumerable<int?[]>>), target.Eval("typeof(IEnumerable<IEnumerable<int?[]>>)"));
-			Assert.AreEqual(typeof(IEnumerable<>), target.Eval("typeof(IEnumerable<>)"));
+			Assert.That(target.Eval("typeof(IEnumerable<int>)"), Is.EqualTo(typeof(IEnumerable<int>)));
+			Assert.That(target.Eval("typeof(IEnumerable<IEnumerable<int?[]>>)"), Is.EqualTo(typeof(IEnumerable<IEnumerable<int?[]>>)));
+			Assert.That(target.Eval("typeof(IEnumerable<>)"), Is.EqualTo(typeof(IEnumerable<>)));
 
-			Assert.AreEqual(typeof(Dictionary<int, string>[,]), target.Eval("typeof(Dictionary<int,string>[,])"));
-			Assert.AreEqual(typeof(Dictionary<int, IEnumerable<int[]>>), target.Eval("typeof(Dictionary<int, IEnumerable<int[]>>)"));
-			Assert.AreEqual(typeof(Dictionary<,>), target.Eval("typeof(Dictionary<,>)"));
+			Assert.That(target.Eval("typeof(Dictionary<int,string>[,])"), Is.EqualTo(typeof(Dictionary<int, string>[,])));
+			Assert.That(target.Eval("typeof(Dictionary<int, IEnumerable<int[]>>)"), Is.EqualTo(typeof(Dictionary<int, IEnumerable<int[]>>)));
+			Assert.That(target.Eval("typeof(Dictionary<,>)"), Is.EqualTo(typeof(Dictionary<,>)));
 		}
 
 		[Test]
@@ -191,9 +191,9 @@ namespace DynamicExpresso.UnitTest
 			target.Reference(typeof(Tuple<>));
 			target.Reference(typeof(Tuple<,>));
 			target.Reference(typeof(Tuple<,,>));
-			Assert.AreEqual(typeof(Tuple<>), target.Eval("typeof(Tuple<>)"));
-			Assert.AreEqual(typeof(Tuple<,>), target.Eval("typeof(Tuple<,>)"));
-			Assert.AreEqual(typeof(Tuple<,,>), target.Eval("typeof(Tuple<,,>)"));
+			Assert.That(target.Eval("typeof(Tuple<>)"), Is.EqualTo(typeof(Tuple<>)));
+			Assert.That(target.Eval("typeof(Tuple<,>)"), Is.EqualTo(typeof(Tuple<,>)));
+			Assert.That(target.Eval("typeof(Tuple<,,>)"), Is.EqualTo(typeof(Tuple<,,>)));
 		}
 
 		[Test]
@@ -206,12 +206,12 @@ namespace DynamicExpresso.UnitTest
 				.SetVariable("b", b, typeof(object));
 
 			// ReSharper disable once ConditionIsAlwaysTrueOrFalse
-			Assert.AreEqual(a is string, target.Eval("a is string"));
-			Assert.AreEqual(typeof(bool), target.Parse("a is string").ReturnType);
+			Assert.That(target.Eval("a is string"), Is.EqualTo(a is string));
+			Assert.That(target.Parse("a is string").ReturnType, Is.EqualTo(typeof(bool)));
 			// ReSharper disable once ConditionIsAlwaysTrueOrFalse
-			Assert.AreEqual(b is string, target.Eval("b is string"));
+			Assert.That(target.Eval("b is string"), Is.EqualTo(b is string));
 			// ReSharper disable once ConditionIsAlwaysTrueOrFalse
-			Assert.AreEqual(b is int, target.Eval("b is int"));
+			Assert.That(target.Eval("b is int"), Is.EqualTo(b is int));
 		}
 
 		[Test]
@@ -226,9 +226,9 @@ namespace DynamicExpresso.UnitTest
 			target.Reference(typeof(Tuple<>));
 			target.Reference(typeof(Tuple<,>));
 
-			Assert.AreEqual(true, target.Eval("a is Tuple<int>"));
-			Assert.AreEqual(typeof(bool), target.Parse("a is Tuple<int>").ReturnType);
-			Assert.AreEqual(true, target.Eval("b is Tuple<int,int>"));
+			Assert.That(target.Eval("a is Tuple<int>"), Is.EqualTo(true));
+			Assert.That(target.Parse("a is Tuple<int>").ReturnType, Is.EqualTo(typeof(bool)));
+			Assert.That(target.Eval("b is Tuple<int,int>"), Is.EqualTo(true));
 		}
 
 		[Test]
@@ -241,11 +241,11 @@ namespace DynamicExpresso.UnitTest
 				.SetVariable("b", b, typeof(object));
 
 			// ReSharper disable once TryCastAlwaysSucceeds
-			Assert.AreEqual(a as string, target.Eval("a as string"));
-			Assert.AreEqual(typeof(string), target.Parse("a as string").ReturnType);
+			Assert.That(target.Eval("a as string"), Is.EqualTo(a as string));
+			Assert.That(target.Parse("a as string").ReturnType, Is.EqualTo(typeof(string)));
 			// ReSharper disable once ExpressionIsAlwaysNull
-			Assert.AreEqual(b as string, target.Eval("b as string"));
-			Assert.AreEqual(typeof(string), target.Parse("b as string").ReturnType);
+			Assert.That(target.Eval("b as string"), Is.EqualTo(b as string));
+			Assert.That(target.Parse("b as string").ReturnType, Is.EqualTo(typeof(string)));
 		}
 
 		[Test]
@@ -253,9 +253,9 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(typeof(string) != typeof(int), target.Eval("typeof(string) != typeof(int)"));
+			Assert.That(target.Eval("typeof(string) != typeof(int)"), Is.EqualTo(typeof(string) != typeof(int)));
 			// ReSharper disable once EqualExpressionComparison
-			Assert.AreEqual(typeof(string) == typeof(string), target.Eval("typeof(string) == typeof(string)"));
+			Assert.That(target.Eval("typeof(string) == typeof(string)"), Is.EqualTo(typeof(string) == typeof(string)));
 		}
 
 		[Test]
@@ -263,7 +263,7 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual("ciao " + "mondo", target.Eval("\"ciao \" + \"mondo\""));
+			Assert.That(target.Eval("\"ciao \" + \"mondo\""), Is.EqualTo("ciao " + "mondo"));
 		}
 
 		[Test]
@@ -271,8 +271,8 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual("ciao " + 1981, target.Eval("\"ciao \" + 1981"));
-			Assert.AreEqual(1981 + "ciao ", target.Eval("1981 + \"ciao \""));
+			Assert.That(target.Eval("\"ciao \" + 1981"), Is.EqualTo("ciao " + 1981));
+			Assert.That(target.Eval("1981 + \"ciao \""), Is.EqualTo(1981 + "ciao "));
 		}
 
 		[Test]
@@ -288,9 +288,9 @@ namespace DynamicExpresso.UnitTest
 			Lambda lambda = interpreter.Parse(expressionText);
             
 			MethodCallExpression methodCallExpression = lambda.Expression as MethodCallExpression;
-            
-			Assert.IsNotNull(methodCallExpression);
-			Assert.AreEqual(expectedMethod, methodCallExpression.Method);
+
+			Assert.That(methodCallExpression, Is.Not.Null);
+			Assert.That(methodCallExpression.Method, Is.EqualTo(expectedMethod));
 		}
 
 		[Test]
@@ -299,20 +299,20 @@ namespace DynamicExpresso.UnitTest
 			Interpreter interpreter = new Interpreter();
 			
 			string expressionText = "\"ciao \" + null";
-			Assert.AreEqual("ciao ", interpreter.Eval(expressionText));
+			Assert.That(interpreter.Eval(expressionText), Is.EqualTo("ciao "));
 			
 			Func<String> someFunc = () => null;
 			interpreter.SetFunction("someFunc", someFunc);
 			expressionText = "\"ciao \" + someFunc()";
-			Assert.AreEqual("ciao ", interpreter.Eval(expressionText));
+			Assert.That(interpreter.Eval(expressionText), Is.EqualTo("ciao "));
 			
 			Func<Object> someFuncObject = () => null;
 			interpreter.SetFunction("someFuncObject", someFuncObject);
 			expressionText = "\"ciao \" + someFuncObject()";
-			Assert.AreEqual("ciao ", interpreter.Eval(expressionText));
+			Assert.That(interpreter.Eval(expressionText), Is.EqualTo("ciao "));
 
 			expressionText = "someFunc() + \"123\" + null + \"678\" + someFuncObject()";
-			Assert.AreEqual("123678", interpreter.Eval(expressionText));
+			Assert.That(interpreter.Eval(expressionText), Is.EqualTo("123678"));
 		}
 		
 		private class MyClass
@@ -338,8 +338,8 @@ namespace DynamicExpresso.UnitTest
 				.SetVariable("myClass", new MyClass())
 				.SetVariable("myClassNullToString", new MyClassNullToString());
 		
-			Assert.AreEqual("ciao MyClassStr", interpreter.Eval("\"ciao \" + myClass"));
-			Assert.AreEqual("ciao ", interpreter.Eval("\"ciao \" + myClassNullToString"));
+			Assert.That(interpreter.Eval("\"ciao \" + myClass"), Is.EqualTo("ciao MyClassStr"));
+			Assert.That(interpreter.Eval("\"ciao \" + myClassNullToString"), Is.EqualTo("ciao "));
 		}
 
 		[Test]
@@ -347,11 +347,11 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(8 / (2 + 2), target.Eval("8 / (2 + 2)"));
-			Assert.AreEqual(58 / (2 * (8 + 2)), target.Eval(" 58 / (2 * (8 + 2))"));
+			Assert.That(target.Eval("8 / (2 + 2)"), Is.EqualTo(8 / (2 + 2)));
+			Assert.That(target.Eval(" 58 / (2 * (8 + 2))"), Is.EqualTo(58 / (2 * (8 + 2))));
 
-			Assert.AreEqual(-(8 / (2 + 2)), target.Eval("-(8 / (2 + 2))"));
-			Assert.AreEqual(+(8 / (2 + 2)), target.Eval("+(8 / (2 + 2))"));
+			Assert.That(target.Eval("-(8 / (2 + 2))"), Is.EqualTo(-(8 / (2 + 2))));
+			Assert.That(target.Eval("+(8 / (2 + 2))"), Is.EqualTo(+(8 / (2 + 2))));
 		}
 
 		[Test]
@@ -359,19 +359,19 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.IsFalse((bool)target.Eval("0 > 3"));
-			Assert.IsFalse((bool)target.Eval("0 >= 3"));
-			Assert.IsTrue((bool)target.Eval("3 < 5"));
-			Assert.IsTrue((bool)target.Eval("3 <= 5"));
-			Assert.IsFalse((bool)target.Eval("5 == 3"));
-			Assert.IsTrue((bool)target.Eval("5 == 5"));
-			Assert.IsTrue((bool)target.Eval("5 >= 5"));
-			Assert.IsTrue((bool)target.Eval("5 <= 5"));
-			Assert.IsTrue((bool)target.Eval("5m >= 5m"));
-			Assert.IsTrue((bool)target.Eval("5f <= 5f"));
-			Assert.IsTrue((bool)target.Eval("5 != 3"));
-			Assert.IsTrue((bool)target.Eval("\"dav\" == \"dav\""));
-			Assert.IsFalse((bool)target.Eval("\"dav\" == \"jack\""));
+			Assert.That((bool)target.Eval("0 > 3"), Is.False);
+			Assert.That((bool)target.Eval("0 >= 3"), Is.False);
+			Assert.That((bool)target.Eval("3 < 5"), Is.True);
+			Assert.That((bool)target.Eval("3 <= 5"), Is.True);
+			Assert.That((bool)target.Eval("5 == 3"), Is.False);
+			Assert.That((bool)target.Eval("5 == 5"), Is.True);
+			Assert.That((bool)target.Eval("5 >= 5"), Is.True);
+			Assert.That((bool)target.Eval("5 <= 5"), Is.True);
+			Assert.That((bool)target.Eval("5m >= 5m"), Is.True);
+			Assert.That((bool)target.Eval("5f <= 5f"), Is.True);
+			Assert.That((bool)target.Eval("5 != 3"), Is.True);
+			Assert.That((bool)target.Eval("\"dav\" == \"dav\""), Is.True);
+			Assert.That((bool)target.Eval("\"dav\" == \"jack\""), Is.False);
 		}
 
 		[Test]
@@ -379,10 +379,10 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(3 < 5f, target.Eval("3 < 5f"));
-			Assert.AreEqual(3f < 5, target.Eval("3f < 5"));
-			Assert.AreEqual(43 > 5m, target.Eval("43 > 5m"));
-			Assert.AreEqual(34 == 34m, target.Eval("34 == 34m"));
+			Assert.That(target.Eval("3 < 5f"), Is.EqualTo(3 < 5f));
+			Assert.That(target.Eval("3f < 5"), Is.EqualTo(3f < 5));
+			Assert.That(target.Eval("43 > 5m"), Is.EqualTo(43 > 5m));
+			Assert.That(target.Eval("34 == 34m"), Is.EqualTo(34 == 34m));
 		}
 
 		[Test]
@@ -395,51 +395,51 @@ namespace DynamicExpresso.UnitTest
 
 			// simple assignment
 			target.Eval("x.Property1 = 156");
-			Assert.AreEqual(156, x.Property1);
+			Assert.That(x.Property1, Is.EqualTo(156));
 
 			// assignment without space
 			target.Eval("x.Property1=156");
-			Assert.AreEqual(156, x.Property1);
+			Assert.That(x.Property1, Is.EqualTo(156));
 
 			// assignment with many spaces
 			target.Eval("x.Property1     =    156");
-			Assert.AreEqual(156, x.Property1);
+			Assert.That(x.Property1, Is.EqualTo(156));
 
 			// assignment should return the assigned value
 			var returnValue = target.Eval("x.Property1 = 81");
-			Assert.AreEqual(81, x.Property1);
-			Assert.AreEqual(x.Property1, returnValue);
+			Assert.That(x.Property1, Is.EqualTo(81));
+			Assert.That(returnValue, Is.EqualTo(x.Property1));
 
 			// assignment can be chained
 			target.Eval("x.Property1 = x.Property2 = 2014");
-			Assert.AreEqual(2014, x.Property1);
-			Assert.AreEqual(x.Property1, x.Property2);
+			Assert.That(x.Property1, Is.EqualTo(2014));
+			Assert.That(x.Property2, Is.EqualTo(x.Property1));
 
 			// assignment can be nested with other operators
 			returnValue = target.Eval("x.Property1 = (486 + 4) * 10");
-			Assert.AreEqual(4900, x.Property1);
-			Assert.AreEqual(x.Property1, returnValue);
+			Assert.That(x.Property1, Is.EqualTo(4900));
+			Assert.That(returnValue, Is.EqualTo(x.Property1));
 
 			// right member is not modified
 			x.Property2 = 2;
 			target.Eval("x.Property1 = x.Property2 * 10");
-			Assert.AreEqual(20, x.Property1);
-			Assert.AreEqual(2, x.Property2);
+			Assert.That(x.Property1, Is.EqualTo(20));
+			Assert.That(x.Property2, Is.EqualTo(2));
 		}
 
 		[Test]
 		public void Null_coalescing()
 		{
 			var interpreter = new Interpreter();
-			Assert.AreEqual(null, interpreter.Eval("null ?? null"));
-			Assert.AreEqual("hallo", interpreter.Eval("\"hallo\" ?? null"));
-			Assert.AreEqual("hallo", interpreter.Eval("null ?? \"hallo\""));
+			Assert.That(interpreter.Eval("null ?? null"), Is.EqualTo(null));
+			Assert.That(interpreter.Eval("\"hallo\" ?? null"), Is.EqualTo("hallo"));
+			Assert.That(interpreter.Eval("null ?? \"hallo\""), Is.EqualTo("hallo"));
 
 			interpreter.SetVariable("x", null, typeof(string));
 			interpreter.SetVariable("y", "hello", typeof(string));
-			Assert.AreEqual(null, interpreter.Eval("x ?? null"));
-			Assert.AreEqual("hallo", interpreter.Eval("x ?? \"hallo\""));
-			Assert.AreEqual("hello", interpreter.Eval("y ?? \"hallo\""));
+			Assert.That(interpreter.Eval("x ?? null"), Is.EqualTo(null));
+			Assert.That(interpreter.Eval("x ?? \"hallo\""), Is.EqualTo("hallo"));
+			Assert.That(interpreter.Eval("y ?? \"hallo\""), Is.EqualTo("hello"));
 		}
 
 		[Test]
@@ -448,7 +448,7 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter();
 			interpreter.SetVariable("x", null, typeof(double?));
 
-			Assert.AreEqual(50.5, interpreter.Eval("x * 2 ?? 50.5"));
+			Assert.That(interpreter.Eval("x * 2 ?? 50.5"), Is.EqualTo(50.5));
 		}
 
 		// ReSharper disable once UnusedAutoPropertyAccessor.Local
@@ -461,7 +461,7 @@ namespace DynamicExpresso.UnitTest
 
 			var result = target.Eval<int>("x = 5", new Parameter("x", 0));
 
-			Assert.AreEqual(5, result);
+			Assert.That(result, Is.EqualTo(5));
 		}
 
 		[Test]
@@ -479,7 +479,7 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 				.EnableAssignment(AssignmentOperators.None);
 
-			Assert.AreEqual(AssignmentOperators.None, target.AssignmentOperators);
+			Assert.That(target.AssignmentOperators, Is.EqualTo(AssignmentOperators.None));
 
 			Assert.Throws<AssignmentOperatorDisabledException>(() => target.Parse("x = 5", new Parameter("x", 0)));
 		}
@@ -490,18 +490,18 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter();
 
 			double x1 = 5;
-			Assert.AreEqual(true, target.Eval("x > 3", new Parameter("x", x1)));
+			Assert.That(target.Eval("x > 3", new Parameter("x", x1)), Is.EqualTo(true));
 			double x2 = 1;
-			Assert.AreEqual(false, target.Eval("x > 3", new Parameter("x", x2)));
+			Assert.That(target.Eval("x > 3", new Parameter("x", x2)), Is.EqualTo(false));
 			decimal x3 = 5;
-			Assert.AreEqual(true, target.Eval("x > 3", new Parameter("x", x3)));
+			Assert.That(target.Eval("x > 3", new Parameter("x", x3)), Is.EqualTo(true));
 			decimal x4 = 1;
-			Assert.AreEqual(false, target.Eval("x > 3", new Parameter("x", x4)));
+			Assert.That(target.Eval("x > 3", new Parameter("x", x4)), Is.EqualTo(false));
 			int x5 = 1;
 			double y1 = 10;
-			Assert.AreEqual(true, target.Eval("x < y", new Parameter("x", x5), new Parameter("y", y1)));
+			Assert.That(target.Eval("x < y", new Parameter("x", x5), new Parameter("y", y1)), Is.EqualTo(true));
 			double x6 = 0;
-			Assert.AreEqual(true, target.Eval("x == 0", new Parameter("x", x6)));
+			Assert.That(target.Eval("x == 0", new Parameter("x", x6)), Is.EqualTo(true));
 		}
 
 		[Test]
@@ -512,10 +512,10 @@ namespace DynamicExpresso.UnitTest
 			InterpreterOptions x = InterpreterOptions.CaseInsensitive;
 			InterpreterOptions y = InterpreterOptions.CaseInsensitive;
 
-			Assert.AreEqual(x == y, target.Eval("x == y", new Parameter("x", x), new Parameter("y", y)));
+			Assert.That(target.Eval("x == y", new Parameter("x", x), new Parameter("y", y)), Is.EqualTo(x == y));
 
 			y = InterpreterOptions.CommonTypes;
-			Assert.AreEqual(x != y, target.Eval("x != y", new Parameter("x", x), new Parameter("y", y)));
+			Assert.That(target.Eval("x != y", new Parameter("x", x), new Parameter("y", y)), Is.EqualTo(x != y));
 		}
 
 		[Test]
@@ -523,67 +523,67 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.IsTrue((bool)target.Eval("0 > 3 || true"));
-			Assert.IsFalse((bool)target.Eval("0 > 3 && 4 < 6"));
+			Assert.That((bool)target.Eval("0 > 3 || true"), Is.True);
+			Assert.That((bool)target.Eval("0 > 3 && 4 < 6"), Is.False);
 		}
 
 		[Test]
 		public void Logical_ExclusiveOr()
 		{
 			var target = new Interpreter();
-			Assert.IsTrue((bool)target.Eval("true ^ false"));
-			Assert.IsTrue((bool)target.Eval("false ^ true"));
-			Assert.IsFalse((bool)target.Eval("true ^ true"));
-			Assert.IsFalse((bool)target.Eval("false ^ false"));
+			Assert.That((bool)target.Eval("true ^ false"), Is.True);
+			Assert.That((bool)target.Eval("false ^ true"), Is.True);
+			Assert.That((bool)target.Eval("true ^ true"), Is.False);
+			Assert.That((bool)target.Eval("false ^ false"), Is.False);
 
-			Assert.AreEqual(2, target.Eval("1 ^ 3"));
-			Assert.AreEqual(3, target.Eval("1 ^ 2"));
+			Assert.That(target.Eval("1 ^ 3"), Is.EqualTo(2));
+			Assert.That(target.Eval("1 ^ 2"), Is.EqualTo(3));
 		}
 
 		[Test]
 		public void Conditional_And()
 		{
 			var target = new Interpreter();
-			Assert.IsFalse((bool)target.Eval("true && false"));
-			Assert.IsFalse((bool)target.Eval("false && true"));
-			Assert.IsTrue((bool)target.Eval("true && true"));
-			Assert.IsFalse((bool)target.Eval("false && false"));
+			Assert.That((bool)target.Eval("true && false"), Is.False);
+			Assert.That((bool)target.Eval("false && true"), Is.False);
+			Assert.That((bool)target.Eval("true && true"), Is.True);
+			Assert.That((bool)target.Eval("false && false"), Is.False);
 		}
 
 		[Test]
 		public void Logical_And()
 		{
 			var target = new Interpreter();
-			Assert.IsFalse((bool)target.Eval("true & false"));
-			Assert.IsFalse((bool)target.Eval("false & true"));
-			Assert.IsTrue((bool)target.Eval("true & true"));
-			Assert.IsFalse((bool)target.Eval("false & false"));
+			Assert.That((bool)target.Eval("true & false"), Is.False);
+			Assert.That((bool)target.Eval("false & true"), Is.False);
+			Assert.That((bool)target.Eval("true & true"), Is.True);
+			Assert.That((bool)target.Eval("false & false"), Is.False);
 
-			Assert.AreEqual(1, target.Eval("1 & 3"));
-			Assert.AreEqual(0, target.Eval("1 & 2"));
+			Assert.That(target.Eval("1 & 3"), Is.EqualTo(1));
+			Assert.That(target.Eval("1 & 2"), Is.EqualTo(0));
 		}
 
 		[Test]
 		public void Conditional_Or()
 		{
 			var target = new Interpreter();
-			Assert.IsTrue((bool)target.Eval("true || false"));
-			Assert.IsTrue((bool)target.Eval("false || true"));
-			Assert.IsTrue((bool)target.Eval("true || true"));
-			Assert.IsFalse((bool)target.Eval("false || false"));
+			Assert.That((bool)target.Eval("true || false"), Is.True);
+			Assert.That((bool)target.Eval("false || true"), Is.True);
+			Assert.That((bool)target.Eval("true || true"), Is.True);
+			Assert.That((bool)target.Eval("false || false"), Is.False);
 		}
 
 		[Test]
 		public void Logical_Or()
 		{
 			var target = new Interpreter();
-			Assert.IsTrue((bool)target.Eval("true | false"));
-			Assert.IsTrue((bool)target.Eval("false | true"));
-			Assert.IsTrue((bool)target.Eval("true | true"));
-			Assert.IsFalse((bool)target.Eval("false | false"));
+			Assert.That((bool)target.Eval("true | false"), Is.True);
+			Assert.That((bool)target.Eval("false | true"), Is.True);
+			Assert.That((bool)target.Eval("true | true"), Is.True);
+			Assert.That((bool)target.Eval("false | false"), Is.False);
 
-			Assert.AreEqual(3, target.Eval("1 | 3"));
-			Assert.AreEqual(3, target.Eval("1 | 2"));
+			Assert.That(target.Eval("1 | 3"), Is.EqualTo(3));
+			Assert.That(target.Eval("1 | 2"), Is.EqualTo(3));
 		}
 
 		[Test]
@@ -594,10 +594,10 @@ namespace DynamicExpresso.UnitTest
 			// From: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/
 
 			var target = new Interpreter();
-			Assert.AreEqual(false ^ false | true & true, target.Eval("false ^ false | true & true"));
-			Assert.AreEqual(false & false ^ false | true, target.Eval("false & false ^ false | true"));
-			Assert.AreEqual(true ^ true & false, target.Eval("true ^ true & false"));
-			Assert.AreEqual(true ^ true && false, target.Eval("true ^ true && false"));
+			Assert.That(target.Eval("false ^ false | true & true"), Is.EqualTo(false ^ false | true & true));
+			Assert.That(target.Eval("false & false ^ false | true"), Is.EqualTo(false & false ^ false | true));
+			Assert.That(target.Eval("true ^ true & false"), Is.EqualTo(true ^ true & false));
+			Assert.That(target.Eval("true ^ true && false"), Is.EqualTo(true ^ true && false));
 		}
 
 		[Test]
@@ -606,9 +606,9 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter();
 
 			// ReSharper disable once UnreachableCode
-			Assert.AreEqual(10 > 3 ? "yes" : "no", target.Eval("10 > 3 ? \"yes\" : \"no\""));
+			Assert.That(target.Eval("10 > 3 ? \"yes\" : \"no\""), Is.EqualTo(10 > 3 ? "yes" : "no"));
 			// ReSharper disable once UnreachableCode
-			Assert.AreEqual(10 < 3 ? "yes" : "no", target.Eval("10 < 3 ? \"yes\" : \"no\""));
+			Assert.That(target.Eval("10 < 3 ? \"yes\" : \"no\""), Is.EqualTo(10 < 3 ? "yes" : "no"));
 		}
 
 		[Test]
@@ -628,7 +628,7 @@ namespace DynamicExpresso.UnitTest
 			var func = target.ParseAsDelegate<Func<int>>("x");
 			var val = func();
 
-			Assert.AreEqual(10, val);
+			Assert.That(val, Is.EqualTo(10));
 		}
 
 		private struct TypeWithImplicitConversion
@@ -655,22 +655,22 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("x", x);
 
 			var y = "5";
-			Assert.IsFalse(x == y);
-			Assert.IsFalse(target.Eval<bool>("x == y", new Parameter("y", y)));
+			Assert.That(x == y, Is.False);
+			Assert.That(target.Eval<bool>("x == y", new Parameter("y", y)), Is.False);
 
 			y = "3";
-			Assert.IsTrue(x == y);
-			Assert.IsTrue(target.Eval<bool>("x == y", new Parameter("y", y)));
+			Assert.That(x == y, Is.True);
+			Assert.That(target.Eval<bool>("x == y", new Parameter("y", y)), Is.True);
 
-			Assert.IsFalse(target.Eval<bool>("x == \"4\""));
-			Assert.IsTrue(target.Eval<bool>("x == \"3\""));
+			Assert.That(target.Eval<bool>("x == \"4\""), Is.False);
+			Assert.That(target.Eval<bool>("x == \"3\""), Is.True);
 
-			Assert.IsTrue(!x == "-3");
-			Assert.IsTrue(target.Eval<bool>("!x == \"-3\""));
+			Assert.That(!x == "-3", Is.True);
+			Assert.That(target.Eval<bool>("!x == \"-3\""), Is.True);
 
 			var z = new StructWithOverloadedBinaryOperators(10);
-			Assert.IsTrue((x + z) == "13");
-			Assert.IsTrue(target.Eval<bool>("(x + z) == \"13\"", new Parameter("z", z)));
+			Assert.That((x + z) == "13", Is.True);
+			Assert.That(target.Eval<bool>("(x + z) == \"13\"", new Parameter("z", z)), Is.True);
 		}
 
 		private struct StructWithOverloadedBinaryOperators
@@ -728,22 +728,22 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("x", x);
 
 			string y = "5";
-			Assert.IsFalse(x == y);
-			Assert.IsFalse(target.Eval<bool>("x == y", new Parameter("y", y)));
+			Assert.That(x == y, Is.False);
+			Assert.That(target.Eval<bool>("x == y", new Parameter("y", y)), Is.False);
 
 			y = "3";
-			Assert.IsTrue(x == y);
-			Assert.IsTrue(target.Eval<bool>("x == y", new Parameter("y", y)));
+			Assert.That(x == y, Is.True);
+			Assert.That(target.Eval<bool>("x == y", new Parameter("y", y)), Is.True);
 
-			Assert.IsFalse(target.Eval<bool>("x == \"4\""));
-			Assert.IsTrue(target.Eval<bool>("x == \"3\""));
+			Assert.That(target.Eval<bool>("x == \"4\""), Is.False);
+			Assert.That(target.Eval<bool>("x == \"3\""), Is.True);
 
-			Assert.IsTrue(!x == "-3");
-			Assert.IsTrue(target.Eval<bool>("!x == \"-3\""));
+			Assert.That(!x == "-3", Is.True);
+			Assert.That(target.Eval<bool>("!x == \"-3\""), Is.True);
 
 			var z = new ClassWithOverloadedBinaryOperators(10);
-			Assert.IsTrue((x + z) == "13");
-			Assert.IsTrue(target.Eval<bool>("(x + z) == \"13\"", new Parameter("z", z)));
+			Assert.That((x + z) == "13", Is.True);
+			Assert.That(target.Eval<bool>("(x + z) == \"13\"", new Parameter("z", z)), Is.True);
 		}
 
 		private class ClassWithOverloadedBinaryOperators
@@ -819,29 +819,29 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("x", x);
 
 			string y = "5";
-			Assert.IsFalse(x == y);
-			Assert.IsFalse(target.Eval<bool>("x == y", new Parameter("y", y)));
+			Assert.That(x == y, Is.False);
+			Assert.That(target.Eval<bool>("x == y", new Parameter("y", y)), Is.False);
 
 			y = "3";
-			Assert.IsTrue(x == y);
-			Assert.IsTrue(target.Eval<bool>("x == y", new Parameter("y", y)));
+			Assert.That(x == y, Is.True);
+			Assert.That(target.Eval<bool>("x == y", new Parameter("y", y)), Is.True);
 
-			Assert.IsFalse(target.Eval<bool>("x == \"4\""));
-			Assert.IsTrue(target.Eval<bool>("x == \"3\""));
+			Assert.That(target.Eval<bool>("x == \"4\""), Is.False);
+			Assert.That(target.Eval<bool>("x == \"3\""), Is.True);
 
-			Assert.IsTrue(!x == "-3");
-			Assert.IsTrue(target.Eval<bool>("!x == \"-3\""));
+			Assert.That(!x == "-3", Is.True);
+			Assert.That(target.Eval<bool>("!x == \"-3\""), Is.True);
 
 			var z = new DerivedClassWithOverloadedBinaryOperators(10);
-			Assert.IsTrue((x + z) == "13");
-			Assert.IsTrue(target.Eval<bool>("(x + z) == \"13\"", new Parameter("z", z)));
+			Assert.That((x + z) == "13", Is.True);
+			Assert.That(target.Eval<bool>("(x + z) == \"13\"", new Parameter("z", z)), Is.True);
 
-			Assert.IsTrue((x * 4) == "12");
-			Assert.IsTrue(target.Eval<bool>("(x * 4) == \"12\""));
+			Assert.That((x * 4) == "12", Is.True);
+			Assert.That(target.Eval<bool>("(x * 4) == \"12\""), Is.True);
 
 			// ensure a user defined operator can be found if it's on the right side operand's type
-			Assert.IsTrue((4 * x) == "12");
-			Assert.IsTrue(target.Eval<bool>("(4 * x) == \"12\""));
+			Assert.That((4 * x) == "12", Is.True);
+			Assert.That(target.Eval<bool>("(4 * x) == \"12\""), Is.True);
 		}
 
 		[Test]
@@ -854,8 +854,8 @@ namespace DynamicExpresso.UnitTest
 
 			// ensure we don't trigger an ambiguous operator exception
 			var z = new DerivedClassWithOverloadedBinaryOperators(10);
-			Assert.IsTrue((x + z) == "13");
-			Assert.IsTrue(target.Eval<bool>("(x + z) == \"13\"", new Parameter("z", z)));
+			Assert.That((x + z) == "13", Is.True);
+			Assert.That(target.Eval<bool>("(x + z) == \"13\"", new Parameter("z", z)), Is.True);
 		}
 
 
@@ -870,7 +870,7 @@ namespace DynamicExpresso.UnitTest
 			var y = "5";
 
 			var ex = Assert.Throws<ParseException>(() => target.Parse("x == y", new Parameter("y", y)));
-			Assert.IsInstanceOf<InvalidOperationException>(ex.InnerException);
+			Assert.That(ex.InnerException, Is.InstanceOf<InvalidOperationException>());
 		}
 
 		[Test]
@@ -884,7 +884,7 @@ namespace DynamicExpresso.UnitTest
 			var y = 5;
 
 			var ex = Assert.Throws<ParseException>(() => target.Parse("x + y", new Parameter("y", y)));
-			Assert.IsInstanceOf<InvalidOperationException>(ex.InnerException);
+			Assert.That(ex.InnerException, Is.InstanceOf<InvalidOperationException>());
 		}
 
 		[Test]
@@ -896,7 +896,7 @@ namespace DynamicExpresso.UnitTest
 			target.SetVariable("x", x);
 
 			var ex = Assert.Throws<ParseException>(() => target.Parse("!x"));
-			Assert.IsInstanceOf<InvalidOperationException>(ex.InnerException);
+			Assert.That(ex.InnerException, Is.InstanceOf<InvalidOperationException>());
 		}
 
 		private struct TypeWithoutOverloadedBinaryOperators

--- a/test/DynamicExpresso.UnitTest/OperatorsTest.cs
+++ b/test/DynamicExpresso.UnitTest/OperatorsTest.cs
@@ -431,13 +431,13 @@ namespace DynamicExpresso.UnitTest
 		public void Null_coalescing()
 		{
 			var interpreter = new Interpreter();
-			Assert.That(interpreter.Eval("null ?? null"), Is.EqualTo(null));
+			Assert.That(interpreter.Eval("null ?? null"), Is.Null);
 			Assert.That(interpreter.Eval("\"hallo\" ?? null"), Is.EqualTo("hallo"));
 			Assert.That(interpreter.Eval("null ?? \"hallo\""), Is.EqualTo("hallo"));
 
 			interpreter.SetVariable("x", null, typeof(string));
 			interpreter.SetVariable("y", "hello", typeof(string));
-			Assert.That(interpreter.Eval("x ?? null"), Is.EqualTo(null));
+			Assert.That(interpreter.Eval("x ?? null"), Is.Null);
 			Assert.That(interpreter.Eval("x ?? \"hallo\""), Is.EqualTo("hallo"));
 			Assert.That(interpreter.Eval("y ?? \"hallo\""), Is.EqualTo("hello"));
 		}

--- a/test/DynamicExpresso.UnitTest/OtherTests.cs
+++ b/test/DynamicExpresso.UnitTest/OtherTests.cs
@@ -14,7 +14,7 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(46, target.Eval("     45\t\t  + 1 \r  \n"));
+			Assert.That(target.Eval("     45\t\t  + 1 \r  \n"), Is.EqualTo(46));
 		}
 
 		[Test]
@@ -22,14 +22,14 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(null, target.Eval(""));
-			Assert.AreEqual(typeof(void), target.Parse("").ReturnType);
+			Assert.That(target.Eval(""), Is.EqualTo(null));
+			Assert.That(target.Parse("").ReturnType, Is.EqualTo(typeof(void)));
 
-			Assert.AreEqual(null, target.Eval(null));
-			Assert.AreEqual(typeof(void), target.Parse(null).ReturnType);
+			Assert.That(target.Eval(null), Is.EqualTo(null));
+			Assert.That(target.Parse(null).ReturnType, Is.EqualTo(typeof(void)));
 
-			Assert.AreEqual(null, target.Eval("  \t\t\r\n  \t   "));
-			Assert.AreEqual(typeof(void), target.Parse("  \t\t\r\n  \t   ").ReturnType);
+			Assert.That(target.Eval("  \t\t\r\n  \t   "), Is.EqualTo(null));
+			Assert.That(target.Parse("  \t\t\r\n  \t   ").ReturnType, Is.EqualTo(typeof(void)));
 		}
 
 		[Test]
@@ -44,10 +44,10 @@ namespace DynamicExpresso.UnitTest
                             new Parameter("y", y.GetType(), y),
                             };
 
-			Assert.AreEqual(x.AProperty > y && x.HelloWorld().Length == 10, target.Eval("x.AProperty      >\t y && \r\n x.HelloWorld().Length == 10", parameters));
-			Assert.AreEqual(x.AProperty * (4 + 65) / x.AProperty, target.Eval("x.AProperty * (4 + 65) / x.AProperty", parameters));
+			Assert.That(target.Eval("x.AProperty      >\t y && \r\n x.HelloWorld().Length == 10", parameters), Is.EqualTo(x.AProperty > y && x.HelloWorld().Length == 10));
+			Assert.That(target.Eval("x.AProperty * (4 + 65) / x.AProperty", parameters), Is.EqualTo(x.AProperty * (4 + 65) / x.AProperty));
 
-			Assert.AreEqual(Convert.ToString(x.AProperty * (4 + 65) / x.AProperty), target.Eval("Convert.ToString(x.AProperty * (4 + 65) / x.AProperty)", parameters));
+			Assert.That(target.Eval("Convert.ToString(x.AProperty * (4 + 65) / x.AProperty)", parameters), Is.EqualTo(Convert.ToString(x.AProperty * (4 + 65) / x.AProperty)));
 		}
 
 		[Test]
@@ -61,18 +61,18 @@ namespace DynamicExpresso.UnitTest
 			var func = target.Parse("x > 4 ? service.VoidMethod() : service.VoidMethod2()",
 															new Parameter("x", typeof(int)));
 
-			Assert.AreEqual(typeof(void), func.ReturnType);
+			Assert.That(func.ReturnType, Is.EqualTo(typeof(void)));
 
-			Assert.AreEqual(0, service.VoidMethodCalled);
-			Assert.AreEqual(0, service.VoidMethod2Called);
+			Assert.That(service.VoidMethodCalled, Is.EqualTo(0));
+			Assert.That(service.VoidMethod2Called, Is.EqualTo(0));
 
 			func.Invoke(new Parameter("x", 5));
-			Assert.AreEqual(1, service.VoidMethodCalled);
-			Assert.AreEqual(0, service.VoidMethod2Called);
+			Assert.That(service.VoidMethodCalled, Is.EqualTo(1));
+			Assert.That(service.VoidMethod2Called, Is.EqualTo(0));
 
 			func.Invoke(new Parameter("x", 2));
-			Assert.AreEqual(1, service.VoidMethodCalled);
-			Assert.AreEqual(1, service.VoidMethod2Called);
+			Assert.That(service.VoidMethodCalled, Is.EqualTo(1));
+			Assert.That(service.VoidMethod2Called, Is.EqualTo(1));
 		}
 
 		[Test]
@@ -87,8 +87,8 @@ namespace DynamicExpresso.UnitTest
                             new Parameter("y", y.GetType(), y),
                             };
 
-			Assert.AreEqual(typeof(bool), target.Parse("x.AProperty > y && x.HelloWorld().Length == 10", parameters).ReturnType);
-			Assert.AreEqual(typeof(int), target.Parse("x.AProperty * (4 + 65) / x.AProperty", parameters).ReturnType);
+			Assert.That(target.Parse("x.AProperty > y && x.HelloWorld().Length == 10", parameters).ReturnType, Is.EqualTo(typeof(bool)));
+			Assert.That(target.Parse("x.AProperty * (4 + 65) / x.AProperty", parameters).ReturnType, Is.EqualTo(typeof(int)));
 		}
 
 		[Test]
@@ -100,15 +100,15 @@ namespace DynamicExpresso.UnitTest
 													new Parameter("x", typeof(double)),
 													new Parameter("y", typeof(double)));
 
-			Assert.AreEqual(Math.Pow(15, 12) + 5, functionX.Invoke(15, 12));
-			Assert.AreEqual(Math.Pow(5, 1) + 5, functionX.Invoke(5, 1));
-			Assert.AreEqual(Math.Pow(11, 8) + 5, functionX.Invoke(11, 8));
-			Assert.AreEqual(Math.Pow(3, 4) + 5, functionX.Invoke(new Parameter("x", 3.0),
-																													new Parameter("y", 4.0)));
-			Assert.AreEqual(Math.Pow(9, 2) + 5, functionX.Invoke(new Parameter("x", 9.0),
-																													new Parameter("y", 2.0)));
-			Assert.AreEqual(Math.Pow(1, 3) + 5, functionX.Invoke(new Parameter("x", 1.0),
-																													new Parameter("y", 3.0)));
+			Assert.That(functionX.Invoke(15, 12), Is.EqualTo(Math.Pow(15, 12) + 5));
+			Assert.That(functionX.Invoke(5, 1), Is.EqualTo(Math.Pow(5, 1) + 5));
+			Assert.That(functionX.Invoke(11, 8), Is.EqualTo(Math.Pow(11, 8) + 5));
+			Assert.That(functionX.Invoke(new Parameter("x", 3.0),
+																													new Parameter("y", 4.0)), Is.EqualTo(Math.Pow(3, 4) + 5));
+			Assert.That(functionX.Invoke(new Parameter("x", 9.0),
+																													new Parameter("y", 2.0)), Is.EqualTo(Math.Pow(9, 2) + 5));
+			Assert.That(functionX.Invoke(new Parameter("x", 1.0),
+																													new Parameter("y", 3.0)), Is.EqualTo(Math.Pow(1, 3) + 5));
 		}
 
 		[Test]
@@ -127,7 +127,7 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter();
 			Func<Customer, bool> dynamicWhere = interpreter.ParseAsDelegate<Func<Customer, bool>>(whereExpression, "customer");
 
-			Assert.AreEqual(1, customers.Where(dynamicWhere).Count());
+			Assert.That(customers.Where(dynamicWhere).Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -138,7 +138,7 @@ namespace DynamicExpresso.UnitTest
 			var whereFunction = new Interpreter()
 				.ParseAsDelegate<Func<int, bool>>("arg > 5");
 
-			Assert.AreEqual(2, prices.Where(whereFunction).Count());
+			Assert.That(prices.Where(whereFunction).Count(), Is.EqualTo(2));
 		}
 
 		[Test]
@@ -157,7 +157,7 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter();
 			Expression<Func<Customer, bool>> expression = interpreter.ParseAsExpression<Func<Customer, bool>>(whereExpression, "customer");
 
-			Assert.AreEqual(1, customers.Where(expression).Count());
+			Assert.That(customers.Where(expression).Count(), Is.EqualTo(1));
 		}
 
 		[Test]
@@ -165,8 +165,8 @@ namespace DynamicExpresso.UnitTest
 		{
 			var interpreter = new Interpreter();
 
-			Assert.AreEqual(2 + ((1 + 5) * (2 - 1)), interpreter.Eval("2 + ((1 + 5) * (2 - 1))"));
-			Assert.AreEqual(2 + ((((1 + 5))) * (((2 - 1)) + 5.5)), interpreter.Eval("2 + ((((1 + 5))) * (((2 - 1))+5.5))"));
+			Assert.That(interpreter.Eval("2 + ((1 + 5) * (2 - 1))"), Is.EqualTo(2 + ((1 + 5) * (2 - 1))));
+			Assert.That(interpreter.Eval("2 + ((((1 + 5))) * (((2 - 1))+5.5))"), Is.EqualTo(2 + ((((1 + 5))) * (((2 - 1)) + 5.5))));
 		}
 
 		[Test]
@@ -174,7 +174,7 @@ namespace DynamicExpresso.UnitTest
 		{
 			var interpreter = new Interpreter();
 
-			Assert.AreEqual(((double)5).GetType().Name, interpreter.Eval("((double)5).GetType().Name"));
+			Assert.That(interpreter.Eval("((double)5).GetType().Name"), Is.EqualTo(((double)5).GetType().Name));
 		}
 
 		private class MyTestService

--- a/test/DynamicExpresso.UnitTest/OtherTests.cs
+++ b/test/DynamicExpresso.UnitTest/OtherTests.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using NUnit.Framework;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Collections.Generic;
+using NUnit.Framework;
 
 namespace DynamicExpresso.UnitTest
 {
@@ -22,13 +22,13 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.That(target.Eval(""), Is.EqualTo(null));
+			Assert.That(target.Eval(""), Is.Null);
 			Assert.That(target.Parse("").ReturnType, Is.EqualTo(typeof(void)));
 
-			Assert.That(target.Eval(null), Is.EqualTo(null));
+			Assert.That(target.Eval(null), Is.Null);
 			Assert.That(target.Parse(null).ReturnType, Is.EqualTo(typeof(void)));
 
-			Assert.That(target.Eval("  \t\t\r\n  \t   "), Is.EqualTo(null));
+			Assert.That(target.Eval("  \t\t\r\n  \t   "), Is.Null);
 			Assert.That(target.Parse("  \t\t\r\n  \t   ").ReturnType, Is.EqualTo(typeof(void)));
 		}
 
@@ -40,9 +40,9 @@ namespace DynamicExpresso.UnitTest
 			var x = new MyTestService();
 			var y = 5;
 			var parameters = new[] {
-                            new Parameter("x", x.GetType(), x),
-                            new Parameter("y", y.GetType(), y),
-                            };
+							new Parameter("x", x.GetType(), x),
+							new Parameter("y", y.GetType(), y),
+							};
 
 			Assert.That(target.Eval("x.AProperty      >\t y && \r\n x.HelloWorld().Length == 10", parameters), Is.EqualTo(x.AProperty > y && x.HelloWorld().Length == 10));
 			Assert.That(target.Eval("x.AProperty * (4 + 65) / x.AProperty", parameters), Is.EqualTo(x.AProperty * (4 + 65) / x.AProperty));
@@ -83,9 +83,9 @@ namespace DynamicExpresso.UnitTest
 			var x = new MyTestService();
 			var y = 5;
 			var parameters = new[] {
-                            new Parameter("x", x.GetType(), x),
-                            new Parameter("y", y.GetType(), y),
-                            };
+							new Parameter("x", x.GetType(), x),
+							new Parameter("y", y.GetType(), y),
+							};
 
 			Assert.That(target.Parse("x.AProperty > y && x.HelloWorld().Length == 10", parameters).ReturnType, Is.EqualTo(typeof(bool)));
 			Assert.That(target.Parse("x.AProperty * (4 + 65) / x.AProperty", parameters).ReturnType, Is.EqualTo(typeof(int)));
@@ -114,13 +114,13 @@ namespace DynamicExpresso.UnitTest
 		[Test]
 		public void Linq_Where()
 		{
-			var customers = new List<Customer> { 
-                                    new Customer() { Name = "David", Age = 31, Gender = 'M' },
-                                    new Customer() { Name = "Mary", Age = 29, Gender = 'F' },
-                                    new Customer() { Name = "Jack", Age = 2, Gender = 'M' },
-                                    new Customer() { Name = "Marta", Age = 1, Gender = 'F' },
-                                    new Customer() { Name = "Moses", Age = 120, Gender = 'M' },
-                                    };
+			var customers = new List<Customer> {
+									new Customer() { Name = "David", Age = 31, Gender = 'M' },
+									new Customer() { Name = "Mary", Age = 29, Gender = 'F' },
+									new Customer() { Name = "Jack", Age = 2, Gender = 'M' },
+									new Customer() { Name = "Marta", Age = 1, Gender = 'F' },
+									new Customer() { Name = "Moses", Age = 120, Gender = 'M' },
+									};
 
 			string whereExpression = "customer.Age > 18 && customer.Gender == 'F'";
 
@@ -133,7 +133,7 @@ namespace DynamicExpresso.UnitTest
 		[Test]
 		public void Linq_Where2()
 		{
-			var prices = new [] { 5, 8, 6, 2 };
+			var prices = new[] { 5, 8, 6, 2 };
 
 			var whereFunction = new Interpreter()
 				.ParseAsDelegate<Func<int, bool>>("arg > 5");
@@ -144,7 +144,7 @@ namespace DynamicExpresso.UnitTest
 		[Test]
 		public void Linq_Queryable_Expression_Where()
 		{
-			IQueryable<Customer> customers = (new List<Customer> { 
+			IQueryable<Customer> customers = (new List<Customer> {
 				new Customer() { Name = "David", Age = 31, Gender = 'M' },
 				new Customer() { Name = "Mary", Age = 29, Gender = 'F' },
 				new Customer() { Name = "Jack", Age = 2, Gender = 'M' },

--- a/test/DynamicExpresso.UnitTest/ParametersTest.cs
+++ b/test/DynamicExpresso.UnitTest/ParametersTest.cs
@@ -19,7 +19,7 @@ namespace DynamicExpresso.UnitTest
                             new Parameter("y", 7)
                             };
 
-			Assert.AreEqual(30, target.Eval("x + y", parameters));
+			Assert.That(target.Eval("x + y", parameters), Is.EqualTo(30));
 		}
 
 		[Test]
@@ -32,7 +32,7 @@ namespace DynamicExpresso.UnitTest
                             new Parameter("A", "A"),
                             };
 
-			Assert.AreEqual("AB", target.Eval("A + B", parameters));
+			Assert.That(target.Eval("A + B", parameters), Is.EqualTo("AB"));
 		}
 
 		[Test]
@@ -47,7 +47,7 @@ namespace DynamicExpresso.UnitTest
 
 			var lambda = target.Parse("A + B", parameters);
 
-			Assert.AreEqual("AB", lambda.Invoke(parameters.Reverse()));
+			Assert.That(lambda.Invoke(parameters.Reverse()), Is.EqualTo("AB"));
 		}
 
 		[Test]
@@ -59,7 +59,7 @@ namespace DynamicExpresso.UnitTest
 
 			var exp = target.Parse("10+5", parameters);
 
-			Assert.AreEqual(15, exp.Invoke());
+			Assert.That(exp.Invoke(), Is.EqualTo(15));
 		}
 
 		[Test]
@@ -98,14 +98,14 @@ namespace DynamicExpresso.UnitTest
                             new Parameter("y", 5)
                             };
 
-			Assert.AreEqual(30, myFunc.Invoke(parameters1));
+			Assert.That(myFunc.Invoke(parameters1), Is.EqualTo(30));
 
 			var parameters2 = new[] {
                             new Parameter("x", 60),
                             new Parameter("y", -2)
                             };
 
-			Assert.AreEqual(58, myFunc.Invoke(parameters2));
+			Assert.That(myFunc.Invoke(parameters2), Is.EqualTo(58));
 		}
 
 		[Test]
@@ -120,8 +120,8 @@ namespace DynamicExpresso.UnitTest
 
 			var myFunc = target.Parse("x + y", parameters);
 
-			Assert.AreEqual(30, myFunc.Invoke(23, 7));
-			Assert.AreEqual(30, myFunc.Invoke(32, -2));
+			Assert.That(myFunc.Invoke(23, 7), Is.EqualTo(30));
+			Assert.That(myFunc.Invoke(32, -2), Is.EqualTo(30));
 		}
 
 		[Test]
@@ -136,11 +136,11 @@ namespace DynamicExpresso.UnitTest
                             new Parameter("y", y.GetType(), y)
                             };
 
-			Assert.AreEqual(x, target.Eval("x", parameters));
-			Assert.AreEqual(x + x + x, target.Eval("x+x+x", parameters));
-			Assert.AreEqual(x * x, target.Eval("x * x", parameters));
-			Assert.AreEqual(y, target.Eval("y", parameters));
-			Assert.AreEqual(y.Length + x, target.Eval("y.Length + x", parameters));
+			Assert.That(target.Eval("x", parameters), Is.EqualTo(x));
+			Assert.That(target.Eval("x+x+x", parameters), Is.EqualTo(x + x + x));
+			Assert.That(target.Eval("x * x", parameters), Is.EqualTo(x * x));
+			Assert.That(target.Eval("y", parameters), Is.EqualTo(y));
+			Assert.That(target.Eval("y.Length + x", parameters), Is.EqualTo(y.Length + x));
 		}
 
 		[Test]
@@ -155,8 +155,8 @@ namespace DynamicExpresso.UnitTest
                             new Parameter("X", X.GetType(), X)
                             };
 
-			Assert.AreEqual(x, target.Eval("x", parameters));
-			Assert.AreEqual(X, target.Eval("X", parameters));
+			Assert.That(target.Eval("x", parameters), Is.EqualTo(x));
+			Assert.That(target.Eval("X", parameters), Is.EqualTo(X));
 		}
 
 		[Test]
@@ -169,8 +169,8 @@ namespace DynamicExpresso.UnitTest
                             new Parameter("x", x.GetType(), x)
                             };
 
-			Assert.AreEqual(x, target.Eval("x", parameters));
-			Assert.AreEqual(x, target.Eval("X", parameters));
+			Assert.That(target.Eval("x", parameters), Is.EqualTo(x));
+			Assert.That(target.Eval("X", parameters), Is.EqualTo(x));
 		}
 
 		[Test]
@@ -194,7 +194,7 @@ namespace DynamicExpresso.UnitTest
 
 			var lambda = target.Parse("x", new Parameter("x", x.GetType()));
 
-			Assert.AreEqual(x, lambda.Invoke(new Parameter("X", x)));
+			Assert.That(lambda.Invoke(new Parameter("X", x)), Is.EqualTo(x));
 		}
 
 		[Test]
@@ -211,9 +211,9 @@ namespace DynamicExpresso.UnitTest
                             new Parameter("z", z.GetType(), z)
                             };
 
-			Assert.AreEqual(x, target.Eval("x", parameters));
-			Assert.AreEqual(y, target.Eval("y", parameters));
-			Assert.AreEqual(z, target.Eval("z", parameters));
+			Assert.That(target.Eval("x", parameters), Is.EqualTo(x));
+			Assert.That(target.Eval("y", parameters), Is.EqualTo(y));
+			Assert.That(target.Eval("z", parameters), Is.EqualTo(z));
 		}
 
 		[Test]
@@ -232,10 +232,10 @@ namespace DynamicExpresso.UnitTest
                             new Parameter("w", w.GetType(), w)
                             };
 
-			Assert.AreEqual(x.HelloWorld(), target.Eval("x.HelloWorld()", parameters));
-			Assert.AreEqual(x.CallMethod(y, z, w), target.Eval("x.CallMethod( y, z,w)", parameters));
-			Assert.AreEqual(x.AProperty + 1, target.Eval("x.AProperty + 1", parameters));
-			Assert.AreEqual(x.AField, target.Eval("x.AField", parameters));
+			Assert.That(target.Eval("x.HelloWorld()", parameters), Is.EqualTo(x.HelloWorld()));
+			Assert.That(target.Eval("x.CallMethod( y, z,w)", parameters), Is.EqualTo(x.CallMethod(y, z, w)));
+			Assert.That(target.Eval("x.AProperty + 1", parameters), Is.EqualTo(x.AProperty + 1));
+			Assert.That(target.Eval("x.AField", parameters), Is.EqualTo(x.AField));
 		}
 
 		[Test]
@@ -253,10 +253,10 @@ namespace DynamicExpresso.UnitTest
                             new Parameter("y", typeof(int?), y)
                             };
 
-			Assert.AreEqual(x, target.Eval("x", parameters));
-			Assert.AreEqual(y, target.Eval("y", parameters));
-			Assert.AreEqual(x.HasValue, target.Eval("x.HasValue", parameters));
-			Assert.AreEqual(y.HasValue, target.Eval("y.HasValue", parameters));
+			Assert.That(target.Eval("x", parameters), Is.EqualTo(x));
+			Assert.That(target.Eval("y", parameters), Is.EqualTo(y));
+			Assert.That(target.Eval("x.HasValue", parameters), Is.EqualTo(x.HasValue));
+			Assert.That(target.Eval("y.HasValue", parameters), Is.EqualTo(y.HasValue));
 		}
 
 		[Test]
@@ -272,8 +272,8 @@ namespace DynamicExpresso.UnitTest
                             new Parameter("myDelegate", myDelegate.GetType(), myDelegate)
                             };
 
-			Assert.AreEqual(9.0, target.Eval("pow(3, 2)", parameters));
-			Assert.AreEqual(4, target.Eval("myDelegate(\"test\")", parameters));
+			Assert.That(target.Eval("pow(3, 2)", parameters), Is.EqualTo(9.0));
+			Assert.That(target.Eval("myDelegate(\"test\")", parameters), Is.EqualTo(4));
 		}
 
 		[Test]
@@ -290,14 +290,14 @@ namespace DynamicExpresso.UnitTest
 			var lambda = target.Parse("x + y", parameters);
 
 			// parameter 'z' is not used
-			Assert.AreEqual(2, lambda.UsedParameters.Count());
-			Assert.AreEqual("x", lambda.UsedParameters.ElementAt(0).Name);
-			Assert.AreEqual("y", lambda.UsedParameters.ElementAt(1).Name);
+			Assert.That(lambda.UsedParameters.Count(), Is.EqualTo(2));
+			Assert.That(lambda.UsedParameters.ElementAt(0).Name, Is.EqualTo("x"));
+			Assert.That(lambda.UsedParameters.ElementAt(1).Name, Is.EqualTo("y"));
 
-			Assert.AreEqual(3, lambda.DeclaredParameters.Count());
-			Assert.AreEqual("x", lambda.DeclaredParameters.ElementAt(0).Name);
-			Assert.AreEqual("y", lambda.DeclaredParameters.ElementAt(1).Name);
-			Assert.AreEqual("z", lambda.DeclaredParameters.ElementAt(2).Name);
+			Assert.That(lambda.DeclaredParameters.Count(), Is.EqualTo(3));
+			Assert.That(lambda.DeclaredParameters.ElementAt(0).Name, Is.EqualTo("x"));
+			Assert.That(lambda.DeclaredParameters.ElementAt(1).Name, Is.EqualTo("y"));
+			Assert.That(lambda.DeclaredParameters.ElementAt(2).Name, Is.EqualTo("z"));
 		}
 
 		[Test]
@@ -312,9 +312,9 @@ namespace DynamicExpresso.UnitTest
 
 			var lambda = target.Parse("x * y + x * y", parameters);
 
-			Assert.AreEqual(2, lambda.UsedParameters.Count());
-			Assert.AreEqual("x", lambda.UsedParameters.ElementAt(0).Name);
-			Assert.AreEqual("y", lambda.UsedParameters.ElementAt(1).Name);
+			Assert.That(lambda.UsedParameters.Count(), Is.EqualTo(2));
+			Assert.That(lambda.UsedParameters.ElementAt(0).Name, Is.EqualTo("x"));
+			Assert.That(lambda.UsedParameters.ElementAt(1).Name, Is.EqualTo("y"));
 		}
 
 		[Test]
@@ -329,7 +329,7 @@ namespace DynamicExpresso.UnitTest
 
 			var lambda = target.Parse("y-x", parameters);
 
-			Assert.AreEqual(4, lambda.Invoke(1, 5));
+			Assert.That(lambda.Invoke(1, 5), Is.EqualTo(4));
 		}
 
 		[Test]
@@ -344,7 +344,7 @@ namespace DynamicExpresso.UnitTest
 
 			var lambda = target.Parse("y+5", parameters);
 
-			Assert.AreEqual(7, lambda.Invoke(new Parameter("y", 2)));
+			Assert.That(lambda.Invoke(new Parameter("y", 2)), Is.EqualTo(7));
 		}
 
 		[Test]
@@ -355,8 +355,8 @@ namespace DynamicExpresso.UnitTest
 			var myDelegate = target.ParseAsDelegate<TestDelegate>("x + y");
 
 			// parameter 'z' is not used but the delegate accept it in any case without problem
-			Assert.AreEqual(3, myDelegate(1, 2, 123123));
-			Assert.AreEqual(24, myDelegate(21, 3, 433123));
+			Assert.That(myDelegate(1, 2, 123123), Is.EqualTo(3));
+			Assert.That(myDelegate(21, 3, 433123), Is.EqualTo(24));
 		}
 
 		public delegate int TestDelegate(int x, int y, int z);

--- a/test/DynamicExpresso.UnitTest/PerformanceTest.cs
+++ b/test/DynamicExpresso.UnitTest/PerformanceTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using NUnit.Framework;
 
 namespace DynamicExpresso.UnitTest
@@ -18,7 +18,7 @@ namespace DynamicExpresso.UnitTest
 				new Interpreter(InterpreterOptions.Default);
 			}
 
-			Assert.Less(stopwatch.ElapsedMilliseconds, 200);
+			Assert.That(stopwatch.ElapsedMilliseconds, Is.LessThan(200));
 		}
 	}
 }

--- a/test/DynamicExpresso.UnitTest/ReferencedTypesPropertyTest.cs
+++ b/test/DynamicExpresso.UnitTest/ReferencedTypesPropertyTest.cs
@@ -13,9 +13,9 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.IsTrue(target.ReferencedTypes.Any(p => p.Name == "string"));
-			Assert.IsTrue(target.ReferencedTypes.Any(p => p.Name == "int"));
-			Assert.IsTrue(target.ReferencedTypes.Any(p => p.Name == "Guid"));
+			Assert.That(target.ReferencedTypes.Any(p => p.Name == "string"), Is.True);
+			Assert.That(target.ReferencedTypes.Any(p => p.Name == "int"), Is.True);
+			Assert.That(target.ReferencedTypes.Any(p => p.Name == "Guid"), Is.True);
 		}
 
 		[Test]
@@ -23,7 +23,7 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter(InterpreterOptions.None);
 
-			Assert.IsFalse(target.ReferencedTypes.Any());
+			Assert.That(target.ReferencedTypes.Any(), Is.False);
 		}
 
 		[Test]
@@ -33,7 +33,7 @@ namespace DynamicExpresso.UnitTest
 
 			target.Reference(typeof(FakeClass));
 
-			Assert.IsTrue(target.ReferencedTypes.Any(p => p.Type == typeof(FakeClass)));
+			Assert.That(target.ReferencedTypes.Any(p => p.Type == typeof(FakeClass)), Is.True);
 		}
 
 		public class FakeClass

--- a/test/DynamicExpresso.UnitTest/StaticTest.cs
+++ b/test/DynamicExpresso.UnitTest/StaticTest.cs
@@ -11,14 +11,14 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(int.MaxValue, target.Eval("Int32.MaxValue"));
-			Assert.AreEqual(double.MaxValue, target.Eval("Double.MaxValue"));
-			Assert.AreEqual(DateTime.MaxValue, target.Eval("DateTime.MaxValue"));
-			Assert.AreEqual(DateTime.Today, target.Eval("DateTime.Today"));
-			Assert.AreEqual(string.Empty, target.Eval("String.Empty"));
-			Assert.AreEqual(bool.FalseString, target.Eval("Boolean.FalseString"));
-			Assert.AreEqual(TimeSpan.TicksPerMillisecond, target.Eval("TimeSpan.TicksPerMillisecond"));
-			Assert.AreEqual(Guid.Empty, target.Eval("Guid.Empty"));
+			Assert.That(target.Eval("Int32.MaxValue"), Is.EqualTo(int.MaxValue));
+			Assert.That(target.Eval("Double.MaxValue"), Is.EqualTo(double.MaxValue));
+			Assert.That(target.Eval("DateTime.MaxValue"), Is.EqualTo(DateTime.MaxValue));
+			Assert.That(target.Eval("DateTime.Today"), Is.EqualTo(DateTime.Today));
+			Assert.That(target.Eval("String.Empty"), Is.EqualTo(string.Empty));
+			Assert.That(target.Eval("Boolean.FalseString"), Is.EqualTo(bool.FalseString));
+			Assert.That(target.Eval("TimeSpan.TicksPerMillisecond"), Is.EqualTo(TimeSpan.TicksPerMillisecond));
+			Assert.That(target.Eval("Guid.Empty"), Is.EqualTo(Guid.Empty));
 		}
 
 		[Test]
@@ -26,8 +26,8 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(TimeSpan.FromMilliseconds(2000.49), target.Eval("TimeSpan.FromMilliseconds(2000.49)"));
-			Assert.AreEqual(DateTime.DaysInMonth(2094, 11), target.Eval("DateTime.DaysInMonth(2094, 11)"));
+			Assert.That(target.Eval("TimeSpan.FromMilliseconds(2000.49)"), Is.EqualTo(TimeSpan.FromMilliseconds(2000.49)));
+			Assert.That(target.Eval("DateTime.DaysInMonth(2094, 11)"), Is.EqualTo(DateTime.DaysInMonth(2094, 11)));
 		}
 
 		[Test]
@@ -35,8 +35,8 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(Math.Pow(3, 4), target.Eval("Math.Pow(3, 4)"));
-			Assert.AreEqual(Math.Sin(30.234), target.Eval("Math.Sin(30.234)"));
+			Assert.That(target.Eval("Math.Pow(3, 4)"), Is.EqualTo(Math.Pow(3, 4)));
+			Assert.That(target.Eval("Math.Sin(30.234)"), Is.EqualTo(Math.Sin(30.234)));
 		}
 
 		[Test]
@@ -44,8 +44,8 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(Convert.ToString(3), target.Eval("Convert.ToString(3)"));
-			Assert.AreEqual(Convert.ToInt16("23"), target.Eval("Convert.ToInt16(\"23\")"));
+			Assert.That(target.Eval("Convert.ToString(3)"), Is.EqualTo(Convert.ToString(3)));
+			Assert.That(target.Eval("Convert.ToInt16(\"23\")"), Is.EqualTo(Convert.ToInt16("23")));
 		}
 
 		[Test]
@@ -53,12 +53,12 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual(int.MaxValue, target.Eval("int.MaxValue"));
-			Assert.AreEqual(double.MaxValue, target.Eval("double.MaxValue"));
-			Assert.AreEqual(string.Empty, target.Eval("string.Empty"));
-			Assert.AreEqual(bool.FalseString, target.Eval("bool.FalseString"));
-			Assert.AreEqual(char.MinValue, target.Eval("char.MinValue"));
-			Assert.AreEqual(byte.MinValue, target.Eval("byte.MinValue"));
+			Assert.That(target.Eval("int.MaxValue"), Is.EqualTo(int.MaxValue));
+			Assert.That(target.Eval("double.MaxValue"), Is.EqualTo(double.MaxValue));
+			Assert.That(target.Eval("string.Empty"), Is.EqualTo(string.Empty));
+			Assert.That(target.Eval("bool.FalseString"), Is.EqualTo(bool.FalseString));
+			Assert.That(target.Eval("char.MinValue"), Is.EqualTo(char.MinValue));
+			Assert.That(target.Eval("byte.MinValue"), Is.EqualTo(byte.MinValue));
 		}
 
 		[Test]
@@ -68,8 +68,8 @@ namespace DynamicExpresso.UnitTest
 											.Reference(typeof(Uri))
 											.Reference(typeof(MyTestService));
 
-			Assert.AreEqual(Uri.UriSchemeHttp, target.Eval("Uri.UriSchemeHttp"));
-			Assert.AreEqual(MyTestService.MyStaticMethod(), target.Eval("MyTestService.MyStaticMethod()"));
+			Assert.That(target.Eval("Uri.UriSchemeHttp"), Is.EqualTo(Uri.UriSchemeHttp));
+			Assert.That(target.Eval("MyTestService.MyStaticMethod()"), Is.EqualTo(MyTestService.MyStaticMethod()));
 		}
 
 		[Test]
@@ -78,8 +78,8 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 											.Reference(typeof(Type));
 
-			Assert.AreEqual(Type.GetType("System.Globalization.CultureInfo"), target.Eval("Type.GetType(\"System.Globalization.CultureInfo\")"));
-			Assert.AreEqual(DateTime.Now.GetType(), target.Eval("DateTime.Now.GetType()"));
+			Assert.That(target.Eval("Type.GetType(\"System.Globalization.CultureInfo\")"), Is.EqualTo(Type.GetType("System.Globalization.CultureInfo")));
+			Assert.That(target.Eval("DateTime.Now.GetType()"), Is.EqualTo(DateTime.Now.GetType()));
 		}
 
 		private class MyTestService

--- a/test/DynamicExpresso.UnitTest/TypesTest.cs
+++ b/test/DynamicExpresso.UnitTest/TypesTest.cs
@@ -47,7 +47,7 @@ namespace DynamicExpresso.UnitTest
                 };
 
 			foreach (var t in predefinedTypes)
-				Assert.AreEqual(t.Value, target.Eval(string.Format("typeof({0})", t.Key)));
+				Assert.That(target.Eval(string.Format("typeof({0})", t.Key)), Is.EqualTo(t.Value));
 		}
 
 		[Test]
@@ -64,8 +64,8 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 											.Reference(typeof(Uri));
 
-			Assert.AreEqual(typeof(Uri), target.Eval("typeof(Uri)"));
-			Assert.AreEqual(new Uri("http://test"), target.Eval("new Uri(\"http://test\")"));
+			Assert.That(target.Eval("typeof(Uri)"), Is.EqualTo(typeof(Uri)));
+			Assert.That(target.Eval("new Uri(\"http://test\")"), Is.EqualTo(new Uri("http://test")));
 		}
 
 		[Test]
@@ -78,8 +78,8 @@ namespace DynamicExpresso.UnitTest
 											.Reference(typeof(Uri))
 											.Reference(typeof(Uri));
 
-			Assert.AreEqual(typeof(Uri), target.Eval("typeof(Uri)"));
-			Assert.AreEqual(new Uri("http://test"), target.Eval("new Uri(\"http://test\")"));
+			Assert.That(target.Eval("typeof(Uri)"), Is.EqualTo(typeof(Uri)));
+			Assert.That(target.Eval("new Uri(\"http://test\")"), Is.EqualTo(new Uri("http://test")));
 		}
 
 		[Test]
@@ -89,10 +89,10 @@ namespace DynamicExpresso.UnitTest
 											.Reference(typeof(string))
 											.Reference(typeof(Uri));
 
-			Assert.AreEqual(typeof(Uri), target.Eval("typeof(Uri)"));
-			Assert.AreEqual(typeof(Uri), target.Eval("typeof(uri)"));
-			Assert.AreEqual(typeof(Uri), target.Eval("typeof(URI)"));
-			Assert.AreEqual(string.Empty, target.Eval("STRING.Empty"));
+			Assert.That(target.Eval("typeof(Uri)"), Is.EqualTo(typeof(Uri)));
+			Assert.That(target.Eval("typeof(uri)"), Is.EqualTo(typeof(Uri)));
+			Assert.That(target.Eval("typeof(URI)"), Is.EqualTo(typeof(Uri)));
+			Assert.That(target.Eval("STRING.Empty"), Is.EqualTo(string.Empty));
 		}
 
 		[Test]
@@ -101,8 +101,8 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 											.Reference(typeof(MyDataContract));
 
-			Assert.AreEqual(new MyDataContract("davide").Name, target.Eval("new MyDataContract(\"davide\").Name"));
-			Assert.AreEqual(new MyDataContract(44, 88).Name, target.Eval("new MyDataContract(44 , 88).Name"));
+			Assert.That(target.Eval("new MyDataContract(\"davide\").Name"), Is.EqualTo(new MyDataContract("davide").Name));
+			Assert.That(target.Eval("new MyDataContract(44 , 88).Name"), Is.EqualTo(new MyDataContract(44, 88).Name));
 		}
 
 		[Test]
@@ -111,7 +111,7 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 											.Reference(typeof(MyDataContract), "DC");
 
-			Assert.AreEqual(typeof(MyDataContract), target.Parse("new DC(\"davide\")").ReturnType);
+			Assert.That(target.Parse("new DC(\"davide\")").ReturnType, Is.EqualTo(typeof(MyDataContract)));
 		}
 
 		[Test]
@@ -120,8 +120,8 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 											.Reference(typeof(MyCustomEnum));
 
-			Assert.AreEqual(MyCustomEnum.Value1, target.Eval("MyCustomEnum.Value1"));
-			Assert.AreEqual(MyCustomEnum.Value2, target.Eval("MyCustomEnum.Value2"));
+			Assert.That(target.Eval("MyCustomEnum.Value1"), Is.EqualTo(MyCustomEnum.Value1));
+			Assert.That(target.Eval("MyCustomEnum.Value2"), Is.EqualTo(MyCustomEnum.Value2));
 		}
 
 		[Test]
@@ -130,8 +130,8 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 											.Reference(typeof(EnumCaseSensitive));
 
-			Assert.AreEqual(EnumCaseSensitive.Test, target.Eval("EnumCaseSensitive.Test"));
-			Assert.AreEqual(EnumCaseSensitive.TEST, target.Eval("EnumCaseSensitive.TEST"));
+			Assert.That(target.Eval("EnumCaseSensitive.Test"), Is.EqualTo(EnumCaseSensitive.Test));
+			Assert.That(target.Eval("EnumCaseSensitive.TEST"), Is.EqualTo(EnumCaseSensitive.TEST));
 		}
 
 		[Test]
@@ -141,9 +141,9 @@ namespace DynamicExpresso.UnitTest
 
 			var lambda = target.Parse("Math.Max(a, typeof(string).Name.Length)", new Parameter("a", 1));
 
-			Assert.AreEqual(2, lambda.Types.Count());
-			Assert.AreEqual("Math", lambda.Types.ElementAt(0).Name);
-			Assert.AreEqual("string", lambda.Types.ElementAt(1).Name);
+			Assert.That(lambda.Types.Count(), Is.EqualTo(2));
+			Assert.That(lambda.Types.ElementAt(0).Name, Is.EqualTo("Math"));
+			Assert.That(lambda.Types.ElementAt(1).Name, Is.EqualTo("string"));
 		}
 
 		public enum EnumCaseSensitive

--- a/test/DynamicExpresso.UnitTest/VariablesTest.cs
+++ b/test/DynamicExpresso.UnitTest/VariablesTest.cs
@@ -104,7 +104,7 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 											.SetVariable("myk", null);
 
-			Assert.That(target.Eval("myk"), Is.EqualTo(null));
+			Assert.That(target.Eval("myk"), Is.Null);
 			Assert.That(target.Eval("myk == null"), Is.EqualTo(true));
 			Assert.That(target.Parse("myk").ReturnType, Is.EqualTo(typeof(object)));
 		}
@@ -115,7 +115,7 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 											.SetVariable("myk", null, typeof(string));
 
-			Assert.That(target.Eval("myk"), Is.EqualTo(null));
+			Assert.That(target.Eval("myk"), Is.Null);
 			Assert.That(target.Eval("myk == null"), Is.EqualTo(true));
 			Assert.That(target.Parse("myk").ReturnType, Is.EqualTo(typeof(string)));
 		}

--- a/test/DynamicExpresso.UnitTest/VariablesTest.cs
+++ b/test/DynamicExpresso.UnitTest/VariablesTest.cs
@@ -1,9 +1,9 @@
 using System;
-using NUnit.Framework;
-using System.Linq.Expressions;
-using DynamicExpresso.Exceptions;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
+using DynamicExpresso.Exceptions;
+using NUnit.Framework;
 
 namespace DynamicExpresso.UnitTest
 {
@@ -32,9 +32,9 @@ namespace DynamicExpresso.UnitTest
 				.SetVariable("Int32", 2)
 				.SetVariable("Math", 3);
 
-			Assert.AreEqual(1, target.Eval("bool"));
-			Assert.AreEqual(2, target.Eval("Int32"));
-			Assert.AreEqual(3, target.Eval("Math"));
+			Assert.That(target.Eval("bool"), Is.EqualTo(1));
+			Assert.That(target.Eval("Int32"), Is.EqualTo(2));
+			Assert.That(target.Eval("Math"), Is.EqualTo(3));
 		}
 
 		[Test]
@@ -43,8 +43,8 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 											.SetVariable("myk", 23);
 
-			Assert.AreEqual(23, target.Eval("myk"));
-			Assert.AreEqual(typeof(int), target.Parse("myk").ReturnType);
+			Assert.That(target.Eval("myk"), Is.EqualTo(23));
+			Assert.That(target.Parse("myk").ReturnType, Is.EqualTo(typeof(int)));
 		}
 
 		[Test]
@@ -54,8 +54,8 @@ namespace DynamicExpresso.UnitTest
 											.SetVariable("x", 23)
 											.SetVariable("X", 50);
 
-			Assert.AreEqual(23, target.Eval("x"));
-			Assert.AreEqual(50, target.Eval("X"));
+			Assert.That(target.Eval("x"), Is.EqualTo(23));
+			Assert.That(target.Eval("X"), Is.EqualTo(50));
 		}
 
 		[Test]
@@ -64,8 +64,8 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter(InterpreterOptions.DefaultCaseInsensitive)
 											.SetVariable("x", 23);
 
-			Assert.AreEqual(23, target.Eval("x"));
-			Assert.AreEqual(23, target.Eval("X"));
+			Assert.That(target.Eval("x"), Is.EqualTo(23));
+			Assert.That(target.Eval("X"), Is.EqualTo(23));
 		}
 
 		[Test]
@@ -74,13 +74,13 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 											.SetVariable("myk", 23);
 
-			Assert.AreEqual(23, target.Eval("myk"));
+			Assert.That(target.Eval("myk"), Is.EqualTo(23));
 
 			target.SetVariable("myk", 3489);
 
-			Assert.AreEqual(3489, target.Eval("myk"));
+			Assert.That(target.Eval("myk"), Is.EqualTo(3489));
 
-			Assert.AreEqual(typeof(int), target.Parse("myk").ReturnType);
+			Assert.That(target.Parse("myk").ReturnType, Is.EqualTo(typeof(int)));
 		}
 
 		[Test]
@@ -89,13 +89,13 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter(InterpreterOptions.DefaultCaseInsensitive)
 											.SetVariable("myk", 23);
 
-			Assert.AreEqual(23, target.Eval("myk"));
+			Assert.That(target.Eval("myk"), Is.EqualTo(23));
 
 			target.SetVariable("MYK", 3489);
 
-			Assert.AreEqual(3489, target.Eval("myk"));
+			Assert.That(target.Eval("myk"), Is.EqualTo(3489));
 
-			Assert.AreEqual(typeof(int), target.Parse("myk").ReturnType);
+			Assert.That(target.Parse("myk").ReturnType, Is.EqualTo(typeof(int)));
 		}
 
 		[Test]
@@ -104,9 +104,9 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 											.SetVariable("myk", null);
 
-			Assert.AreEqual(null, target.Eval("myk"));
-			Assert.AreEqual(true, target.Eval("myk == null"));
-			Assert.AreEqual(typeof(object), target.Parse("myk").ReturnType);
+			Assert.That(target.Eval("myk"), Is.EqualTo(null));
+			Assert.That(target.Eval("myk == null"), Is.EqualTo(true));
+			Assert.That(target.Parse("myk").ReturnType, Is.EqualTo(typeof(object)));
 		}
 
 		[Test]
@@ -115,9 +115,9 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 											.SetVariable("myk", null, typeof(string));
 
-			Assert.AreEqual(null, target.Eval("myk"));
-			Assert.AreEqual(true, target.Eval("myk == null"));
-			Assert.AreEqual(typeof(string), target.Parse("myk").ReturnType);
+			Assert.That(target.Eval("myk"), Is.EqualTo(null));
+			Assert.That(target.Eval("myk == null"), Is.EqualTo(true));
+			Assert.That(target.Parse("myk").ReturnType, Is.EqualTo(typeof(string)));
 		}
 
 		[Test]
@@ -127,7 +127,7 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 									.SetExpression("pow", pow);
 
-			Assert.AreEqual(9.0, target.Eval("pow(3, 2)"));
+			Assert.That(target.Eval("pow(3, 2)"), Is.EqualTo(9.0));
 		}
 
 		[Test]
@@ -137,7 +137,7 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 									.SetFunction("pow", pow);
 
-			Assert.AreEqual(9.0, target.Eval("pow(3, 2)"));
+			Assert.That(target.Eval("pow(3, 2)"), Is.EqualTo(9.0));
 		}
 
 		[Test]
@@ -148,7 +148,7 @@ namespace DynamicExpresso.UnitTest
 									.SetFunction("pow", pow)
 									.SetFunction("pow", pow);
 
-			Assert.AreEqual(9.0, target.Eval("pow(3, 2)"));
+			Assert.That(target.Eval("pow(3, 2)"), Is.EqualTo(9.0));
 		}
 
 		[Test]
@@ -162,7 +162,7 @@ namespace DynamicExpresso.UnitTest
 									.SetFunction("f", f2);
 
 			// f2 should override the f1 registration, because both delegates have the same signature
-			Assert.AreEqual(2, target.Eval("f(0d)"));
+			Assert.That(target.Eval("f(0d)"), Is.EqualTo(2));
 		}
 
 		[Test]
@@ -185,8 +185,8 @@ namespace DynamicExpresso.UnitTest
 			interpreter.SetFunction("ROUND", roundFunction1);
 			interpreter.SetFunction("ROUND", roundFunction2);
 
-			Assert.AreEqual(3.13M, interpreter.Eval("ROUND(3.12789M, 2)"));
-			Assert.AreEqual(3M, interpreter.Eval("ROUND(3.12789M)"));
+			Assert.That(interpreter.Eval("ROUND(3.12789M, 2)"), Is.EqualTo(3.13M));
+			Assert.That(interpreter.Eval("ROUND(3.12789M)"), Is.EqualTo(3M));
 		}
 
 		[Test]
@@ -206,7 +206,7 @@ namespace DynamicExpresso.UnitTest
 			Assert.Throws<ParseException>(() => interpreter.Eval("MyFunc(null)"));
 
 			// call resolved to the string overload
-			Assert.AreEqual("test", interpreter.Eval("MyFunc(\"test\")"));
+			Assert.That(interpreter.Eval("MyFunc(\"test\")"), Is.EqualTo("test"));
 		}
 
 		[Test]
@@ -221,7 +221,7 @@ namespace DynamicExpresso.UnitTest
 
 			// there should be no ambiguous exception: int can implicitly be converted to double, 
 			// but there's a perfect match 
-			Assert.AreEqual("integer", interpreter.Eval("MyFunc(5)"));
+			Assert.That(interpreter.Eval("MyFunc(5)"), Is.EqualTo("integer"));
 		}
 
 		[Test]
@@ -235,14 +235,14 @@ namespace DynamicExpresso.UnitTest
 			var del = methodInfo.CreateDelegate(Expression.GetDelegateType(types.ToArray()));
 			target.SetFunction(methodInfo.Name, del);
 
-			Assert.IsNotNull(del.Method.GetParameters()[0].GetCustomAttribute<ParamArrayAttribute>());
+			Assert.That(del.Method.GetParameters()[0].GetCustomAttribute<ParamArrayAttribute>(), Is.Not.Null);
 
 			var flags = BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.Instance;
 			var invokeMethod = (MethodInfo)(del.GetType().FindMembers(MemberTypes.Method, flags, Type.FilterName, "Invoke")[0]);
-			Assert.IsNull(invokeMethod.GetParameters()[0].GetCustomAttribute<ParamArrayAttribute>()); // should be not null!
+			Assert.That(invokeMethod.GetParameters()[0].GetCustomAttribute<ParamArrayAttribute>(), Is.Null); // should be not null!
 
 			// the imported Sum function can be called with any parameters
-			Assert.AreEqual(6, target.Eval<int>("Sum(1, 2, 3)"));
+			Assert.That(target.Eval<int>("Sum(1, 2, 3)"), Is.EqualTo(6));
 		}
 
 		internal static int Sum(params int[] integers)

--- a/test/DynamicExpresso.UnitTest/VisitorsTest.cs
+++ b/test/DynamicExpresso.UnitTest/VisitorsTest.cs
@@ -23,8 +23,8 @@ namespace DynamicExpresso.UnitTest
 		{
 			var target = new Interpreter();
 
-			Assert.AreEqual("Double", target.Eval("typeof(double).Name"));
-			Assert.AreEqual("X", target.Eval("x.GetType().Name", new Parameter("x", typeof(X), new X())));
+			Assert.That(target.Eval("typeof(double).Name"), Is.EqualTo("Double"));
+			Assert.That(target.Eval("x.GetType().Name", new Parameter("x", typeof(X), new X())), Is.EqualTo("X"));
 		}
 
 		[Test]
@@ -33,12 +33,12 @@ namespace DynamicExpresso.UnitTest
 			var target = new Interpreter()
 				.EnableReflection();
 
-			Assert.AreEqual(typeof(double).GetMethods(), target.Eval("typeof(double).GetMethods()"));
-			Assert.AreEqual(typeof(double).Assembly, target.Eval("typeof(double).Assembly"));
+			Assert.That(target.Eval("typeof(double).GetMethods()"), Is.EqualTo(typeof(double).GetMethods()));
+			Assert.That(target.Eval("typeof(double).Assembly"), Is.EqualTo(typeof(double).Assembly));
 
 			var x = new X();
-			Assert.AreEqual(x.GetType().GetMethods(), target.Eval("x.GetType().GetMethods()", new Parameter("x", x)));
-			Assert.AreEqual(x.GetType().Assembly, target.Eval("x.GetType().Assembly", new Parameter("x", x)));
+			Assert.That(target.Eval("x.GetType().GetMethods()", new Parameter("x", x)), Is.EqualTo(x.GetType().GetMethods()));
+			Assert.That(target.Eval("x.GetType().Assembly", new Parameter("x", x)), Is.EqualTo(x.GetType().Assembly));
 		}
 
 		public class X { }

--- a/test/DynamicExpresso.UnitTest/WorkingContextTest.cs
+++ b/test/DynamicExpresso.UnitTest/WorkingContextTest.cs
@@ -14,7 +14,7 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter();
 			interpreter.SetVariable("this", workingContext);
 
-			Assert.AreEqual(workingContext.FirstName, interpreter.Eval("this.FirstName"));
+			Assert.That(interpreter.Eval("this.FirstName"), Is.EqualTo(workingContext.FirstName));
 		}
 
 		[Test]
@@ -27,7 +27,7 @@ namespace DynamicExpresso.UnitTest
 			var firstNameExpression = interpreter.Parse("this.FirstName").Expression;
 			interpreter.SetExpression("FirstName", firstNameExpression);
 
-			Assert.AreEqual(workingContext.FirstName, interpreter.Eval("FirstName"));
+			Assert.That(interpreter.Eval("FirstName"), Is.EqualTo(workingContext.FirstName));
 		}
 
 		[Test]
@@ -41,7 +41,7 @@ namespace DynamicExpresso.UnitTest
 			var interpreter = new Interpreter();
 			interpreter.SetExpression("FirstName", firstNameExpression);
 
-			Assert.AreEqual(workingContext.FirstName, interpreter.Eval("FirstName"));
+			Assert.That(interpreter.Eval("FirstName"), Is.EqualTo(workingContext.FirstName));
 		}
 	}
 }


### PR DESCRIPTION
Starting with NUnit 4, the "classic" model of assertions is no longer available. This PR updates the test dependencies to the latest versions, including NUnit, and use the new [constraint model](https://docs.nunit.org/articles/nunit/writing-tests/assertions/assertion-models/constraint.html). 

This means that instead of writing:

```c#
Assert.AreEqual(23, target.Eval("myVar"));
```

we must write 

```c#
Assert.That(target.Eval("myVar"), Is.EqualTo(23));
```

Note that the goal is to have up-to-date dependencies, but we can stay on the 3.x version if you don't like the constraint model :)