### PR TITLE
rollback: mark DetectorOptions.IncludeChildren as obsolete and del implementation

### DIFF
--- a/src/DynamicExpresso.Core/Detector.cs
+++ b/src/DynamicExpresso.Core/Detector.cs
@@ -14,11 +14,6 @@ namespace DynamicExpresso
 		private static readonly Regex RootIdentifierDetectionRegex =
 			new Regex(@"(?<=[^\w@]|^)(?<id>@?[\p{L}\p{Nl}_][\p{L}\p{Nl}\p{Nd}\p{Mn}\p{Mc}\p{Pc}\p{Cf}_]*)", RegexOptions.Compiled);
 
-		private static readonly Regex ChildIdentifierDetectionRegex = new Regex(
-			@"(?<=[^\w@]|^)(?<id>@?[\p{L}\p{Nl}_][\p{L}\p{Nl}\p{Nd}\p{Mn}\p{Mc}\p{Pc}\p{Cf}_]*(\.[\p{L}\p{Nl}_][\p{L}\p{Nl}\p{Nd}\p{Mn}\p{Mc}\p{Pc}\p{Cf}_]*)*)",
-			RegexOptions.Compiled);
-
-
 		private static readonly string Id = RootIdentifierDetectionRegex.ToString();
 		private static readonly string Type = Id.Replace("<id>", "<type>");
 
@@ -80,11 +75,7 @@ namespace DynamicExpresso
 				}
 			}
 
-			var identifierRegex = option == DetectorOptions.IncludeChildren
-				? ChildIdentifierDetectionRegex
-				: RootIdentifierDetectionRegex;
-
-			foreach (Match match in identifierRegex.Matches(expression))
+			foreach (Match match in RootIdentifierDetectionRegex.Matches(expression))
 			{
 				var idGroup = match.Groups["id"];
 				var identifier = idGroup.Value;

--- a/src/DynamicExpresso.Core/DetectorOptions.cs
+++ b/src/DynamicExpresso.Core/DetectorOptions.cs
@@ -6,6 +6,7 @@ namespace DynamicExpresso
 	public enum DetectorOptions
 	{
 		None = 0,
+		[System.Obsolete("IncludeChildren is deprecated and will be removed in a future version.")]
 		IncludeChildren = 1
 	}
 }

--- a/test/DynamicExpresso.UnitTest/DetectIdentifiersTest.cs
+++ b/test/DynamicExpresso.UnitTest/DetectIdentifiersTest.cs
@@ -44,19 +44,6 @@ namespace DynamicExpresso.UnitTest
 		}
 
 		[Test]
-		public void Detect_unknown_identifiers_with_complete_variable_name()
-		{
-			var target = new Interpreter();
-
-			var detectedIdentifiers = target.DetectIdentifiers("Contact.Personal.Year_of_birth = 1987",
-				DetectorOptions.IncludeChildren);
-
-			Assert.That(
-				detectedIdentifiers.UnknownIdentifiers,
-				Is.EqualTo(new[] { "Contact.Personal.Year_of_birth" }));
-		}
-
-		[Test]
 		public void Should_detect_various_format_of_identifiers()
 		{
 			var target = new Interpreter();

--- a/test/DynamicExpresso.UnitTest/DetectIdentifiersTest.cs
+++ b/test/DynamicExpresso.UnitTest/DetectIdentifiersTest.cs
@@ -354,7 +354,7 @@ namespace DynamicExpresso.UnitTest
 		[Test]
 		public void Detect_class_members_invocations()
 		{
-			TestClass customer = new() { Age = 1, Name = "abc" };
+			TestClass customer = new TestClass() { Age = 1, Name = "abc" };
 			Interpreter target = new Interpreter();
 			target.SetVariable("test", customer);
 


### PR DESCRIPTION
Rollback #323 due to #351.

Fix #351.