### PR TITLE
Feature/custom member access

### DIFF
--- a/src/DynamicExpresso.Core/IMemberAccessProvider.cs
+++ b/src/DynamicExpresso.Core/IMemberAccessProvider.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace DynamicExpresso
+{
+    public interface IMemberAccessProvider
+    {
+		bool TryGetMemberAccess(Expression leftHand, string identifier, out Expression result);
+	}
+}

--- a/src/DynamicExpresso.Core/Interpreter.cs
+++ b/src/DynamicExpresso.Core/Interpreter.cs
@@ -155,6 +155,7 @@ namespace DynamicExpresso
 		{
 			get { return _visitors; }
 		}
+		public IMemberAccessProvider MemberAccessProvider { get; set; }
 
 		/// <summary>
 		/// Enable reflection expression (like x.GetType().GetMethod() or typeof(double).Assembly) by removing the DisableReflectionVisitor.
@@ -558,7 +559,8 @@ namespace DynamicExpresso
 				expressionText,
 				_settings,
 				expressionType,
-				parameters);
+				parameters,
+				MemberAccessProvider);
 
 			var expression = Parser.Parse(arguments);
 

--- a/src/DynamicExpresso.Core/ParserArguments.cs
+++ b/src/DynamicExpresso.Core/ParserArguments.cs
@@ -21,12 +21,13 @@ namespace DynamicExpresso
 			string expressionText, 
 			ParserSettings settings, 
 			Type expressionReturnType,
-			IEnumerable<Parameter> declaredParameters
+			IEnumerable<Parameter> declaredParameters,
+			IMemberAccessProvider memberAccessProvider
 		)
 		{
 			ExpressionText = expressionText;
 			ExpressionReturnType = expressionReturnType;
-
+			MemberAccessProvider = memberAccessProvider;
 			Settings = settings;
 			_declaredParameters = new Dictionary<string, Parameter>(settings.KeyComparer);
 			foreach (var pe in declaredParameters)
@@ -46,6 +47,7 @@ namespace DynamicExpresso
 		public string ExpressionText { get; private set; }
 		public Type ExpressionReturnType { get; private set; }
 		public IEnumerable<Parameter> DeclaredParameters { get { return _declaredParameters.Values; } }
+		public IMemberAccessProvider MemberAccessProvider { get; set; }
 
 		public IEnumerable<Parameter> UsedParameters
 		{

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1658,6 +1658,11 @@ namespace DynamicExpresso.Parsing
 
 		private Expression GeneratePropertyOrFieldExpression(Type type, Expression instance, int errorPos, string propertyOrFieldName)
 		{
+			if (_arguments.MemberAccessProvider != null && _arguments.MemberAccessProvider.TryGetMemberAccess(instance, propertyOrFieldName, out var result))
+			{
+				return result;
+			}
+
 			var member = _memberFinder.FindPropertyOrField(type, propertyOrFieldName, instance == null);
 			if (member != null)
 			{

--- a/test/DynamicExpresso.UnitTest/FakeDynamicMemberAccess.cs
+++ b/test/DynamicExpresso.UnitTest/FakeDynamicMemberAccess.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace DynamicExpresso.UnitTest
+{
+	[TestFixture]
+    public class FakeDynamicMemberAccess
+    {
+		private class DictMemberAccessProvider<TDict> : IMemberAccessProvider
+		{
+			readonly HashSet<string> _allowedProperties;
+			public DictMemberAccessProvider(HashSet<string> allowedProperties = null)
+			{
+				_allowedProperties = allowedProperties;
+			}
+
+			public bool TryGetMemberAccess(Expression leftHand, string identifier, out Expression result)
+			{
+				if (leftHand.Type != typeof(TDict))
+				{
+					result = null;
+					return false;
+				}
+				if (_allowedProperties != null && _allowedProperties.Contains(identifier) == false)
+				{
+					result = null;
+					return false;
+				}
+
+				result = Expression.Convert(
+					Expression.Call(leftHand,
+					typeof(TDict).GetMethod("get_Item", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public),
+					Expression.Constant(identifier)
+					), typeof(int));
+				return true;
+			}
+		}
+		private class TestDict : Dictionary<string, int>
+		{
+			public int Y { get; set; }
+		}
+
+		[Test]
+		public void Parse_Dictionary()
+		{
+			var interpreter = new Interpreter()
+			{
+				MemberAccessProvider = new DictMemberAccessProvider<Dictionary<string, int>>()
+			};
+			Dictionary<string, int> context = new Dictionary<string, int>() { { "x", 5 }, { "y", 6 } };
+
+			var cb = interpreter.ParseAsDelegate<Func<Dictionary<string, int>, int>>("x + y", "this");
+			Assert.AreEqual(11, cb(context));
+
+			interpreter.SetVariable("this", context);
+			Assert.AreEqual(5, interpreter.Eval("x"));
+			Assert.AreEqual(6, interpreter.Eval("this.y"));
+			Assert.AreEqual(30, interpreter.Eval("x * this.y"));
+		}
+
+		[Test]
+		public void NonExistentMembersFallThrough()
+		{
+			var interpreter = new Interpreter(InterpreterOptions.DefaultCaseInsensitive)
+			{
+				MemberAccessProvider = new DictMemberAccessProvider<TestDict>(new HashSet<string>(StringComparer.InvariantCultureIgnoreCase) { "x" })
+			};
+			TestDict context = new TestDict() { { "x", 5 } };
+			context.Y = 10;
+
+			var cb = interpreter.ParseAsDelegate<Func<TestDict, int>>("x + y", "this");
+			Assert.AreEqual(15, cb(context));
+
+			interpreter.SetVariable("this", context);
+			Assert.AreEqual(5, interpreter.Eval("x"));
+			Assert.AreEqual(10, interpreter.Eval("this.y"));
+		}
+
+		[Test]
+		public void AccessIsSetAtParseTime()
+		{
+			var interpreter = new Interpreter(InterpreterOptions.DefaultCaseInsensitive)
+			{
+				MemberAccessProvider = new DictMemberAccessProvider<TestDict>(new HashSet<string>(StringComparer.InvariantCultureIgnoreCase) { "x" })
+			};
+			TestDict context = new TestDict() { { "x", 5 } };
+			context.Y = 10;
+
+			var cb = interpreter.ParseAsDelegate<Func<TestDict, int>>("x + y", "this");
+			Assert.AreEqual(15, cb(context));
+			context["y"] = 30;
+			Assert.AreEqual(15, cb(context));
+		}
+    }
+}


### PR DESCRIPTION
We have a project that requires running expressions on mostly configuration based objects (in reality they're nested dictionaries with per-member/per-dict configuration of what variables are stored inside, with type information).
These expressions may in the future be written by people with limited technical experience, so `field * 5` is easy to explain but `(int)data["field"] * 5` is harder, and it gets worse from there (`(int)((List<Dictionary<string,object>>)this["child"])[0].field` vs `child.field`)

We could use dynamic objects but that would require generating a lot of them as it's a complex hierarchical data structure, and this would lose type information, as well as performance.

Instead I've made a small interface that serves as an extension point, if it's used then on attempting to resolve member access it will first attempt to call `bool TryGetMemberAccess(Expression leftHand, string identifier, out Expression result)`.
If it returns false normal code flow resumes, if true is returned result should be an Expression that represents the member access.

This can of course be anything, in the unit tests it generates a dictionary access and a cast.
Case insensitivity must be implemented by the implementer of IMemberAccessProvider if they with to use case insensitivity.