### PR TITLE
Properly handle default parameter value when the parameter type is a value type

### DIFF
--- a/src/DynamicExpresso.Core/Resolution/MethodResolution.cs
+++ b/src/DynamicExpresso.Core/Resolution/MethodResolution.cs
@@ -165,7 +165,12 @@ namespace DynamicExpresso.Resolution
 				if (parameter.HasDefaultValue)
 				{
 					var parameterType = TypeUtils.GetConcreteTypeForGenericMethod(parameter.ParameterType, promotedArgs, method);
-					promotedArgs.Add(Expression.Constant(parameter.DefaultValue, parameterType));
+
+					var defaultValue = parameter.DefaultValue;
+					if (defaultValue is null && parameterType.IsValueType)
+						defaultValue = Activator.CreateInstance(parameterType);
+
+					promotedArgs.Add(Expression.Constant(defaultValue, parameterType));
 				}
 				else if (ReflectionExtensions.HasParamsArrayType(parameter))
 				{

--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -706,6 +706,11 @@ namespace DynamicExpresso.UnitTest
 			{
 				return list.Select(i => transform(i)).ToList();
 			}
+
+			public Guid ReturnsGuid(Guid guid = default)
+			{
+				return guid;
+			}
 		}
 
 		[Test]
@@ -876,6 +881,15 @@ namespace DynamicExpresso.UnitTest
 			interpreter.SetVariable("x", x);
 
 			Assert.That(interpreter.Eval<bool>("(int)x == 1"), Is.EqualTo((int)x == 1));
+		}
+
+		[Test]
+		public void GitHub_Issue_354()
+		{
+			var interpreter = new Interpreter();
+			interpreter.SetVariable("b", new Functions());
+
+			Assert.That(interpreter.Eval<Guid>("b.ReturnsGuid()"), Is.EqualTo(Guid.Empty));
 		}
 	}
 


### PR DESCRIPTION
For value types parameters, the parameter's default value returned by the reflection API is `null`, which is not a valid value for value types.

This PR detects the situation, and instantiates the value type to the default value.

```c#
public class Functions
{
	public Guid ReturnsGuid(Guid guid = default)
	{
		return guid;
	}
}

var interpreter = new Interpreter();
interpreter.SetVariable("b", new Functions());

Assert.That(interpreter.Eval<Guid>("b.ReturnsGuid()"), Is.EqualTo(Guid.Empty));
```

Fixes #354