### PR TITLE
Add support of method invocation with dynamic arguments

### DIFF
--- a/src/DynamicExpresso.Core/Identifier.cs
+++ b/src/DynamicExpresso.Core/Identifier.cs
@@ -37,6 +37,7 @@ namespace DynamicExpresso
 
 	/// <summary>
 	/// Custom expression that simulates a method group (ie. a group of methods with the same name).
+	/// It's used when custom functions are added to the interpreter via <see cref="Interpreter.SetFunction(string, Delegate)"/>.
 	/// </summary>
 	internal class MethodGroupExpression : Expression
 	{

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1691,7 +1691,7 @@ namespace DynamicExpresso.Parsing
 			if (methodInvocationExpression != null)
 				return methodInvocationExpression;
 
-			if (TypeUtils.IsDynamicType(type) || IsDynamicExpression(instance))
+			if (TypeUtils.IsDynamicType(type) || IsDynamicExpression(instance) || args.Any(IsDynamicExpression))
 				return ParseDynamicMethodInvocation(type, instance, methodName, args);
 
 			throw new NoApplicableMethodException(methodName, TypeUtils.GetTypeName(type), errorPos);
@@ -1791,8 +1791,9 @@ namespace DynamicExpresso.Parsing
 		private static Expression ParseDynamicMethodInvocation(Type type, Expression instance, string methodName, Expression[] args)
 		{
 			var argsDynamic = args.ToList();
-			argsDynamic.Insert(0, instance);
-			return Expression.Dynamic(new LateInvokeMethodCallSiteBinder(methodName), typeof(object), argsDynamic);
+			var isStatic = instance == null;
+			argsDynamic.Insert(0, !isStatic ? instance : Expression.Constant(type));
+			return Expression.Dynamic(new LateInvokeMethodCallSiteBinder(methodName, isStatic), typeof(object), argsDynamic);
 		}
 
 		private static Expression ParseDynamicIndex(Type type, Expression instance, Expression[] args)

--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1697,15 +1697,15 @@ namespace DynamicExpresso.Parsing
 			throw new NoApplicableMethodException(methodName, TypeUtils.GetTypeName(type), errorPos);
 		}
 
-		private Expression ParseExtensionMethodInvocation(Type type, Expression instance, int errorPos, string id, Expression[] args)
+		private Expression ParseExtensionMethodInvocation(Type type, Expression instance, int errorPos, string methodName, Expression[] args)
 		{
 			var extensionMethodsArguments = new Expression[args.Length + 1];
 			extensionMethodsArguments[0] = instance;
 			args.CopyTo(extensionMethodsArguments, 1);
 
-			var extensionMethods = _memberFinder.FindExtensionMethods(id, extensionMethodsArguments);
+			var extensionMethods = _memberFinder.FindExtensionMethods(methodName, extensionMethodsArguments);
 			if (extensionMethods.Length > 1)
-				throw ParseException.Create(errorPos, ErrorMessages.AmbiguousMethodInvocation, id, TypeUtils.GetTypeName(type));
+				throw ParseException.Create(errorPos, ErrorMessages.AmbiguousMethodInvocation, methodName, TypeUtils.GetTypeName(type));
 
 			if (extensionMethods.Length == 1)
 			{
@@ -1719,11 +1719,11 @@ namespace DynamicExpresso.Parsing
 			return null;
 		}
 
-		private Expression ParseNormalMethodInvocation(Type type, Expression instance, int errorPos, string id, Expression[] args)
+		private Expression ParseNormalMethodInvocation(Type type, Expression instance, int errorPos, string methodName, Expression[] args)
 		{
-			var applicableMethods = _memberFinder.FindMethods(type, id, instance == null, args);
+			var applicableMethods = _memberFinder.FindMethods(type, methodName, instance == null, args);
 			if (applicableMethods.Length > 1)
-				throw ParseException.Create(errorPos, ErrorMessages.AmbiguousMethodInvocation, id, TypeUtils.GetTypeName(type));
+				throw ParseException.Create(errorPos, ErrorMessages.AmbiguousMethodInvocation, methodName, TypeUtils.GetTypeName(type));
 
 			if (applicableMethods.Length == 1)
 			{

--- a/src/DynamicExpresso.Core/Resolution/LateBinders.cs
+++ b/src/DynamicExpresso.Core/Resolution/LateBinders.cs
@@ -67,6 +67,33 @@ namespace DynamicExpresso.Resolution
 	}
 
 	/// <summary>
+	/// Binds to a delegate invocation as late as possible.  This allows the use of delegates with dynamic arguments.
+	/// </summary>
+	internal class LateInvokeDelegateCallSiteBinder : CallSiteBinder
+	{
+		public LateInvokeDelegateCallSiteBinder()
+		{
+		}
+
+		public override Expression Bind(object[] args, ReadOnlyCollection<ParameterExpression> parameters, LabelTarget returnLabel)
+		{
+			// the first argument is the delegate to invoke
+			var _delegate = (Delegate)args[0];
+			var argumentInfo = parameters.Select(x => CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)).ToArray();
+
+			// instruct the compiler that we already know the delegate's type
+			argumentInfo[0] = CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType, null);
+
+			var binderM = Binder.Invoke(
+				CSharpBinderFlags.None,
+				null,
+				argumentInfo
+			);
+			return binderM.Bind(args, parameters, returnLabel);
+		}
+	}
+
+	/// <summary>
 	/// Binds to an items invocation of an instance as late as possible.  This allows the use of anonymous types on dynamic values.
 	/// </summary>
 	internal class LateInvokeIndexCallSiteBinder : CallSiteBinder

--- a/src/DynamicExpresso.Core/Resolution/LateBinders.cs
+++ b/src/DynamicExpresso.Core/Resolution/LateBinders.cs
@@ -46,7 +46,7 @@ namespace DynamicExpresso.Resolution
 		public override Expression Bind(object[] args, ReadOnlyCollection<ParameterExpression> parameters, LabelTarget returnLabel)
 		{
 			// if the method is static, the first argument is the type containing the method,
-			// otherwise it is the instance on which the method is called
+			// otherwise it's the instance on which the method is called
 			var context = _isStatic ? (Type)args[0] : args[0]?.GetType();
 			var argumentInfo = parameters.Select(x => CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)).ToArray();
 			if (_isStatic)

--- a/test/DynamicExpresso.UnitTest/DynamicTest.cs
+++ b/test/DynamicExpresso.UnitTest/DynamicTest.cs
@@ -435,9 +435,44 @@ namespace DynamicExpresso.UnitTest
 
 			Assert.That(interpreter.Eval("!dyn.Foo"), Is.EqualTo(!dyn.Foo));
 			Assert.That(interpreter.Eval("-dyn.Bar"), Is.EqualTo(-dyn.Bar));
+		}
+
+		[Test]
+		public void Static_method_call_with_dynamic_arg()
+		{
+			dynamic dyn = new ExpandoObject();
+			dyn.Foo = "test";
+
+			var myClass = new MyClass();
+
+			var interpreter = new Interpreter()
+				.SetVariable("dyn", (object)dyn);
+
+			Assert.That(interpreter.Eval("string.IsNullOrEmpty(dyn.Foo)"), Is.EqualTo(string.IsNullOrEmpty(dyn.Foo)));
+		}
 
 
+		[Test]
+		public void Method_call_with_dynamic_arg()
+		{
+			dynamic dyn = new ExpandoObject();
+			dyn.Foo = "test";
 
+			var myClass = new MyClass();
+
+			var interpreter = new Interpreter()
+				.SetVariable("dyn", (object)dyn)
+				.SetVariable("myClass", myClass);
+
+			Assert.That(interpreter.Eval("myClass.MyMethod(dyn.Foo)"), Is.EqualTo(myClass.MyMethod(dyn.Foo)));
+		}
+
+		public class MyClass
+		{
+			public string MyMethod(string input)
+			{
+				return input;
+			}
 		}
 
 		public class TestDynamicClass : DynamicObject

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -887,5 +887,3 @@ namespace DynamicExpresso.UnitTest
 		}
 	}
 }
-
-

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -775,7 +775,6 @@ namespace DynamicExpresso.UnitTest
 		}
 
 		[Test]
-		[Ignore("The fix suggested in #296 break other use cases, so let's ignore this test for now")]
 		public void GitHub_Issue_295()
 		{
 			var evaluator = new Interpreter();
@@ -789,11 +788,11 @@ namespace DynamicExpresso.UnitTest
 			globalSettings.MyTestPath = "C:\\delme\\";
 			evaluator.SetVariable("GlobalSettings", globalSettings);
 
-			var works = (string)evaluator.Eval("StringConcat((string)GlobalSettings.MyTestPath,\"test.txt\")");
-			Assert.That(works, Is.EqualTo("C:\\delme\\test.txt"));
+			var worksWithCast = (string)evaluator.Eval("StringConcat((string)GlobalSettings.MyTestPath,\"test.txt\")");
+			Assert.That(worksWithCast, Is.EqualTo("C:\\delme\\test.txt"));
 
-			var doesntWork = (string)evaluator.Eval("StringConcat(GlobalSettings.MyTestPath,\"test.txt\")");
-			Assert.That(doesntWork, Is.EqualTo("C:\\delme\\test.txt"));
+			var worksWithoutCast = (string)evaluator.Eval("StringConcat(GlobalSettings.MyTestPath,\"test.txt\")");
+			Assert.That(worksWithoutCast, Is.EqualTo("C:\\delme\\test.txt"));
 		}
 
 		#region GitHub_Issue_305
@@ -888,3 +887,5 @@ namespace DynamicExpresso.UnitTest
 		}
 	}
 }
+
+


### PR DESCRIPTION
This PR fixes two things:
* Normal method invocations with dynamic arguments, through the C# member binder
* Invocations of methods registered via `SetFunction` (the issue reported in #295), through the C# invoke binder. This is currently less powerful, because it doesn't support multiple overloads

Extension methods invocations are not touched; I didn't check the behavior of the C# compiler in that case.

Fixes #295