### PR TITLE
Add support of dynamic property and index assignments

### DIFF
--- a/src/DynamicExpresso.Core/Parsing/Parser.cs
+++ b/src/DynamicExpresso.Core/Parsing/Parser.cs
@@ -1815,7 +1815,7 @@ namespace DynamicExpresso.Parsing
 		{
 			var argsDynamic = args.ToList();
 			argsDynamic.Insert(0, instance);
-			return Expression.Dynamic(new LateInvokeIndexCallSiteBinder(), typeof(object), argsDynamic);
+			return Expression.Dynamic(new LateGetIndexCallSiteBinder(), typeof(object), argsDynamic);
 		}
 
 		private Expression[] ParseArgumentList(TokenId openToken, string missingOpenTokenMsg,

--- a/test/DynamicExpresso.UnitTest/DynamicTest.cs
+++ b/test/DynamicExpresso.UnitTest/DynamicTest.cs
@@ -24,12 +24,38 @@ namespace DynamicExpresso.UnitTest
 		}
 
 		[Test]
+		public void Set_Property_of_an_ExpandoObject()
+		{
+			dynamic dyn = new ExpandoObject();
+			var interpreter = new Interpreter(InterpreterOptions.Default | InterpreterOptions.LateBindObject)
+				.SetVariable("dyn", (object)dyn);
+
+			interpreter.Eval("dyn.Foo = 10");
+
+			Assert.That(dyn.Foo, Is.EqualTo(10));
+		}
+
+		[Test]
 		public void Get_Property_of_a_nested_anonymous()
 		{
 			dynamic dyn = new ExpandoObject();
 			dyn.Sub = new { Foo = new { Bar = new { Foo2 = "bar" } } };
 			var interpreter = new Interpreter().SetVariable("dyn", (object)dyn);
 			Assert.That(interpreter.Eval("dyn.Sub.Foo.Bar.Foo2"), Is.EqualTo(dyn.Sub.Foo.Bar.Foo2));
+		}
+
+		[Test]
+		public void Set_Property_of_a_nested_ExpandoObject()
+		{
+			dynamic dyn = new ExpandoObject();
+			dyn.Sub = new ExpandoObject();
+			dyn.Sub.Foo = "bar";
+
+			var interpreter = new Interpreter().SetVariable("dyn", (object)dyn);
+
+			interpreter.Eval("dyn.Sub.Foo = \"foobar\"");
+
+			Assert.That(dyn.Sub.Foo, Is.EqualTo("foobar"));
 		}
 
 		[Test]

--- a/test/DynamicExpresso.UnitTest/DynamicTest.cs
+++ b/test/DynamicExpresso.UnitTest/DynamicTest.cs
@@ -210,6 +210,21 @@ namespace DynamicExpresso.UnitTest
 		}
 
 		[Test]
+		public void Set_value_of_a_dynamic_object()
+		{
+			dynamic dyn = new ExpandoObject();
+			dyn.Foo = new int[5];
+			dyn.Bar = new Dictionary<string, int>();
+
+			var interpreter = new Interpreter().SetVariable("dyn", (object)dyn);
+			interpreter.Eval("dyn.Foo[2] = 5");
+			interpreter.Eval("dyn.Bar[\"foo\"] = 50");
+
+			Assert.That(dyn.Foo[2], Is.EqualTo(5));
+			Assert.That(dyn.Bar["foo"], Is.EqualTo(50));
+		}
+
+		[Test]
 		public void Get_value_of_a_nested_array_error()
 		{
 			dynamic dyn = new ExpandoObject();


### PR DESCRIPTION
This allows to write:

```c#
dynamic dyn = new ExpandoObject();
dyn.Foo = new int[5];

var interpreter = new Interpreter().SetVariable("dyn", (object)dyn);
interpreter.Eval("dyn.Foo[2] = 5");
interpreter.Eval("dyn.Bar = \"foo\"");

Assert.That(dyn.Foo[2], Is.EqualTo(5));
Assert.That(dyn.Bar, Is.EqualTo("foo"));
```

The fix is bit tricky: when we parse the assignment, the left operand is a dynamic `GetMember` expression, which can't be assigned via an `Expression.Assign`. We must instead change the dynamic expression from a `GetMember` to a `SetMember`. Those bindings  are performed via our Late binders.

We fix the issue by adding a new interface `IConvertibleToWritableBinder` that can convert the read binder to a write binder.

Fixes #340