### PR TITLE
Fix #368: generate proper expression for null-coalescing operators on nullable types

### DIFF
--- a/test/DynamicExpresso.UnitTest/GithubIssues.cs
+++ b/test/DynamicExpresso.UnitTest/GithubIssues.cs
@@ -891,6 +891,16 @@ namespace DynamicExpresso.UnitTest
 
 			Assert.That(interpreter.Eval<Guid>("b.ReturnsGuid()"), Is.EqualTo(Guid.Empty));
 		}
+
+		[Test]
+		public void GitHub_Issue_367()
+		{
+			var interpreter = new DynamicExpresso.Interpreter();
+			interpreter.SetVariable("MyValue", null, typeof(int?));
+
+			var result = interpreter.Eval<int>("MyValue ?? 10");
+			Assert.That(result, Is.EqualTo(10));
+		}
 	}
 
 	internal static class GithubIssuesTestExtensionsMethods


### PR DESCRIPTION
The expression we generate for the null-coalescing operator doesn't work for nullable types, because there's no comparison operator between a nullable type and an object:

```c#
const object nullConst = null;
int? MyVar = null;
return MyVar == nullConst ? 0 : MyVar; // <-- doesn't compile
```

This PR changes the generated expression for nullable types from `expr == null ? exprRight : expr` to `expr.HasValue ? expr.Value : exprRight`

Fix #368 